### PR TITLE
Allow nested and private object subclasses in Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ x.y.z Release notes (yyyy-MM-dd)
 Replace Xcode 14.3 binaries with 14.3.1, which has important bug fixes for Swift Concurrency.
 
 ### Enhancements
-* None.
+* Adjust the error message for private `Object` subclasses and subclasses
+  nested inside other types to explain how to make them work rather than state
+  that it's impossible. ([#5662](https://github.com/realm/realm-cocoa/issues/5662)).
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -153,7 +153,7 @@ static void RLMRegisterClassLocalNames(Class *classes, NSUInteger count) {
         // but not for nested classes. _T indicates it's a Swift symbol, t
         // indicates it's a type, and C indicates it's a class.
         else if ([className hasPrefix:@"_TtC"]) {
-            @throw RLMException(@"RLMObject subclasses cannot be nested within other declarations. Please move %@ to global scope.", className);
+            @throw RLMException(@"Object subclass '%@' must explicitly set the class's objective-c name with @objc(ClassName) because it is not a top-level public class.", className);
         }
 
         if (Class existingClass = s_localNameToClass[className]) {

--- a/Realm/TestUtils/RLMTestCase.m
+++ b/Realm/TestUtils/RLMTestCase.m
@@ -218,7 +218,7 @@ static BOOL encryptTests(void) {
     return _bgQueue;
 }
 
-- (void)dispatchAsync:(dispatch_block_t)block {
+- (void)dispatchAsync:(RLM_SWIFT_SENDABLE dispatch_block_t)block {
     dispatch_async(self.bgQueue, ^{
         @autoreleasepool {
             block();
@@ -226,7 +226,7 @@ static BOOL encryptTests(void) {
     });
 }
 
-- (void)dispatchAsyncAndWait:(dispatch_block_t)block {
+- (void)dispatchAsyncAndWait:(RLM_SWIFT_SENDABLE dispatch_block_t)block {
     [self dispatchAsync:block];
     dispatch_sync(_bgQueue, ^{});
 }

--- a/Realm/TestUtils/include/RLMTestCase.h
+++ b/Realm/TestUtils/include/RLMTestCase.h
@@ -53,8 +53,8 @@ NSData *RLMGenerateKey(void);
 - (nullable id)nonLiteralNil;
 - (BOOL)encryptTests;
 
-- (void)dispatchAsync:(dispatch_block_t)block;
-- (void)dispatchAsyncAndWait:(dispatch_block_t)block;
+- (void)dispatchAsync:(RLM_SWIFT_SENDABLE dispatch_block_t)block;
+- (void)dispatchAsyncAndWait:(RLM_SWIFT_SENDABLE dispatch_block_t)block;
 
 @property (nonatomic, readonly) dispatch_queue_t bgQueue;
 

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -678,14 +678,12 @@ RLM_COLLECTION_TYPE(MigrationTestObject);
     };
     [RLMRealm asyncOpenWithConfiguration:c
                            callbackQueue:dispatch_get_main_queue()
-                                 callback:^(RLMRealm * _Nullable realm, NSError * _Nullable error) {
+                                 callback:^(RLMRealm *realm, NSError *error) {
         XCTAssertTrue(migrationCalled);
         XCTAssertNil(error);
         XCTAssertNotNil(realm);
         [ex fulfill];
     }];
-    XCTAssertFalse(migrationCalled);
-    XCTAssertNil(RLMGetAnyCachedRealmForPath(c.pathOnDisk.UTF8String));
     [self waitForExpectationsWithTimeout:1 handler:nil];
     XCTAssertTrue(migrationCalled);
     XCTAssertNil(RLMGetAnyCachedRealmForPath(c.pathOnDisk.UTF8String));

--- a/Realm/Tests/Swift/SwiftRealmTests.swift
+++ b/Realm/Tests/Swift/SwiftRealmTests.swift
@@ -163,8 +163,8 @@ class SwiftRLMRealmTests: RLMTestCase {
             try! realm.commitWriteTransaction()
 
             let objects = SwiftRLMStringObject.allObjects(in: realm)
-            XCTAssertEqual(objects.count, UInt(1), "There should be 1 object of type StringObject")
-            XCTAssertEqual((objects[0] as! SwiftRLMStringObject).stringCol, "string", "Value of first column should be 'string'")
+            XCTAssertEqual(objects.count, UInt(1))
+            XCTAssertEqual((objects[0] as! SwiftRLMStringObject).stringCol, "string")
         }
 
         waitForExpectations(timeout: 2.0, handler: nil)
@@ -172,8 +172,8 @@ class SwiftRLMRealmTests: RLMTestCase {
 
         // get object
         let objects = SwiftRLMStringObject.allObjects(in: realm)
-        XCTAssertEqual(objects.count, UInt(1), "There should be 1 object of type RLMTestObject")
-        XCTAssertEqual((objects[0] as! SwiftRLMStringObject).stringCol, "string", "Value of first column should be 'string'")
+        XCTAssertEqual(objects.count, UInt(1))
+        XCTAssertEqual((objects[0] as! SwiftRLMStringObject).stringCol, "string")
     }
 
     // Objective-C models

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -902,6 +902,15 @@ class ObjectCreationTests: TestCase {
         realmB.cancelWrite()
     }
 
+    func testCreateObjectWithNestedEmbeddedType() throws {
+        let realm = try Realm()
+        let obj = try realm.write {
+            realm.create(ObjectWithNestedEmbeddedObject.self, value: [1, [2]])
+        }
+        XCTAssertEqual(obj.value, 1)
+        XCTAssertEqual(obj.inner!.value, 2)
+    }
+
     // test null object
     // test null list
 

--- a/RealmSwift/Tests/SchemaTests.swift
+++ b/RealmSwift/Tests/SchemaTests.swift
@@ -55,4 +55,13 @@ class SchemaTests: TestCase {
         XCTAssertNil(schema["DynamicObject"])
         XCTAssertNil(schema["MigrationObject"])
     }
+
+    func testValidNestedClass() throws {
+        let privateSubclass = try XCTUnwrap(schema["PrivateObjectSubclass"])
+        XCTAssertEqual(privateSubclass.className, "PrivateObjectSubclass")
+
+        let parent = try XCTUnwrap(schema["ObjectWithNestedEmbeddedObject"])
+        XCTAssertEqual(parent.properties[1].objectClassName, "ObjectWithNestedEmbeddedObject_NestedInnerClass")
+        XCTAssertNotNil(schema["ObjectWithNestedEmbeddedObject_NestedInnerClass"])
+    }
 }

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -853,3 +853,18 @@ class EmbeddedTreeObject3: EmbeddedObject, EmbeddedTreeObject {
     let parent3 = LinkingObjects(fromType: EmbeddedTreeObject2.self, property: "child")
     let parent4 = LinkingObjects(fromType: EmbeddedTreeObject2.self, property: "children")
 }
+
+class ObjectWithNestedEmbeddedObject: Object {
+    @objc dynamic var value = 0
+    @objc dynamic var inner: NestedInnerClass?
+
+    @objc(ObjectWithNestedEmbeddedObject_NestedInnerClass)
+    class NestedInnerClass: EmbeddedObject {
+        @objc dynamic var value = 0
+    }
+}
+
+@objc(PrivateObjectSubclass)
+private class PrivateObjectSubclass: Object {
+    @objc dynamic var value = 0
+}


### PR DESCRIPTION
This is something that's actually worked fine ever since Swift 3 added the ability to override the obj-c name for Swift types and we just needed an error message explaining what to do.

Fixes https://github.com/realm/realm-cocoa/issues/5662.