### PR TITLE
Fix carthage build error in v5

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -410,7 +410,7 @@ download_common() {
         if ! [ -f $test_lib ]; then
             test_lib="core/librealm-sync-ios-dbg.a"
         fi
-        clang++ -Wl,-all_load -g -arch x86_64 -shared -target ios13.0 \
+        xcrun clang++ -Wl,-all_load -g -arch x86_64 -shared -target ios13.0 \
           -isysroot $(xcrun --sdk iphonesimulator --show-sdk-path) -o tmp.dylib \
           $test_lib -lz -framework Security
         if ! dsymutil tmp.dylib -o tmp.dSYM 2> /dev/null; then

--- a/build.sh
+++ b/build.sh
@@ -689,7 +689,7 @@ case "$COMMAND" in
                 # -all_load makes every object file in the input get linked
                 # into the shared library.
                 ar -d $realm_lib feature_token.cpp.o 2> /dev/null || true
-                clang++ -shared $architectures \
+                xcrun clang++ -shared $architectures \
                     -target ${target} \
                     -isysroot $(xcrun --sdk ${sdk} --show-sdk-path) \
                     -install_name "$install_name" \


### PR DESCRIPTION
Carthage build has been broken since v5.5.1 due to the updates on build script.
The error looks like the following:

```
$ carthage build --no-skip-current --platform iOS

(omitted)

Downloading dependency: sync 5.0.33 from https://static.realm.io/downloads/sync/realm-sync-xcframework-5.0.33.tar.xz
ld: building for iOS Simulator, but linking in .tbd built for macOS/Mac Catalyst, file '/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/lib/libz.tbd' for architecture x86_64
clang-12: error: linker command failed with exit code 1 (use -v to see invocation)
note: Using new build system
note: Using codesigning identity override:
note: Planning build
note: Analyzing workspace
note: Constructing build description
note: Build preparation complete
error: There is no XCFramework found at '/Users/kiyotaka.sasaya/devel/realm-cocoa/core/realm-sync.xcframework'. (in target 'Realm iOS static' from project 'Realm')

** ARCHIVE FAILED **
```

Using xcrun for clang++ invocation solves this error.

Similar error in `build.sh verify-xcframework` is also fixed in a36829b
