### PR TITLE
Exposed RLMArray  initWithObjectType constructor to create primitive type array using swift language in realm Objective-c Library

### DIFF
--- a/Realm/RLMArray.h
+++ b/Realm/RLMArray.h
@@ -618,6 +618,8 @@ __attribute__((warn_unused_result));
 @interface RLMArray (Swift)
 // for use only in Swift class definitions
 - (instancetype)initWithObjectClassName:(NSString *)objectClassName;
+- (instancetype)initWithObjectType:(RLMPropertyType)type optional:(BOOL)optional;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
I am working on the project that has the combination of both objective-c and Swift. While working with realm-coca, using the swift language in same project , I found that below mentioned constructor is not exposed in RLMArray.h file to create the primitive type Array.
`- (instancetype)initWithObjectType:(RLMPropertyType)type optional:(BOOL)optional;`


Only `- (instancetype)initWithObjectClassName:(NSString *)objectClassName;` is exposed to create the array of RLMObject.

As With the requirement of project ,we require this constructor to be exposed .