### PR TITLE
Combine publisher for subscribing to single object changes

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -428,6 +428,8 @@
 		5DEAA36720212AF00024A6BE /* work_queue.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5DEAA36520212AF00024A6BE /* work_queue.hpp */; };
 		5DEAA36820212BF90024A6BE /* work_queue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5DEAA36420212AEF0024A6BE /* work_queue.cpp */; };
 		5DEAA36920212BF90024A6BE /* work_queue.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5DEAA36520212AF00024A6BE /* work_queue.hpp */; };
+		6D82A0ED22C6E60300B67A4E /* ObjectCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D82A0EC22C6E60300B67A4E /* ObjectCombineTests.swift */; };
+		6D82A0EF22C6E63600B67A4E /* Object+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D82A0EE22C6E63600B67A4E /* Object+Combine.swift */; };
 		C042A48D1B7522A900771ED2 /* RealmConfigurationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C042A48C1B7522A900771ED2 /* RealmConfigurationTests.mm */; };
 		C042A48E1B7522A900771ED2 /* RealmConfigurationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C042A48C1B7522A900771ED2 /* RealmConfigurationTests.mm */; };
 		C0CDC0821B38DABA00C5716D /* UtilTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 021A88311AAFB5BE00EEAC84 /* UtilTests.mm */; };
@@ -925,6 +927,8 @@
 		5DD755E31BE05EA1002800DA /* Tests iOS static.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Tests iOS static.xcconfig"; sourceTree = "<group>"; };
 		5DEAA36420212AEF0024A6BE /* work_queue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = work_queue.cpp; path = sync/impl/work_queue.cpp; sourceTree = "<group>"; };
 		5DEAA36520212AF00024A6BE /* work_queue.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = work_queue.hpp; path = sync/impl/work_queue.hpp; sourceTree = "<group>"; };
+		6D82A0EC22C6E60300B67A4E /* ObjectCombineTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectCombineTests.swift; sourceTree = "<group>"; };
+		6D82A0EE22C6E63600B67A4E /* Object+Combine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Object+Combine.swift"; sourceTree = "<group>"; };
 		A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMObjectBase_Dynamic.h; sourceTree = "<group>"; };
 		C0004BEB1B8E4FCF00304BF3 /* RLMOptionalBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMOptionalBase.h; sourceTree = "<group>"; };
 		C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMOptionalBase.mm; sourceTree = "<group>"; };
@@ -1359,6 +1363,7 @@
 				5D660FE51BE98D670021E04F /* Migration.swift */,
 				3FE5818322C2B4B900BA10E7 /* Nonsync.swift */,
 				5D660FE61BE98D670021E04F /* Object.swift */,
+				6D82A0EE22C6E63600B67A4E /* Object+Combine.swift */,
 				3FE5818422C2B4B900BA10E7 /* ObjectiveCSupport+Sync.swift */,
 				5B77EACD1DCC5614006AB51D /* ObjectiveCSupport.swift */,
 				5D660FE71BE98D670021E04F /* ObjectSchema.swift */,
@@ -1392,6 +1397,7 @@
 				5BC537151DD5B8D70055C524 /* ObjectiveCSupportTests.swift */,
 				5D6610041BE98D880021E04F /* ObjectSchemaInitializationTests.swift */,
 				5D6610051BE98D880021E04F /* ObjectSchemaTests.swift */,
+				6D82A0EC22C6E60300B67A4E /* ObjectCombineTests.swift */,
 				5D6610061BE98D880021E04F /* ObjectTests.swift */,
 				5D6610071BE98D880021E04F /* PerformanceTests.swift */,
 				3F2633C21E9D630000B32D30 /* PrimitiveListTests.swift */,
@@ -2487,6 +2493,7 @@
 				5D660FF81BE98D670021E04F /* Realm.swift in Sources */,
 				1AB605D31D495927007F53DE /* RealmCollection.swift in Sources */,
 				5D660FFA1BE98D670021E04F /* RealmConfiguration.swift in Sources */,
