### PR TITLE
Simplify cocoapods setup

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -107,7 +107,7 @@ Pod::Spec.new do |s|
   s.frameworks              = 'Security'
   s.module_map              = 'Realm/Realm.modulemap'
   s.compiler_flags          = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"#{s.version}\"' -D__ASSERTMACROS__ -DREALM_ENABLE_SYNC"
-  s.prepare_command         = 'sh build.sh cocoapods-setup'
+  s.prepare_command         = 'sh scripts/setup-cocoapods.sh'
   s.source_files            = private_header_files + ['Realm/*.{m,mm}']
   s.private_header_files    = private_header_files
   s.header_mappings_dir     = 'include'
@@ -118,7 +118,7 @@ Pod::Spec.new do |s|
                                 'OTHER_CPLUSPLUSFLAGS[arch=armv7]' => '-isystem "${PODS_ROOT}/Realm/include/core" -fvisibility-inlines-hidden -fno-aligned-new',
                                 'USER_HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/Realm/include" "${PODS_ROOT}/Realm/include/Realm"',
                               }
-  s.preserve_paths          = %w(build.sh include)
+  s.preserve_paths          = %w(include scripts)
 
   s.ios.deployment_target   = '9.0'
   s.osx.deployment_target   = '10.9'

--- a/build.sh
+++ b/build.sh
@@ -15,9 +15,6 @@ set -e
 
 readonly source_root="$(dirname "$0")"
 
-# You can override the version of the core library
-: "${REALM_BASE_URL:="https://static.realm.io/downloads"}" # set it if you need to use a remote repo
-
 : "${REALM_CORE_VERSION:=$(sed -n 's/^REALM_CORE_VERSION=\(.*\)$/\1/p' "${source_root}/dependencies.list")}" # set to "current" to always use the current build
 
 # You can override the xcmode used
@@ -281,93 +278,6 @@ if [ "$#" -eq 0 ] || [ "$#" -gt 3 ]; then
 fi
 
 ######################################
-# Downloading
-######################################
-
-copy_core() {
-    local src="$1"
-    rm -rf core
-    mkdir core
-    ditto "$src" core
-
-    # XCFramework processing only copies the "realm" headers, so put the third-party ones in a known location
-    mkdir -p core/include
-    find "$src" -name external -exec ditto "{}" core/include/external \; -quit
-}
-
-download_common() {
-    local tries_left=3 version url error suffix
-    suffix='-xcframework'
-
-    version=$REALM_CORE_VERSION
-    url="${REALM_BASE_URL}/core/realm-monorepo-xcframework-v${version}.tar.xz"
-
-    # First check if we need to do anything
-    if [ -e core ]; then
-        if [ -e core/version.txt ]; then
-            if [ "$(cat core/version.txt)" == "$version" ]; then
-                echo "Version ${version} already present"
-                exit 0
-            else
-                echo "Switching from version $(cat core/version.txt) to ${version}"
-            fi
-        else
-            if [ "$(find core -name librealm-monorepo.a)" ]; then
-                echo 'Using existing custom core build without checking version'
-                exit 0
-            fi
-        fi
-    fi
-
-    # We may already have this version downloaded and just need to set it as
-    # the active one
-    local versioned_dir="realm-core-${version}${suffix}"
-    if [ -e "$versioned_dir/version.txt" ]; then
-        echo "Setting ${version} as the active version"
-        copy_core "$versioned_dir"
-        exit 0
-    fi
-
-    echo "Downloading dependency: ${version} from ${url}"
-
-    if [ -z "$TMPDIR" ]; then
-        TMPDIR='/tmp'
-    fi
-    local temp_dir=$(dirname "$TMPDIR/waste")/realm-core-tmp
-    mkdir -p "$temp_dir"
-    local tar_path="${temp_dir}/${versioned_dir}.tar.xz"
-    local temp_path="${tar_path}.tmp"
-
-    while [ 0 -lt $tries_left ] && [ ! -f "$tar_path" ]; do
-        if ! error=$(/usr/bin/curl --fail --silent --show-error --location "$url" --output "$temp_path" 2>&1); then
-            tries_left=$((tries_left-1))
-        else
-            mv "$temp_path" "$tar_path"
-        fi
-    done
-
-    if [ ! -f "$tar_path" ]; then
-        printf "Downloading core failed:\n\t%s\n\t%s\n" "$url" "$error"
-        exit 1
-    fi
-
-    (
-        cd "$temp_dir"
-        rm -rf core
-        tar xf "$tar_path" --xz
-        if [ ! -f core/version.txt ]; then
-            printf %s "${version}" > core/version.txt
-        fi
-
-        mv core "${versioned_dir}"
-    )
-
-    rm -rf "${versioned_dir}"
-    mv "${temp_dir}/${versioned_dir}" .
-    copy_core "$versioned_dir"
-}
-
-######################################
 # Variables
 ######################################
 
@@ -406,7 +316,7 @@ case "$COMMAND" in
     # Dependencies
     ######################################
     "download-core")
-        download_common
+        sh scripts/download-core.sh
         exit 0
         ;;
 
