### PR TITLE
Add async scheduler

### DIFF
--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -1019,5 +1019,13 @@ extension RealmTests {
         await waitForExpectations(timeout: 2)
         XCTAssertTrue(boolObject.boolCol)
          */
+
+        let ex = expectation(description: "wait for subtask")
+        Task {
+            assertThrows(boolObject.boolCol)
+            ex.fulfill()
+        }
+
+        await waitForExpectations(timeout: 2)
     }
 }


### PR DESCRIPTION
There is obvious code duplication here, please disregard it.

There is also a pain point that users can still technically open Realms in an asynchronous context using `asyncOpen`, which means we need to detect whether or not to use the AsyncScheduler there as well using `withUnsafeCurrentTask`.