### PR TITLE
Don't declare all Objects as conforming to Identifiable

### DIFF
--- a/Realm/ObjectServerTests/SwiftServerObjects.swift
+++ b/Realm/ObjectServerTests/SwiftServerObjects.swift
@@ -19,7 +19,7 @@
 import Foundation
 import RealmSwift
 
-public class SwiftPerson: Object, ObjectKeyIdentifiable {
+public class SwiftPerson: Object {
     @objc public dynamic var _id: ObjectId? = ObjectId.generate()
     @objc public dynamic var firstName: String = ""
     @objc public dynamic var lastName: String = ""
@@ -35,6 +35,9 @@ public class SwiftPerson: Object, ObjectKeyIdentifiable {
         return "_id"
     }
 }
+
+@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+extension SwiftPerson: ObjectKeyIdentifiable {}
 
 public class SwiftTypesSyncObject: Object {
     @objc public dynamic var _id: ObjectId? = ObjectId.generate()
@@ -183,7 +186,7 @@ public class SwiftMissingObject: Object {
     }
 }
 
-@objcMembers public class SwiftHugeSyncObject: Object, ObjectKeyIdentifiable {
+@objcMembers public class SwiftHugeSyncObject: Object {
     dynamic var _id = ObjectId.generate()
     dynamic var data: Data?
 

--- a/Realm/RLMUser.h
+++ b/Realm/RLMUser.h
@@ -229,8 +229,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
-
 /**
  A profile for a given User.
  */
@@ -258,3 +256,5 @@ NS_ASSUME_NONNULL_END
 @property (nonatomic, readonly) NSDictionary *metadata NS_REFINED_FOR_SWIFT;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -382,7 +382,7 @@ private class ObservableStorage<ObservedType>: ObservableObject where ObservedTy
  It's made to specialize the init methods of ObservedResults.
  */
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
-public protocol _ObservedResultsValue: RealmCollectionValue, Identifiable { }
+public protocol _ObservedResultsValue: RealmCollectionValue { }
 
 /// :nodoc:
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
@@ -404,7 +404,7 @@ extension Projection: _ObservedResultsValue { }
 /// Given `@ObservedResults var v` in SwiftUI, `$v` refers to a `BoundCollection`.
 ///
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
-@propertyWrapper public struct ObservedResults<ResultType>: DynamicProperty, BoundCollection where ResultType: _ObservedResultsValue & RealmFetchable & KeypathSortable {
+@propertyWrapper public struct ObservedResults<ResultType>: DynamicProperty, BoundCollection where ResultType: _ObservedResultsValue & RealmFetchable & KeypathSortable & Identifiable {
     private class Storage: ObservableStorage<Results<ResultType>> {
         var setupHasRun = false
         private func didSet() {

--- a/RealmSwift/Tests/CombineTests.swift
+++ b/RealmSwift/Tests/CombineTests.swift
@@ -2725,20 +2725,32 @@ class CombineProjectionPublisherTests: CombinePublisherTestCase {
 
     func testIdentifiable() {
         let realm = realmWithTestPath()
-        let object = try! realm.write {
-            realm.create(SimpleObject.self, value: [1])
-        }
-        let projection = realm.objects(SimpleProjection.self).first!
-        XCTAssertNotEqual(projection.id, object.id)
-        let projection2 = SimpleProjection(projecting: object)
-        XCTAssertNotEqual(projection.id, projection2.id)
-        let altProjection = AltSimpleProjection(projecting: object)
-        XCTAssertNotEqual(projection.id, altProjection.id)
-        let storeId = projection.id
         try! realm.write {
-            projection.int += 1
+            realm.create(SimpleObject.self, value: [1])
+            realm.create(SimpleObject.self, value: [2])
         }
-        XCTAssertEqual(storeId, projection.id)
+        let objects = realm.objects(SimpleObject.self)
+        let projections = realm.objects(SimpleProjection.self)
+
+        XCTAssertEqual(objects[0].id, objects[0].id)
+        XCTAssertEqual(objects[1].id, objects[1].id)
+        XCTAssertNotEqual(objects[0].id, objects[1].id)
+
+        XCTAssertEqual(projections[0].id, projections[0].id)
+        XCTAssertEqual(projections[1].id, projections[1].id)
+        XCTAssertNotEqual(projections[0].id, projections[1].id)
+
+        XCTAssertEqual(objects[0].id, projections[0].id)
+        XCTAssertEqual(objects[1].id, projections[1].id)
+
+        let altProjection = AltSimpleProjection(projecting: objects[0])
+        XCTAssertEqual(altProjection.id, projections[0].id)
+
+        let storedId = altProjection.id
+        try! realm.write {
+            altProjection.int += 1
+        }
+        XCTAssertEqual(storedId, altProjection.id)
     }
 }
 

--- a/RealmSwift/Tests/ProjectionTests.swift
+++ b/RealmSwift/Tests/ProjectionTests.swift
@@ -217,16 +217,16 @@ public final class PersonProjection: Projection<CommonPerson> {
     @Projected(\CommonPerson.friends.projectTo.firstName) var firstFriendsName: ProjectedCollection<String>
 }
 
-public class SimpleObject: Object {
+public class SimpleObject: Object, ObjectKeyIdentifiable {
     @Persisted var int: Int
     @Persisted var bool: Bool
 }
 
-public final class SimpleProjection: Projection<SimpleObject> {
+public final class SimpleProjection: Projection<SimpleObject>, ObjectKeyIdentifiable {
     @Projected(\SimpleObject.int) var int
 }
 
-public final class AltSimpleProjection: Projection<SimpleObject> {
+public final class AltSimpleProjection: Projection<SimpleObject>, ObjectKeyIdentifiable {
     @Projected(\SimpleObject.int) var int
 }
 

--- a/RealmSwift/Tests/SwiftUITests.swift
+++ b/RealmSwift/Tests/SwiftUITests.swift
@@ -36,7 +36,7 @@ class SwiftUIObject: Object, ObjectKeyIdentifiable {
     }
 }
 
-class UIElementsProjection: Projection<SwiftUIObject> {
+class UIElementsProjection: Projection<SwiftUIObject>, ObjectKeyIdentifiable {
     @Projected(\SwiftUIObject.str) var label
     @Projected(\SwiftUIObject.int) var counter
 }


### PR DESCRIPTION
Making Object conform to Identifiable results in an invalid default implementation for it being supplied, which is not overridden by the correct one from ObjectKeyIdentifiable on subclasses.

No changelog entry since we haven't released this yet.