### PR TITLE
Add ability to use type safe queries in SwiftUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ x.y.z Release notes (yyyy-MM-dd)
   be invoked with `User.delete()`/`[RLMUser deleteWithCompletion:]`.
 * Add `NSCopying` conformance to `RLMDecimal128` and `RLMObjectId`.
 * Add Xcode 13.3 binaries to the release package (and remove 13.0).
+* Conform `@ThreadSafe` and `ThreadSafeReference` to `Sendable`.
+* Add ability to use Swift Query syntax in `@ObservedResults`.
+* Add ability to use Swift Query syntax in `@ObservedResults`, which allows you 
+  to filter results using the where parameter.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Add ability to use Swift Query syntax in `@ObservedResults`, which allows you 
+  to filter results using the `where` parameter.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
@@ -45,8 +46,6 @@ x.y.z Release notes (yyyy-MM-dd)
   be invoked with `User.delete()`/`[RLMUser deleteWithCompletion:]`.
 * Add `NSCopying` conformance to `RLMDecimal128` and `RLMObjectId`.
 * Add Xcode 13.3 binaries to the release package (and remove 13.0).
-* Add ability to use Swift Query syntax in `@ObservedResults`, which allows you 
-  to filter results using the `where` parameter.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,10 +45,8 @@ x.y.z Release notes (yyyy-MM-dd)
   be invoked with `User.delete()`/`[RLMUser deleteWithCompletion:]`.
 * Add `NSCopying` conformance to `RLMDecimal128` and `RLMObjectId`.
 * Add Xcode 13.3 binaries to the release package (and remove 13.0).
-* Conform `@ThreadSafe` and `ThreadSafeReference` to `Sendable`.
-* Add ability to use Swift Query syntax in `@ObservedResults`.
 * Add ability to use Swift Query syntax in `@ObservedResults`, which allows you 
-  to filter results using the where parameter.
+  to filter results using the `where` parameter.
 
 ### Fixed
 

--- a/Realm/Tests/SwiftUITestHost/SwiftUITestHostApp.swift
+++ b/Realm/Tests/SwiftUITestHost/SwiftUITestHostApp.swift
@@ -94,7 +94,11 @@ struct ReminderListResultsView: View {
                 }.accessibilityIdentifier(list.name).accessibilityActivationPoint(CGPoint(x: 0, y: 0))
             }.onDelete(perform: $reminders.remove)
         }.onChange(of: searchFilter) { value in
-            $reminders.filter = value.isEmpty ? nil : NSPredicate(format: "name CONTAINS[c] %@", value)
+            if ProcessInfo.processInfo.environment["query_type"] == "type_safe_query" {
+                $reminders.where = value.isEmpty ? nil : { $0.name.contains(value, options: .caseInsensitive) }
+            } else {
+                $reminders.filter = value.isEmpty ? nil : NSPredicate(format: "name CONTAINS[c] %@", value)
+            }
         }
     }
 }
@@ -127,6 +131,7 @@ struct SearchView: View {
                 TextField("search", text: $searchFilter)
                     .padding(.top, 7)
                     .padding(.bottom, 7)
+                    .accessibility(identifier: "searchField")
             }.background(RoundedRectangle(cornerRadius: 15)
                             .fill(Color.secondarySystemBackground))
             Spacer()

--- a/Realm/Tests/SwiftUITestHostUITests/SwiftUITestHostUITests.swift
+++ b/Realm/Tests/SwiftUITestHostUITests/SwiftUITestHostUITests.swift
@@ -125,6 +125,39 @@ class SwiftUITests: XCTestCase {
         XCTAssertEqual(realm.objects(ReminderList.self).count, 0)
     }
 
+    func testNSPredicateObservedResults() throws {
+        app.launch()
+        try observedResultsQueryTest()
+    }
+
+    func testSwiftQueryObservedResults() throws {
+        app.launchEnvironment["query_type"] = "type_safe_query"
+        app.launch()
+        try observedResultsQueryTest()
+    }
+
+    private func observedResultsQueryTest() throws {
+        let addButton = app.buttons["addList"]
+        (1...20).forEach { _ in
+            addButton.tap()
+        }
+
+        // Name every reminders list for search
+        try realm.write {
+            for (index, obj) in (realm.objects(ReminderList.self)).enumerated() {
+                obj.name = "reminder list \(index)"
+            }
+        }
+
+        let searchBar = app.textFields["searchField"]
+        let table = app.tables.firstMatch
+
+        searchBar.tap()
+
+        searchBar.typeText("reminder list 1")
+        XCTAssertEqual(table.cells.count, 11)
+    }
+
     func testMultipleEnvironmentRealms() {
         app.launchEnvironment["test_type"] = "multi_realm_test"
         app.launch()

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -441,13 +441,11 @@ extension Projection: _ObservedResultsValue { }
                 didSet()
             }
         }
-
         var `where`: ((Query<ResultType>) -> Query<Bool>)? {
             didSet {
                 didSet()
             }
         }
-
         var configuration: Realm.Configuration? {
             didSet {
                 didSet()
@@ -477,13 +475,18 @@ extension Projection: _ObservedResultsValue { }
             storage.filter = newValue
         }
     }
