### PR TITLE
[SPM] Fix invalid exclude of "tools" directory

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -159,7 +159,6 @@ let package = Package(
                 "logo.png",
                 "plugin",
                 "scripts",
-                "tools",
             ],
             sources: [
                 "Realm/RLMAccessor.mm",


### PR DESCRIPTION
#7624 - Fix warning introduced in Xcode 13.1 by removing invalid exclude of non-existent "tools" directory from Realm target in Package.swift.