### PR TITLE
Work around compiler crashes with Xcode 13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ x.y.z Release notes (yyyy-MM-dd)
     - Write a copy of a synced Realm in use with user A, and open it with user B.
     - Note that migrations may be required when using a local realm configuration to open a realm file that
       was copied from a synchronized realm.
-      
+
   An exception will be thrown if a Realm exists at the destination.
 * Add a `seedFilePath` option to `RLMRealmConfiguration` and `Configuration`. If this
   option is set then instead of creating an empty Realm, the realm at the `seedFilePath` will
@@ -31,6 +31,10 @@ x.y.z Release notes (yyyy-MM-dd)
   }
   ```
   ([Cocoa #7633](https://github.com/realm/realm-swift/issues/7633), since v10.19.0)
+* Work around a compiler crash when building with Swift 5.6 / Xcode 13.3.
+  CustomPersistable's PersistedType must now always be a built-in type rather
+  than possibly another CustomPersistable type as Swift 5.6 has removed support
+  for infinitely-recursive associated types ([#7654](https://github.com/realm/realm-swift/issues/7654)).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 
@@ -39,7 +43,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * APIs are backwards compatible with all previous releases in the 10.x.y series.
 * Carthage release for Swift is built with Xcode 13.2.1.
 * CocoaPods: 1.10 or later.
-* Xcode: 12.4-13.2.1.
+* Xcode: 12.4-13.3 beta 3.
 
 ### Internal
 * Upgraded realm-core from ? to ?

--- a/RealmSwift/Impl/Persistable.swift
+++ b/RealmSwift/Impl/Persistable.swift
@@ -44,7 +44,7 @@ extension NSDate: _HasPersistedType {
 }
 
 // A type which can be stored by the @Persisted property wrapper
-public protocol _Persistable: _RealmSchemaDiscoverable, _HasPersistedType where PersistedType: _Persistable {
+public protocol _Persistable: _RealmSchemaDiscoverable, _HasPersistedType where PersistedType: _Persistable, PersistedType.PersistedType.PersistedType == PersistedType.PersistedType {
     // Read a value of this type from the target object
     static func _rlmGetProperty(_ obj: ObjectBase, _ key: PropertyKey) -> Self
     // Set a value of this type on the target object


### PR DESCRIPTION
Fixes #7654. See https://bugs.swift.org/browse/SR-15792 for why this is needed.