+#if swift(>=5.5)
     /// Stores a type safe query used for filtering the Results. This is mutually exclusive
     /// to the `filter` parameter.
     @State public var `where`: ((Query<ResultType>) -> Query<Bool>)? {
+        // The introduction of this property produces a compiler bug in
+        // Xcode 12.5.1. So Swift Queries are supported on Xcode 13 and above
+        // when used with SwiftUI.
         willSet {
             storage.where = newValue
         }
     }
+#endif
     /// :nodoc:
     @State public var sortDescriptor: SortDescriptor? {
         willSet {
@@ -549,6 +552,7 @@ extension Projection: _ObservedResultsValue { }
         self.filter = filter
         self.sortDescriptor = sortDescriptor
     }
+#if swift(>=5.5)
     /**
      Initialize a `ObservedResults` struct for a given `Object` or `EmbeddedObject` type.
      - parameter type: Observed type
@@ -556,7 +560,7 @@ extension Projection: _ObservedResultsValue { }
      user's sync configuration for the given partition value will be set as the `syncConfiguration`,
      if empty the configuration is set to the `defaultConfiguration`
      - parameter where: Observations will be made only for passing objects.
-     If no type safe query given - all objects will be observed
+     If no type safe query is given - all objects will be observed
      - parameter keyPaths: Only properties contained in the key paths array will be observed.
      If `nil`, notifications will be delivered for any property change on the object.
      String key paths which do not correspond to a valid a property will throw an exception.
@@ -572,6 +576,7 @@ extension Projection: _ObservedResultsValue { }
         self.where = `where`
         self.sortDescriptor = sortDescriptor
     }
+#endif
     /// :nodoc:
     public init(_ type: ResultType.Type,
                 keyPaths: [String]? = nil,

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -424,8 +424,7 @@ extension Projection: _ObservedResultsValue { }
             }
             if let filter = filter {
                 value = value.filter(filter)
-            }
-            if let `where` = `where` {
+            } else if let `where` = `where` {
                 value = value.where(`where`)
             }
             setupHasRun = true

--- a/RealmSwift/Tests/SwiftUITests.swift
+++ b/RealmSwift/Tests/SwiftUITests.swift
@@ -306,7 +306,7 @@ class SwiftUITests: TestCase {
     }
     func testSwiftQuerySyntax() throws {
         let realm = inMemoryRealm(inMemoryIdentifier)
-        try! realm.write {
+        try realm.write {
             realm.add(SwiftUIObject(value: ["str": "apple"]))
             realm.add(SwiftUIObject(value: ["str": "antenna"]))
             realm.add(SwiftUIObject(value: ["str": "baz"]))

--- a/RealmSwift/Tests/SwiftUITests.swift
+++ b/RealmSwift/Tests/SwiftUITests.swift
@@ -304,6 +304,7 @@ class SwiftUITests: TestCase {
         state.projectedValue.remove(object)
         XCTAssertEqual(state.wrappedValue.count, 0)
     }
+    #if swift(>=5.5)
     func testSwiftQuerySyntax() throws {
         let realm = inMemoryRealm(inMemoryIdentifier)
         try realm.write {
@@ -319,6 +320,7 @@ class SwiftUITests: TestCase {
         XCTAssertEqual(filteredResults.wrappedValue.count, 2)
         XCTAssertEqual(filteredResults.wrappedValue[0].str, "antenna")
     }
+    #endif
     // MARK: Object Operations
     func testUnmanagedObjectModification() throws {
         let state = StateRealmObject(wrappedValue: SwiftUIObject())

--- a/RealmSwift/Tests/SwiftUITests.swift
+++ b/RealmSwift/Tests/SwiftUITests.swift
@@ -304,6 +304,21 @@ class SwiftUITests: TestCase {
         state.projectedValue.remove(object)
         XCTAssertEqual(state.wrappedValue.count, 0)
     }
+    func testSwiftQuerySyntax() throws {
+        let realm = inMemoryRealm(inMemoryIdentifier)
+        try! realm.write {
+            realm.add(SwiftUIObject(value: ["str": "apple"]))
+            realm.add(SwiftUIObject(value: ["str": "antenna"]))
+            realm.add(SwiftUIObject(value: ["str": "baz"]))
+        }
+
+        let filteredResults = ObservedResults(SwiftUIObject.self,
+                                              configuration: realm.configuration,
+                                              where: { $0.str.starts(with: "a") },
+                                              sortDescriptor: SortDescriptor.init(keyPath: \SwiftUIObject.str, ascending: true))
+        XCTAssertEqual(filteredResults.wrappedValue.count, 2)
+        XCTAssertEqual(filteredResults.wrappedValue[0].str, "antenna")
+    }
     // MARK: Object Operations
     func testUnmanagedObjectModification() throws {
         let state = StateRealmObject(wrappedValue: SwiftUIObject())

--- a/examples/ios/swift/ListSwiftUI/Views/ContentView.swift
+++ b/examples/ios/swift/ListSwiftUI/Views/ContentView.swift
@@ -201,7 +201,7 @@ struct ReminderListResultsView: View {
         } else {
             list
                 .onChange(of: searchFilter) { value in
-                    $reminders.filter = value.isEmpty ? nil : NSPredicate(format: "name CONTAINS[c] %@", value)
+                    $reminders.where = { $0.name.contains(value, options: .caseInsensitive) }
                 }
         }
     }


### PR DESCRIPTION
This PR adds functionality to `@ObservedResults` that allows you to filter your collection with the Swift Query syntax.