### PR TITLE
Cut the size of the compiled library a bit

### DIFF
--- a/Realm/RLMCollection.mm
+++ b/Realm/RLMCollection.mm
@@ -100,7 +100,7 @@ static const int RLMEnumerationBufferSize = 16;
 
 - (instancetype)initWithResults:(realm::Results&)results
                      collection:(id)collection
-                      classInfo:(RLMClassInfo&)info {
+                      classInfo:(RLMClassInfo&)info RLM_DIRECT {
     self = [super init];
     if (self) {
         _info = &info;
@@ -392,7 +392,7 @@ std::vector<std::pair<std::string, bool>> RLMSortDescriptorsToKeypathArray(NSArr
     realm::CollectionChangeSet _indices;
 }
 
-- (instancetype)initWithChanges:(realm::CollectionChangeSet)indices {
+- (instancetype)initWithChanges:(realm::CollectionChangeSet)indices RLM_DIRECT {
     self = [super init];
     if (self) {
         _indices = std::move(indices);

--- a/Realm/RLMCollection_Private.hpp
+++ b/Realm/RLMCollection_Private.hpp
@@ -88,7 +88,7 @@ NSUInteger RLMFastEnumerate(NSFastEnumerationState *state, NSUInteger len, id<RL
 @end
 
 @interface RLMCollectionChange ()
-- (instancetype)initWithChanges:(realm::CollectionChangeSet)indices;
+- (instancetype)initWithChanges:(realm::CollectionChangeSet)indices RLM_DIRECT;
 @end
 
 realm::CollectionChangeCallback RLMWrapCollectionChangeCallback(void (^block)(id, id, NSError *),

--- a/Realm/RLMFindOneAndModifyOptions_Private.hpp
+++ b/Realm/RLMFindOneAndModifyOptions_Private.hpp
@@ -21,5 +21,5 @@
 #import <realm/object-store/sync/mongo_collection.hpp>
 
 @interface RLMFindOneAndModifyOptions ()
-- (realm::app::MongoCollection::FindOneAndModifyOptions)_findOneAndModifyOptions;
+@property (nonatomic, readonly, direct) realm::app::MongoCollection::FindOneAndModifyOptions _findOneAndModifyOptions;
 @end

--- a/Realm/RLMFindOptions.mm
+++ b/Realm/RLMFindOptions.mm
@@ -20,12 +20,9 @@
 #import "RLMBSON_Private.hpp"
 #import "RLMCollection.h"
 
-@interface RLMFindOptions() {
+@implementation RLMFindOptions {
     realm::app::MongoCollection::FindOptions _options;
-};
-@end
-
-@implementation RLMFindOptions
+}
 
 - (instancetype)initWithLimit:(NSInteger)limit
                    projection:(id<RLMBSON> _Nullable)projection

--- a/Realm/RLMFindOptions_Private.hpp
+++ b/Realm/RLMFindOptions_Private.hpp
@@ -23,7 +23,7 @@
 RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface RLMFindOptions ()
-- (realm::app::MongoCollection::FindOptions)_findOptions;
+@property (nonatomic, readonly, direct) realm::app::MongoCollection::FindOptions _findOptions;
 @end
 
 RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMMongoCollection.mm
+++ b/Realm/RLMMongoCollection.mm
@@ -136,7 +136,7 @@ __attribute__((objc_direct_members))
 - (void)findWhere:(NSDictionary<NSString *, id<RLMBSON>> *)document
           options:(RLMFindOptions *)options
        completion:(RLMMongoFindBlock)completion {
-    self.collection.find(toBsonDocument(document), [options _findOptions],
+    self.collection.find(toBsonDocument(document), options._findOptions,
                          [completion](std::optional<realm::bson::BsonArray> documents,
                                       std::optional<realm::app::AppError> error) {
         if (error) {
@@ -154,7 +154,7 @@ __attribute__((objc_direct_members))
 - (void)findOneDocumentWhere:(NSDictionary<NSString *, id<RLMBSON>> *)document
                      options:(RLMFindOptions *)options
                   completion:(RLMMongoFindOneBlock)completion {
-    self.collection.find_one(toBsonDocument(document), [options _findOptions],
+    self.collection.find_one(toBsonDocument(document), options._findOptions,
                              [completion](std::optional<realm::bson::BsonDocument> document,
                                           std::optional<realm::app::AppError> error) {
         if (error) {

--- a/Realm/RLMObjectId_Private.hpp
+++ b/Realm/RLMObjectId_Private.hpp
@@ -18,6 +18,8 @@
 
 #import <Realm/RLMObjectId.h>
 
+#import <Realm/RLMConstants.h>
+
 namespace realm {
 class ObjectId;
 }

--- a/Realm/RLMObjectSchema_Private.hpp
+++ b/Realm/RLMObjectSchema_Private.hpp
@@ -26,11 +26,11 @@ namespace realm {
 @class RLMSchema;
 
 @interface RLMObjectSchema ()
-- (std::string const&)objectStoreName;
+@property (nonatomic, readonly) std::string const& objectStoreName;
 
 // create realm::ObjectSchema copy
-- (realm::ObjectSchema)objectStoreCopy:(RLMSchema *)schema;
+- (realm::ObjectSchema)objectStoreCopy:(RLMSchema *)schema RLM_DIRECT;
 
 // initialize with realm::ObjectSchema
-+ (instancetype)objectSchemaForObjectStoreSchema:(realm::ObjectSchema const&)objectSchema;
++ (instancetype)objectSchemaForObjectStoreSchema:(realm::ObjectSchema const&)objectSchema RLM_DIRECT;
 @end

--- a/Realm/RLMPredicateUtil.hpp
+++ b/Realm/RLMPredicateUtil.hpp
@@ -16,7 +16,6 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <functional>
 
-using ExpressionVisitor = std::function<NSExpression *(NSExpression *)>;
+using ExpressionVisitor = NSExpression *(*)(NSExpression *);
 NSPredicate *transformPredicate(NSPredicate *, ExpressionVisitor);

--- a/Realm/RLMProviderClient_Private.hpp
+++ b/Realm/RLMProviderClient_Private.hpp
@@ -18,6 +18,8 @@
 
 #import <Realm/RLMProviderClient.h>
 
+#import <Realm/RLMConstants.h>
+
 #import <realm/object-store/sync/app.hpp>
 
 @interface RLMProviderClient ()

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import "RLMRealmConfiguration_Private.h"
+#import "RLMRealmConfiguration_Private.hpp"
 
 #import "RLMEvent.h"
 #import "RLMObjectSchema_Private.hpp"

--- a/Realm/RLMRealmConfiguration_Private.hpp
+++ b/Realm/RLMRealmConfiguration_Private.hpp
@@ -21,11 +21,11 @@
 #import <realm/object-store/shared_realm.hpp>
 
 @interface RLMRealmConfiguration ()
-- (realm::Realm::Config)config;
-- (realm::Realm::Config&)configRef;
-- (std::string const&)path;
-
+@property (nonatomic, readonly) realm::Realm::Config config;
+@property (nonatomic, readonly) realm::Realm::Config& configRef;
+@property (nonatomic, readonly) std::string const& path;
 @property (nonatomic) realm::SchemaMode schemaMode;
+
 - (void)updateSchemaMode;
 @end
 

--- a/Realm/RLMSchema_Private.hpp
+++ b/Realm/RLMSchema_Private.hpp
@@ -18,6 +18,8 @@
 
 #import "RLMSchema_Private.h"
 
+#import <Realm/RLMConstants.h>
+
 #import <memory>
 
 namespace realm {

--- a/Realm/RLMSyncConfiguration_Private.hpp
+++ b/Realm/RLMSyncConfiguration_Private.hpp
@@ -31,13 +31,13 @@ RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface RLMSyncConfiguration ()
 - (instancetype)initWithRawConfig:(realm::SyncConfig)config path:(std::string const&)path;
-- (realm::SyncConfig&)rawConfiguration;
 
 // Pass the RLMRealmConfiguration to it's sync configuration so client reset callbacks
 // can access schema, dynamic, and path properties.
 void RLMSetConfigInfoForClientResetCallbacks(realm::SyncConfig& syncConfig, RLMRealmConfiguration *config);
 
 @property (nonatomic, direct) std::string path;
+@property (nonatomic, readonly) realm::SyncConfig& rawConfiguration;
 @end
 
 RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSyncManager_Private.hpp
+++ b/Realm/RLMSyncManager_Private.hpp
@@ -38,16 +38,16 @@ class Logger;
 RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface RLMSyncManager ()
-- (std::weak_ptr<realm::app::App>)app;
-- (std::shared_ptr<realm::SyncManager>)syncManager;
-- (instancetype)initWithSyncManager:(std::shared_ptr<realm::SyncManager>)syncManager;
+@property (nonatomic, readonly, direct) std::weak_ptr<realm::app::App> app;
+@property (nonatomic, readonly, direct) std::shared_ptr<realm::SyncManager> syncManager;
 
+- (instancetype)initWithSyncManager:(std::shared_ptr<realm::SyncManager>)syncManager RLM_DIRECT;
 + (realm::SyncClientConfig)configurationWithRootDirectory:(nullable NSURL *)rootDirectory
                                                     appId:(nonnull NSString *)appId;
 
 - (void)resetForTesting;
 - (void)waitForSessionTermination;
-- (void)populateConfig:(realm::SyncConfig&)config;
+- (void)populateConfig:(realm::SyncConfig&)config RLM_DIRECT;
 @end
 
 std::shared_ptr<realm::util::Logger> RLMWrapLogFunction(RLMSyncLogFunction);

--- a/Realm/RLMSyncSession_Private.hpp
+++ b/Realm/RLMSyncSession_Private.hpp
@@ -35,7 +35,7 @@ RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 - (instancetype)init __attribute__((unavailable("This type cannot be created directly")));
 + (instancetype)new __attribute__((unavailable("This type cannot be created directly")));
 
-- (instancetype)initWithSyncSession:(std::shared_ptr<realm::SyncSession> const&)session;
+- (instancetype)initWithSyncSession:(std::shared_ptr<realm::SyncSession> const&)session RLM_DIRECT;
 
 /// Wait for pending uploads to complete or the session to expire, and dispatch the callback onto the specified queue.
 - (BOOL)waitForUploadCompletionOnQueue:(nullable dispatch_queue_t)queue callback:(void(^)(NSError * _Nullable))callback;

--- a/Realm/RLMThreadSafeReference_Private.hpp
+++ b/Realm/RLMThreadSafeReference_Private.hpp
@@ -18,6 +18,8 @@
 
 #import "RLMThreadSafeReference.h"
 
+#import <Realm/RLMConstants.h>
+
 #import <realm/object-store/thread_safe_reference.hpp>
 
 RLM_HEADER_AUDIT_BEGIN(nullability, sendability)

--- a/Realm/RLMUpdateResult_Private.hpp
+++ b/Realm/RLMUpdateResult_Private.hpp
@@ -18,10 +18,12 @@
 
 #import <Realm/RLMUpdateResult.h>
 
+#import <Realm/RLMConstants.h>
+
 #import <realm/object-store/sync/mongo_collection.hpp>
 
 RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 @interface RLMUpdateResult ()
-- (instancetype)initWithUpdateResult:(realm::app::MongoCollection::UpdateResult)UpdateResult;
+- (instancetype)initWithUpdateResult:(realm::app::MongoCollection::UpdateResult)UpdateResult RLM_DIRECT;
 @end
 RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMUserAPIKey_Private.hpp
+++ b/Realm/RLMUserAPIKey_Private.hpp
@@ -18,9 +18,11 @@
 
 #import <Realm/RLMUserAPIKey.h>
 
+#import <Realm/RLMConstants.h>
+
 #import <realm/object-store/sync/app.hpp>
 
 @interface RLMUserAPIKey ()
-- (realm::app::App::UserAPIKey)_apiKey;
-- (instancetype)initWithUserAPIKey:(realm::app::App::UserAPIKey)userAPIKey;
+- (realm::app::App::UserAPIKey)_apiKey RLM_DIRECT;
+- (instancetype)initWithUserAPIKey:(realm::app::App::UserAPIKey)userAPIKey RLM_DIRECT;
 @end

--- a/Realm/RLMUser_Private.hpp
+++ b/Realm/RLMUser_Private.hpp
@@ -43,13 +43,13 @@ private:
 };
 
 @interface RLMUser ()
-- (instancetype)initWithUser:(std::shared_ptr<realm::SyncUser>)user app:(RLMApp *)app;
-- (std::string)pathForPartitionValue:(std::string const&)partitionValue;
-- (std::string)pathForFlexibleSync;
-- (std::shared_ptr<realm::SyncUser>)_syncUser;
-+ (void)_setUpBindingContextFactory;
 @property (weak, readonly) RLMApp *app;
 
+- (instancetype)initWithUser:(std::shared_ptr<realm::SyncUser>)user app:(RLMApp *)app RLM_DIRECT;
+- (std::string)pathForPartitionValue:(std::string const&)partitionValue RLM_DIRECT;
+- (std::string)pathForFlexibleSync RLM_DIRECT;
+- (std::shared_ptr<realm::SyncUser>)_syncUser;
++ (void)_setUpBindingContextFactory;
 @end
 
 @interface RLMUserProfile ()

--- a/Realm/Tests/PredicateUtilTests.mm
+++ b/Realm/Tests/PredicateUtilTests.mm
@@ -28,8 +28,9 @@
 
 - (void)testVisitingAllExpressionTypes {
     auto testPredicate = [&](NSPredicate *predicate, size_t expectedExpressionCount) {
-        size_t visitCount = 0;
-        auto visitExpression = [&](NSExpression *expression) {
+        static size_t visitCount;
+        visitCount = 0;
+        auto visitExpression = [](NSExpression *expression) {
             visitCount++;
             return expression;
         };


### PR DESCRIPTION
Inspired by https://pspdfkit.com/blog/2020/objc-type-encodings/ I took a look to see if we had any silly large type encodings, and unsurprisingly we did. Most of the methods with large signatures we can mark as `objc_direct`, but some of them actually do need dynamic dispatch.  I also noticed that an unreasonably large portion of the binary is from std::function instantiations, so I refactored some code to cut that down.

Size changes for the macOS obj-c dynamic framework (with x86_64 and arm64):

| Modification | Size Reduction |
| ------------ | -------------- |
| objc_direct  | 128.5 KB       |
| RLMIvar | 112 KB |
| Extract duplicate code | 118 KB |