### PR TITLE
Change configuration logic in ObservedResults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ x.y.z Release notes (yyyy-MM-dd)
 ### Fixed
 * Adding a Realm Object to a `ObservedResults` or a collections using `StateRealmObject` that is managed by the same Realm 
   would throw if the Object was frozen and not thawed before hand.
+* Setting a Realm Configuration for @ObservedResults using it's initializer would be overrode by the Realm Configuration stored in
+  `.environment(\.realmConfiguration, ...)` if they did not match ([Cocoa #7463](https://github.com/realm/realm-swift/issues/7463), since v10.6.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/Tests/SwiftUITestHost/SwiftUITestHostApp.swift
+++ b/Realm/Tests/SwiftUITestHost/SwiftUITestHostApp.swift
@@ -306,6 +306,46 @@ struct ObservedResultsSearchableTestView: View {
     }
 }
 
+struct ObservedResultsConfiguration: View {
+    @ObservedResults(ReminderList.self) var remindersA // config from `.environment`
+    @ObservedResults(ReminderList.self,
+                     configuration: Realm.Configuration(inMemoryIdentifier: "realm_b")) var remindersB
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                Text(remindersA.realm?.configuration.inMemoryIdentifier ?? "no memory identifier")
+                    .accessibility(identifier: "realm_a_label")
+                Text(remindersB.realm?.configuration.inMemoryIdentifier ?? "no memory identifier")
+                    .accessibility(identifier: "realm_b_label")
+                List {
+                    ForEach(remindersA) { reminder in
+                        Text(reminder.name)
+                    }
+                }.accessibility(identifier: "ListA")
+                List {
+                    ForEach(remindersB) { reminder in
+                        Text(reminder.name)
+                    }
+                }.accessibility(identifier: "ListB")
+            }
+            .navigationTitle("Reminders")
+            .navigationBarItems(leading:
+                Button("add A") {
+                    let reminder = ReminderList()
+                    $remindersA.append(reminder)
+                }.accessibility(identifier: "addListA")
+            )
+            .navigationBarItems(trailing:
+                Button("add B") {
+                    let reminder = ReminderList()
+                    $remindersB.append(reminder)
+                }.accessibility(identifier: "addListB")
+            )
+        }
+    }
+}
+
 @main
 struct App: SwiftUI.App {
     var body: some Scene {
@@ -330,6 +370,9 @@ struct App: SwiftUI.App {
                 } else {
                     return AnyView(EmptyView())
                 }
+            case "observed_results_configuration":
+                return AnyView(ObservedResultsConfiguration()
+                                .environment(\.realmConfiguration, Realm.Configuration(inMemoryIdentifier: "realm_a")))
             default:
                 return AnyView(ContentView())
             }

--- a/Realm/Tests/SwiftUITestHostUITests/SwiftUITestHostUITests.swift
+++ b/Realm/Tests/SwiftUITestHostUITests/SwiftUITestHostUITests.swift
@@ -288,4 +288,28 @@ class SwiftUITests: XCTestCase {
         searchBar.typeText("12")
         XCTAssertEqual(table.cells.count, 1)
     }
+
+    func testObservedResultsConfiguration() {
+        app.launchEnvironment["test_type"] = "observed_results_configuration"
+        app.launch()
+
+        // Check that both @ObservedResults contain the correct configuration.
+        // `remindersA` will get it's config from .environment, while `remindersA`
+        // will get it's Realm config passed in the @ObservedResults initializer.
+        XCTAssertEqual(app.staticTexts["realm_a_label"].label, "realm_a")
+        XCTAssertEqual(app.staticTexts["realm_b_label"].label, "realm_b")
+
+        let addButtonA = app.buttons["addListA"]
+        let addButtonB = app.buttons["addListB"]
+        (1...5).forEach { _ in
+            addButtonA.tap()
+            addButtonB.tap()
+        }
+
+        let tableA = app.tables["ListA"]
+        XCTAssertEqual(tableA.cells.count, 5)
+
+        let tableB = app.tables["ListB"]
+        XCTAssertEqual(tableB.cells.count, 5)
+    }
 }

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -603,7 +603,7 @@ extension Projection: _ObservedResultsValue { }
     public mutating func update() {
         // When the view updates, it will inject the @Environment
         // into the propertyWrapper
-        if storage.configuration == nil || storage.configuration != configuration {
+        if storage.configuration == nil {
             storage.configuration = configuration
         }
     }


### PR DESCRIPTION
In this PR I'm omitting the condition to check if the stored realm config in `Storage` matches the config stored in the SwiftUI environment values. 

This is because a user can pass a realm configuration to `@ObservedResults` and that Realm config will always be overridden  by whatever config is stored in the environment value.

This change may only affect a user who is passing their config via `.environment(\.realmConfiguration, ...)` in a dynamic fashion on a view update.

May fix: https://github.com/realm/realm-cocoa/issues/7463