### PR TITLE
Updated build.sh to link swift framework

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -175,7 +175,7 @@ build_combined() {
 
     # Combine .swiftmodule
     if [ -d $simulator_path/Modules/$module_name.swiftmodule ]; then
-      cp $simulator_path/Modules/$module_name.swiftmodule/* $os_path/Modules/$module_name.swiftmodule/
+      cp -r $simulator_path/Modules/$module_name.swiftmodule/* $os_path/Modules/$module_name.swiftmodule/
     fi
 
     # Xcode 10.2 merges the generated headers together with ifdef guards for


### PR DESCRIPTION
Previously RealmSwift framework was not copied, this resolves the issue and generates the dynamic frameworks.