### PR TITLE
Test ROS on a poor network connectivity condition 

### DIFF
--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -1356,7 +1356,11 @@
             XCTAssertTrue([[RLMRealm realmWithConfiguration:c error:nil] isEmpty]);
         }
         XCTAssertNil(RLMGetAnyCachedRealmForPath(c.pathOnDisk.UTF8String));
-        [self waitForExpectationsWithTimeout:60.0 handler:nil];
+        if (simulateReconnection) {
+            [self waitForExpectationsWithTimeout:60.0 handler:nil];
+        } else {
+            [self waitForExpectationsWithTimeout:10.0 handler:nil];
+        }
         XCTAssertGreaterThan(fileSize(c.pathOnDisk), sizeBefore);
         XCTAssertNil(RLMGetAnyCachedRealmForPath(c.pathOnDisk.UTF8String));
     } else {
@@ -1374,7 +1378,7 @@
             [realm addObject:[HugeSyncObject object]];
         }
         [realm commitWriteTransaction];
-        [self waitForUploadsForUser:user url:url];
+        [self waitForUploadsForUser:user url:url timeout:simulateReconnection ? 20.0 : 60.0 error:nil];
         CHECK_COUNT(NUMBER_OF_BIG_OBJECTS, HugeSyncObject, realm);
     }
 }

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -114,6 +114,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// Wait for uploads to complete; drop any error.
 - (void)waitForUploadsForUser:(RLMSyncUser *)user url:(NSURL *)url;
 
+/// Wait for uploads to complete
+- (void)waitForUploadsForUser:(RLMSyncUser *)user
+                          url:(NSURL *)url
+                      timeout:(NSTimeInterval)timeout
+                        error:(NSError **)error;
+
 /// Wait for downloads to complete while spinning the runloop. This method uses expectations.
 - (void)waitForDownloadsForUser:(RLMSyncUser *)user
                             url:(NSURL *)url

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -88,6 +88,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Synchronously create, log in, and return a user.
 - (RLMSyncUser *)logInUserForCredentials:(RLMSyncCredentials *)credentials
                                   server:(NSURL *)url;
+- (RLMSyncUser *)logInUserForCredentials:(RLMSyncCredentials *)credentials
+                                  server:(NSURL *)url
+                    simulateReconnection:(BOOL)simulateReconnection;
 
 /// Create and log in an admin user.
 - (RLMSyncUser *)createAdminUserForURL:(NSURL *)url username:(NSString *)username;
@@ -122,6 +125,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Manually set the refresh token for a user. Used for testing invalid token conditions.
 - (void)manuallySetRefreshTokenForUser:(RLMSyncUser *)user value:(NSString *)tokenValue;
+
+/// Simulate no network condition
+- (void)disableNetworking;
+/// Clear poor network simulation
+- (void)enableNetworkingAfter:(NSTimeInterval)secs;
 
 @end
 

--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,8 @@
 set -o pipefail
 set -e
 
+source ./scripts/bandwidth_throttling.sh
+
 source_root="$(dirname "$0")"
 
 # You can override the version of the core library

--- a/build.sh
+++ b/build.sh
@@ -13,8 +13,6 @@
 set -o pipefail
 set -e
 
-source ./scripts/bandwidth_throttling.sh
-
 source_root="$(dirname "$0")"
 
 # You can override the version of the core library

--- a/build.sh
+++ b/build.sh
@@ -713,7 +713,18 @@ case "$COMMAND" in
         ;;
 
     "test-osx-object-server")
-        xc "-scheme 'Object Server Tests' -configuration $CONFIGURATION -sdk macosx test"
+        xc "-scheme 'Object Server Tests' -configuration $CONFIGURATION -sdk macosx test \
+            -skip-testing:ObjectServerTests/RLMObjectServerTests/testUsernamePasswordAuthenticationWithReconnection \
+            -skip-testing:ObjectServerTests/RLMObjectServerTests/testAddObjectsWithReconnection \
+            -skip-testing:ObjectServerTests/RLMObjectServerTests/testDownloadRealmWithReconnection"
+        exit 0
+        ;;
+
+    "test-osx-object-server-poor-network")
+        xc "-scheme 'Object Server Tests' -configuration $CONFIGURATION -sdk macosx test \
+            -only-testing:ObjectServerTests/RLMObjectServerTests/testUsernamePasswordAuthenticationWithReconnection \
+            -only-testing:ObjectServerTests/RLMObjectServerTests/testAddObjectsWithReconnection \
+            -only-testing:ObjectServerTests/RLMObjectServerTests/testDownloadRealmWithReconnection"
         exit 0
         ;;
 
@@ -853,6 +864,13 @@ case "$COMMAND" in
     "verify-osx-object-server")
         sh build.sh download-object-server
         sh build.sh test-osx-object-server
+        sh build.sh reset-object-server
+        exit 0
+        ;;
+
+    "verify-osx-object-server-poor-network")
+        sh build.sh download-object-server
+        sh build.sh test-osx-object-server-poor-network
         sh build.sh reset-object-server
         exit 0
         ;;

--- a/scripts/bandwidth_throttling.sh
+++ b/scripts/bandwidth_throttling.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -o pipefail
+set -e
+
+######################################
+# Simulating Poor Network Connectivity
+######################################
+enable_bandwidth_throttling() {
+    # run inside sudo
+    sudo sh <<SCRIPT
+        dnctl pipe 1 config bw $1 plr $2 delay $3
+        dnctl list
+        echo "dummynet out proto tcp from 127.0.0.1 to 127.0.0.1 pipe 1" | pfctl -f -
+        pfctl -e
+SCRIPT
+}
+
+disable_bandwidth_throttling() {
+    # run inside sudo
+    sudo sh <<SCRIPT
+        dnctl -f flush
+        pfctl -f /etc/pf.conf
+        pfctl -d
+SCRIPT
+}

--- a/scripts/disable_networking.sh
+++ b/scripts/disable_networking.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -o pipefail
+set -e
+
+source ./scripts/bandwidth_throttling.sh
+
+# Set 100% packet loss
+enable_bandwidth_throttling '40Mbit/s' 100 0

--- a/scripts/disable_networking.sh
+++ b/scripts/disable_networking.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set -o pipefail
 set -e
 

--- a/scripts/enable_networking.sh
+++ b/scripts/enable_networking.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -o pipefail
+set -e
+
+source ./scripts/bandwidth_throttling.sh
+
+disable_bandwidth_throttling

--- a/scripts/enable_networking.sh
+++ b/scripts/enable_networking.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set -o pipefail
 set -e
 


### PR DESCRIPTION
Fixes https://github.com/realm/realm-cocoa/issues/4900
This is a WIP, but I’d appreciate it if you could give me your feedback.

Add an ROS test that running on a slow network environment. It uses `pfctl`, ` dnctl` and `dummynet` to simulate a slow network. Network Link Conditioner probably uses the same mechanism. Since Network Link Conditioner doesn't has command line interface, it doesn't seem to affect local hosts.

@jpsim Does this fit your thoughts? These commands require `sudo`. How should we handle a password?

CC @bdash @stel 