### PR TITLE
Needed quotes around the simulator location

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -364,8 +364,9 @@ download_common() {
         # Xcode 11 dsymutil crashes when given debugging symbols created by
         # Xcode 12. Check if this breaks, and strip them if so.
         local test_lib=core/realm-monorepo.xcframework/ios-*-simulator/librealm-monorepo.a
+        local isysroot=$(xcrun --sdk iphonesimulator --show-sdk-path)
         xcrun clang++ -Wl,-all_load -g -arch x86_64 -shared -target ios13.0 \
-          -isysroot $(xcrun --sdk iphonesimulator --show-sdk-path) -o tmp.dylib \
+          -isysroot "$isysroot" -o tmp.dylib \
           $test_lib -lz -framework Security
         if ! dsymutil tmp.dylib -o tmp.dSYM 2> /dev/null; then
             find core -name '*.a' -exec strip -x "{}" \; 2> /dev/null


### PR DESCRIPTION
I have multiple versions of macOS running on my machine (Catalina, Big Sur, Big Sur Beta) and I only keep a bunch of Xcode versions on my main partition because of HD space issues. The default HD name is "Macintosh HD" which contains a space and if I target an Xcode that is on that disk the `build.sh` script fails when installing Cocoapods because it encounters an unexpected space in the path.

I patched it by generating the simulator path first and then putting quotes around the variable containing the path. After a clean it started building again, so that seems to fix the problem.

Since Realm is a dependency of a dependency (matrix) it's hard to work around the problem so I would really appreciate if you could merge it into the main branch sometime soon.