### PR TITLE
Fix redundant call to filter on `@ObservedResults` from `searchable` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ x.y.z Release notes (yyyy-MM-dd)
   CustomPersistable's PersistedType must now always be a built-in type rather
   than possibly another CustomPersistable type as Swift 5.6 has removed support
   for infinitely-recursive associated types ([#7654](https://github.com/realm/realm-swift/issues/7654)).
+* Fix redundant call to filter on `@ObservedResults` from `searchable` component, since v10.19.0.
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 


### PR DESCRIPTION
Fix redundant call to filter on `@ObservedResults` from `searchable` component.

This pull request also adds both schemas for running SwiftUI and SwiftUISync tests from Realm project, and a fix for been able to run SwiftUI tests, for this I had to delete the following line (`TEST_HOST[sdk=iphone*] = $(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost;`) from the `TestBase.xcconfig` which wasn't allowing to run SwiftUI tests on local and the CI.

edit by @pavel-ship-it : it will fix the issue #7679