@@ -1061,23 +971,6 @@ case "$COMMAND" in
         done
         echo 'Error: Built library does not contain bitcode'
         exit 1
-        ;;
-
-    ######################################
-    # CocoaPods
-    ######################################
-    "cocoapods-setup")
-        if [ ! -f core/version.txt ]; then
-          sh build.sh download-core
-        fi
-
-        rm -rf include
-        mkdir -p include
-        cp -R core/realm-monorepo.xcframework/ios-armv7_arm64/Headers include/core
-
-        mkdir -p include
-        echo '' > Realm/RLMPlatform.h
-        cp Realm/*.h Realm/*.hpp include
         ;;
 
     ######################################

--- a/scripts/download-core.sh
+++ b/scripts/download-core.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+source_root="$(dirname "$0")/.."
+readonly source_root
+
+# override this env variable if you need to download from a private mirror
+: "${REALM_BASE_URL:="https://static.realm.io/downloads"}"
+# set to "current" to always use the current build
+: "${REALM_CORE_VERSION:=$(sed -n 's/^REALM_CORE_VERSION=\(.*\)$/\1/p' "${source_root}/dependencies.list")}"
+
+readonly dst="$source_root/core"
+copy_core() {
+    local src="$1"
+    rm -rf "$dst"
+    mkdir "$dst"
+    ditto "$src" "$dst"
+
+    # XCFramework processing only copies the "realm" headers, so put the third-party ones in a known location
+    mkdir -p "$dst/include"
+    find "$src" -name external -exec ditto "{}" "$dst/include/external" \; -quit
+}
+
+tries_left=3
+readonly version="$REALM_CORE_VERSION"
+readonly url="${REALM_BASE_URL}/core/realm-monorepo-xcframework-v${version}.tar.xz"
+
+# First check if we need to do anything
+if [ -e "$dst" ]; then
+    if [ -e "$dst/version.txt" ]; then
+        if [ "$(cat "$dst/version.txt")" == "$version" ]; then
+            echo "Version ${version} already present"
+            exit 0
+        else
+            echo "Switching from version $(cat "$dst/version.txt") to ${version}"
+        fi
+    else
+        if [ "$(find "$dst" -name librealm-monorepo.a)" ]; then
+            echo 'Using existing custom core build without checking version'
+            exit 0
+        fi
+    fi
+fi
+
+# We may already have this version downloaded and just need to set it as
+# the active one
+readonly versioned_name="realm-core-${version}-xcframework"
+readonly versioned_dir="$source_root/$versioned_name"
+if [ -e "$versioned_dir/version.txt" ]; then
+    echo "Setting ${version} as the active version"
+    copy_core "$versioned_dir"
+    exit 0
+fi
+
+echo "Downloading dependency: ${version} from ${url}"
+
+if [ -z "$TMPDIR" ]; then
+    TMPDIR='/tmp'
+fi
+temp_dir=$(dirname "$TMPDIR/waste")/realm-core-tmp
+readonly temp_dir
+mkdir -p "$temp_dir"
+readonly tar_path="${temp_dir}/${versioned_name}.tar.xz"
+readonly temp_path="${tar_path}.tmp"
+
+while [ 0 -lt $tries_left ] && [ ! -f "$tar_path" ]; do
+    if ! error=$(/usr/bin/curl --fail --silent --show-error --location "$url" --output "$temp_path" 2>&1); then
+        tries_left=$((tries_left-1))
+    else
+        mv "$temp_path" "$tar_path"
+    fi
+done
+
+if [ ! -f "$tar_path" ]; then
+    printf "Downloading core failed:\n\t%s\n\t%s\n" "$url" "$error"
+    exit 1
+fi
+
+(
+    cd "$temp_dir"
+    rm -rf core
+    tar xf "$tar_path" --xz
+    if [ ! -f core/version.txt ]; then
+        printf %s "${version}" > core/version.txt
+    fi
+
+    mv core "${versioned_name}"
+)
+
+rm -rf "${versioned_dir}"
+mv "${temp_dir}/${versioned_name}" "$source_root"
+copy_core "$versioned_dir"

--- a/scripts/setup-cocoapods.sh
+++ b/scripts/setup-cocoapods.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+source_root="$(dirname "$0")/.."
+readonly source_root
+
+if [ ! -f "$source_root/core/version.txt" ]; then
+  sh "$source_root/scripts/download-core.sh"
+fi
+
+rm -rf "$source_root/include"
+mkdir -p "$source_root/include"
+cp -R "$source_root/core/realm-monorepo.xcframework/ios-armv7_arm64/Headers" "$source_root/include/core"
+
+mkdir -p "$source_root/include"
+echo '' > "$source_root/Realm/RLMPlatform.h"
+cp "$source_root/Realm/"*.h "$source_root/Realm/"*.hpp "$source_root/include"


### PR DESCRIPTION
We no longer need the shared setup stuff like detecting the Xcode and Swift version for cocoapods setup, so extract cocoapods setup (and core downloading) from build.sh into its own script.

Fixes #7660.