### PR TITLE
Fix for @ObservedResults not refreshing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,6 @@ let people: Results<PersonProjection> = realm.objects(PersonProjection.self)
   `Element` conforms to `Comparable`.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
 * Add missing `Indexable` support for UUID.
   ([Cocoa #7545](https://github.com/realm/realm-swift/issues/7545), since v10.10.0)
 * `where()` allowed constructing some nonsensical queries due to boolean comparisons returning `Query<T>` rather than `Query<Bool>`.
@@ -64,6 +63,7 @@ let people: Results<PersonProjection> = realm.objects(PersonProjection.self)
   query.
 * `Object.init(value:)` did not allow initializing `RLMDictionary<NSString, RLMObject>`/`Map<String, Object?>`
   properties with null values for map entries (since v10.8.0).
+* `@ObservedResults` did not refresh when changes were made to the observed collection. (since v10.6.0)
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/Tests/SwiftUISyncTestHost/ContentView.swift
+++ b/Realm/Tests/SwiftUISyncTestHost/ContentView.swift
@@ -29,6 +29,8 @@ enum LoggingViewState {
 
 struct MainView: View {
     let testType: String = ProcessInfo.processInfo.environment["async_view_type"]!
+    let partitionValue: String? = ProcessInfo.processInfo.environment["partition_value"]
+
     @State var viewState: LoggingViewState = .initial
     @State var user: User?
 
@@ -76,7 +78,7 @@ struct MainView: View {
                         .transition(AnyTransition.move(edge: .leading)).animation(.default)
                 case "async_open_environment_partition":
                     AsyncOpenPartitionView()
-                        .environment(\.partitionValue, user!.id)
+                        .environment(\.partitionValue, partitionValue ?? user!.id)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .background(Color.green)
                         .transition(AnyTransition.move(edge: .leading)).animation(.default)

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -173,7 +173,7 @@ private final class ObservableStoragePublisher<ObjectType>: Publisher where Obje
     public typealias Output = Void
     public typealias Failure = Never
 
-    private var subscribers = [AnySubscriber<Void, Never>]()
+    var subscribers = [AnySubscriber<Void, Never>]()
     private let value: ObjectType
     private let keyPaths: [String]?
     private let unwrappedValue: ObjectBase?
@@ -231,8 +231,10 @@ private class ObservableStorage<ObservedType>: ObservableObject where ObservedTy
     @Published var value: ObservedType {
         willSet {
             if newValue != value {
+                objectWillChange.subscribers.forEach {
+                    $0.receive(subscription: ObservationSubscription(token: newValue._observe(keyPaths, $0)))
+                }
                 objectWillChange.send()
-                self.objectWillChange = ObservableStoragePublisher(newValue, self.keyPaths)
             }
         }
     }


### PR DESCRIPTION
This PR fixes an issue were a SwiftUI View using `@ObservedResults` would not update when either sync or local changes to the collection were performed.