### PR TITLE
Wrap write transactions in background tasks on supported platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Add a `{RLM}SyncUser.isAdmin` property indicating whether a user is a Realm
   Object Server administrator.
+* Write transactions are automatically marked as background tasks on platforms
+  which support them to avoid having an app suspended while it holds the write
+  lock.
 
 ### Bugfixes
 


### PR DESCRIPTION
This asks the OS to not suspend the app while a write is in progress, which can help prevent apps which share realm files between processes from getting "stuck" due to a suspended app holding the write lock. Because unconditionally wrapping things in tasks is extremely slow, it uses the app state change notification to only do so when the app is actually running in the background.

The manual testing I did for this (since it isn't really possible to write tests for) was:

1. Run performance tests
2. Run repro case from #4797 and verify that everything works as expected (on device only the active app makes forward progress, but I could never get the active app to get "stuck" by rapidly switching between the apps and/or killing them)
3. Run extension example on device and verify that still works.

Fixes #4797.