+				6D82A0EF22C6E63600B67A4E /* Object+Combine.swift in Sources */,
 				5D660FFB1BE98D670021E04F /* Results.swift in Sources */,
 				5D660FFC1BE98D670021E04F /* Schema.swift in Sources */,
 				5D660FFD1BE98D670021E04F /* SortDescriptor.swift in Sources */,
@@ -2513,6 +2520,7 @@
 				3F8825021E5E335000586B35 /* ObjectSchemaTests.swift in Sources */,
 				3F8825031E5E335000586B35 /* ObjectTests.swift in Sources */,
 				3F8825041E5E335000586B35 /* PerformanceTests.swift in Sources */,
+				6D82A0ED22C6E60300B67A4E /* ObjectCombineTests.swift in Sources */,
 				3F2633C31E9D630000B32D30 /* PrimitiveListTests.swift in Sources */,
 				3F8825051E5E335000586B35 /* PropertyTests.swift in Sources */,
 				3F8825061E5E335000586B35 /* RealmCollectionTypeTests.swift in Sources */,

--- a/RealmSwift/Object+Combine.swift
+++ b/RealmSwift/Object+Combine.swift
@@ -20,16 +20,24 @@ import Foundation
 import Realm
 import Combine
 
+/**
+ Produces a Combine publisher for subscribing to changes to an object
+ 
+ This publisher will produce the following:
+ - a `[PropertyChange]` value whenever any object property changes
+ - an `NSError` when an observation error occurs
+ - a completion when the object is deleted
+ */
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-extension Object {
-    public func asPublisher() -> AnyPublisher<[PropertyChange], NSError> {
+public extension Object {
+    func asPublisher() -> AnyPublisher<[PropertyChange], NSError> {
         let publisher = ObjectChangesPublisher(self)
         return publisher.eraseToAnyPublisher()
     }
 }
 
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-class ObjectChangesSubscription: Subscription {
+fileprivate class ObjectChangesSubscription: Subscription {
     var token: NotificationToken?
     var demand: Subscribers.Demand = .unlimited
     
@@ -60,13 +68,14 @@ class ObjectChangesSubscription: Subscription {
     
     func cancel() {
         token?.invalidate()
+        token = nil
         demand = .none
     }
     
 }
 
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-struct ObjectChangesPublisher: Publisher {
+fileprivate struct ObjectChangesPublisher: Publisher {
     
     typealias Output = [PropertyChange]
     typealias Failure = NSError

--- a/RealmSwift/Object+Combine.swift
+++ b/RealmSwift/Object+Combine.swift
@@ -45,7 +45,7 @@ fileprivate class ObjectChangesSubscription: Subscription {
 
     init<S>(_ object: Object, subscriber: S) where S: Subscriber, NSError == S.Failure, [PropertyChange] == S.Input {
 
-        token = object.observe() {
+        token = object.observe {
             [weak self] in
             self?.dispatchObjectChange($0, to: subscriber)
         }
@@ -87,7 +87,7 @@ fileprivate struct ObjectChangesPublisher: Publisher {
     public init(_ object: Object) {
         self.object = object
     }
-    func receive<S>(subscriber: S) where S : Subscriber, NSError == S.Failure, [PropertyChange] == S.Input {
+    func receive<S>(subscriber: S) where S: Subscriber, NSError == S.Failure, [PropertyChange] == S.Input {
         subscriber.receive(subscription: ObjectChangesSubscription(object, subscriber: subscriber))
     }
 

--- a/RealmSwift/Object+Combine.swift
+++ b/RealmSwift/Object+Combine.swift
@@ -16,6 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+#if compiler(>=5.1)
+
 import Foundation
 import Realm
 import Combine
@@ -90,3 +92,5 @@ fileprivate struct ObjectChangesPublisher: Publisher {
     }
 
 }
+
+#endif

--- a/RealmSwift/Object+Combine.swift
+++ b/RealmSwift/Object+Combine.swift
@@ -22,7 +22,7 @@ import Combine
 
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Object {
-    public func asPublisher() -> AnyPublisher<[PropertyChange], Error> {
+    public func asPublisher() -> AnyPublisher<[PropertyChange], NSError> {
         let publisher = ObjectChangesPublisher(self)
         return publisher.eraseToAnyPublisher()
     }
@@ -33,7 +33,7 @@ class ObjectChangesSubscription: Subscription {
     var token: NotificationToken?
     var demand: Subscribers.Demand = .unlimited
     
-    init<S>(_ object: Object, subscriber: S) where S: Subscriber, Error == S.Failure, [PropertyChange] == S.Input {
+    init<S>(_ object: Object, subscriber: S) where S: Subscriber, NSError == S.Failure, [PropertyChange] == S.Input {
         
         token = object.observe() {
             [weak self] in
@@ -41,7 +41,7 @@ class ObjectChangesSubscription: Subscription {
         }
     }
     
-    private func dispatchObjectChange<S>(_ objectChange: ObjectChange, to subscriber: S)  where S: Subscriber, Error == S.Failure, [PropertyChange] == S.Input {
+    private func dispatchObjectChange<S>(_ objectChange: ObjectChange, to subscriber: S)  where S: Subscriber, NSError == S.Failure, [PropertyChange] == S.Input {
         switch(objectChange) {
         case .change(let propertyChanges):
             if self.demand != .none {
@@ -69,14 +69,14 @@ class ObjectChangesSubscription: Subscription {
 struct ObjectChangesPublisher: Publisher {
     
     typealias Output = [PropertyChange]
-    typealias Failure = Error
+    typealias Failure = NSError
     
     private let object: Object
     
     public init(_ object: Object) {
         self.object = object
     }
-    func receive<S>(subscriber: S) where S : Subscriber, Error == S.Failure, [PropertyChange] == S.Input {
+    func receive<S>(subscriber: S) where S : Subscriber, NSError == S.Failure, [PropertyChange] == S.Input {
         subscriber.receive(subscription: ObjectChangesSubscription(object, subscriber: subscriber))
     }
     

--- a/RealmSwift/Object+Combine.swift
+++ b/RealmSwift/Object+Combine.swift
@@ -1,0 +1,72 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2014 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import Foundation
+import Realm
+import Combine
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Object {
+    public func asPublisher() -> AnyPublisher<ObjectChange, Error> {
+        let publisher = ObjectChangesPublisher(self)
+        return publisher.eraseToAnyPublisher()
+    }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+class ObjectChangesSubscription: Subscription {
+    var token: NotificationToken?
+    var demand: Subscribers.Demand = .unlimited
+    
+    init<S>(_ object: Object, subscriber: S) where S: Subscriber, Error == S.Failure, ObjectChange == S.Input {
+        
+        token = object.observe() {
+            [weak self] in
+            if let s = self, s.demand != .none {
+                s.demand = subscriber.receive($0)
+            }
+        }
+    }
+    
+    func request(_ demand: Subscribers.Demand) {
+        self.demand = demand
+    }
+    
+    func cancel() {
+        token?.invalidate()
+        demand = .none
+    }
+    
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+struct ObjectChangesPublisher: Publisher {
+    
+    typealias Output = ObjectChange
+    typealias Failure = Error
+    
+    private let object: Object
+    
+    public init(_ object: Object) {
+        self.object = object
+    }
+    func receive<S>(subscriber: S) where S : Subscriber, Error == S.Failure, ObjectChange == S.Input {
+        subscriber.receive(subscription: ObjectChangesSubscription(object, subscriber: subscriber))
+    }
+    
+}

--- a/RealmSwift/Tests/ObjectCombineTests.swift
+++ b/RealmSwift/Tests/ObjectCombineTests.swift
@@ -16,6 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+#if compiler(>=5.1)
+
 import XCTest
 import RealmSwift
 import Foundation
@@ -120,3 +122,5 @@ class ObjectCombineTests: TestCase {
 
 
 }
+
+#endif

--- a/RealmSwift/Tests/ObjectCombineTests.swift
+++ b/RealmSwift/Tests/ObjectCombineTests.swift
@@ -91,7 +91,7 @@ class ObjectCombineTests: TestCase {
 
     func testAsPublisherCancel() {
         let exp = expectation(description: "")
-        
+
         let realm = try! Realm()
         var object: SwiftObject!
         try! realm.write {

--- a/RealmSwift/Tests/ObjectCombineTests.swift
+++ b/RealmSwift/Tests/ObjectCombineTests.swift
@@ -26,7 +26,7 @@ class ObjectCombineTests: TestCase {
 
     func testAsPublisher() {
         let exp = expectation(description: "")
-        
+
         let realm = try! Realm()
         var object: SwiftObject!
         try! realm.write {
@@ -34,7 +34,7 @@ class ObjectCombineTests: TestCase {
         }
         let objectRef = ThreadSafeReference(to: object)
         var objectChanges: [[PropertyChange]] = []
-        let subscriber = object.asPublisher().sink() {
+        let subscriber = object.asPublisher().sink {
             objectChanges.append($0)
         }
         queue.async {
@@ -55,17 +55,17 @@ class ObjectCombineTests: TestCase {
         XCTAssertEqual(objectChanges[0][0].newValue as! String, "abcd", "Wrong value was reported")
         subscriber.cancel()
     }
-    
+
     func testAsPublisherCompletion() {
         let exp = expectation(description: "")
-        
+
         let realm = try! Realm()
         var object: SwiftObject!
         try! realm.write {
             object = realm.create(SwiftObject.self, value: [:])
         }
         let objectRef = ThreadSafeReference(to: object)
-        
+
         var receivedCompletion: Bool = false
         var receivedValue: Bool = false
         let subscriber = object.asPublisher().sink(receiveCompletion: {_ in receivedCompletion = true },
@@ -78,10 +78,10 @@ class ObjectCombineTests: TestCase {
             }
             exp.fulfill()
         }
-        
+
         waitForExpectations(timeout: 0.2)
         realm.refresh()
-        
+
         XCTAssertTrue(receivedCompletion)
         XCTAssertFalse(receivedValue)
         subscriber.cancel()
@@ -96,11 +96,11 @@ class ObjectCombineTests: TestCase {
             object = realm.create(SwiftObject.self, value: [:])
         }
         let objectRef = ThreadSafeReference(to: object)
-        
+
         var valuePublished = false
 
-        let subscriber = object.asPublisher().sink() {
-            _ in valuePublished = true
+        let subscriber = object.asPublisher().sink { _ in
+            valuePublished = true
         }
         subscriber.cancel()
         queue.async {
@@ -114,9 +114,9 @@ class ObjectCombineTests: TestCase {
 
         waitForExpectations(timeout: 0.2)
         realm.refresh()
-        
+
         XCTAssertFalse(valuePublished, "Value was published after cancel.")
     }
 
-    
+
 }

--- a/RealmSwift/Tests/ObjectCombineTests.swift
+++ b/RealmSwift/Tests/ObjectCombineTests.swift
@@ -1,0 +1,61 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import XCTest
+import RealmSwift
+import Foundation
+
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+class ObjectCombineTests: TestCase {
+
+    // init() Tests are in ObjectCreationTests.swift
+
+    // init(value:) tests are in ObjectCreationTests.swift
+
+    func testAsPublisher() {
+        let exp = expectation(description: "")
+        
+        let realm = try! Realm()
+        var object: SwiftObject!
+        try! realm.write {
+            object = realm.create(SwiftObject.self, value: [:])
+        }
+        let objectRef = ThreadSafeReference(to: object)
+        var objectChanges: [ObjectChange] = []
+        let subscriber = object.asPublisher().sink() {
+            objectChanges.append($0)
+        }
+        queue.async {
+            let realm = try! Realm()
+            let object = realm.resolve(objectRef)!
+            try! realm.write {
+                object.stringCol = "abcd"
+            }
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 0.2)
+        realm.refresh()
+
+        XCTAssertEqual(objectChanges.count, 1, "Value was not published")
+        subscriber.cancel()
+    }
+
+    
+}


### PR DESCRIPTION
You can use it like so:
```
object.asPublisher().sink {
   // $0 is a [PropertyChange]
}
```

with errors from `observe` being propagated, and deletions resulting in subscription completion.

`Demand` values other than `unlimited` and `none` are not yet supported.