### PR TITLE
Add ability to permanently delete a User from App.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ x.y.z Release notes (yyyy-MM-dd)
   will be opened instead. Note that to use this parameter with a synced Realm configuration
   the seed Realm must be appropriately copied to a destination with 
   `Realm.writeCopy(configuration:)`/`[RLMRealm writeCopyForConfiguration:]` first.
-
+* Add ability to permanently delete a User from a MongoDB Realm app. This can
+  be invoked with `User.delete()`/`[RLMUser deleteWithCompletion:]`.
 
 ### Fixed
 * Add support of arm64 in Carthage build ([#7154](https://github.com/realm/realm-cocoa/issues/7154)

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -177,6 +177,27 @@ static NSString *generateRandomString(int num) {
     [self waitForExpectationsWithTimeout:60.0 handler:nil];
 }
 
+- (void)testDeleteUser {
+    RLMUser *firstUser = [self logInUserForCredentials:[self basicCredentialsWithName:NSStringFromSelector(_cmd)
+                                                                             register:YES]];
+    RLMUser *secondUser = [self logInUserForCredentials:[self basicCredentialsWithName:@"test2@10gen.com"
+                                                                              register:YES]];
+
+    XCTAssert([self.app.currentUser.identifier isEqualToString:secondUser.identifier]);
+
+    XCTestExpectation *deleteUserExpectation = [self expectationWithDescription:@"should delete user"];
+
+    [secondUser deleteWithCompletion:^(NSError *error) {
+        XCTAssert(!error);
+        XCTAssert(self.app.allUsers.count == 1);
+        XCTAssertNil(self.app.currentUser);
+        XCTAssertEqual(secondUser.state, RLMUserStateRemoved);
+        [deleteUserExpectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:60.0 handler:nil];
+}
+
 - (void)testDeviceRegistration {
     RLMPushClient *client = [self.app pushClientWithServiceName:@"gcm"];
     auto expectation = [self expectationWithDescription:@"should register device"];

--- a/Realm/ObjectServerTests/RealmServer.swift
+++ b/Realm/ObjectServerTests/RealmServer.swift
@@ -922,6 +922,16 @@ public class RealmServer: NSObject {
         return appId
     }
 
+    public func retrieveUser(_ appId: String, userId: String, _ completion: @escaping (Result<Any?, Error>) -> Void) {
+        guard let appServerId = try? RealmServer.shared.retrieveAppServerId(appId),
+              let session = session else {
+            completion(.failure(URLError.unknown as! Error))
+            return
+        }
+        let app = session.apps[appServerId]
+        app.users[userId].get(completion)
+    }
+
     // Remove User from MongoDB Realm using the Admin API
     public func removeUserForApp(_ appId: String, userId: String, _ completion: @escaping (Result<Any?, Error>) -> Void) {
         guard let appServerId = try? RealmServer.shared.retrieveAppServerId(appId),

--- a/Realm/RLMUser.h
+++ b/Realm/RLMUser.h
@@ -172,6 +172,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)removeWithCompletion:(RLMUserOptionalErrorBlock)completion;
 
 /**
+ Permanently deletes this user from your MongoDB Realm app.
+
+ The users state will be set to `Removed` and the session will be destroyed.
+ If the delete request fails, the local authentication state will be untouched.
+
+ @param completion A callback invoked on completion
+*/
+- (void)deleteWithCompletion:(RLMUserOptionalErrorBlock)completion;
+
+/**
  Logs out the current user
 
  The users state will be set to `Removed` is they are an anonymous user or `LoggedOut` if they are authenticated by an email / password or third party auth clients

--- a/Realm/RLMUser.mm
+++ b/Realm/RLMUser.mm
@@ -239,6 +239,12 @@ using namespace realm;
     });
 }
 
+- (void)deleteWithCompletion:(RLMUserOptionalErrorBlock)completion {
+    _app._realmApp->delete_user(_user, ^(realm::util::Optional<app::AppError> error) {
+        [self handleResponse:error completion:completion];
+    });
+}
+
 - (void)logOutWithCompletion:(RLMOptionalErrorBlock)completion {
     _app._realmApp->log_out(_user, ^(realm::util::Optional<app::AppError> error) {
         [self handleResponse:error completion:completion];

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -681,6 +681,22 @@ public extension User {
             }
         }
     }
+
+    /// Permanently deletes this user from your MongoDB Realm app.
+    /// The users state will be set to `Removed` and the session will be destroyed.
+    /// If the delete request fails, the local authentication state will be untouched.
+    /// @returns A publisher that eventually return `Result.success` or `Error`.
+    func delete() -> Future<Void, Error> {
+        return Future<Void, Error> { promise in
+            self.delete { error in
+                if let error = error {
+                    promise(.failure(error))
+                } else {
+                    promise(.success(()))
+                }
+            }
+        }
+    }
 }
 
 /// :nodoc:


### PR DESCRIPTION
This PR allows you to permanently delete a User associated with your MongoDB Realm app. This can be invoked from `User.delete()`/`[RLMUser deleteWithCompletion:]`