### PR TITLE
Add a TMPDIR fallback for download-core.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ x.y.z Release notes (yyyy-MM-dd)
 * The Swift package set the linker flags on the wrong target, resulting in
   linker errors when SPM decides to build the core library as a dynamic library
   ([#7266](https://github.com/realm/realm-swift/issues/7266)).
+* The download-core task failed if run in an environment without TMPDIR set
+  ([#7688](https://github.com/realm/realm-swift/issues/7688), since v10.23.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/scripts/download-core.sh
+++ b/scripts/download-core.sh
@@ -8,6 +8,8 @@ readonly source_root
 : "${REALM_BASE_URL:="https://static.realm.io/downloads"}"
 # set to "current" to always use the current build
 : "${REALM_CORE_VERSION:=$(sed -n 's/^REALM_CORE_VERSION=\(.*\)$/\1/p' "${source_root}/dependencies.list")}"
+# Provide a fallback value for TMPDIR, relevant for Xcode Bots
+: "${TMPDIR:=$(getconf DARWIN_USER_TEMP_DIR)}"
 
 readonly dst="$source_root/core"
 copy_core() {


### PR DESCRIPTION
I missed this variable when splitting download-core.sh out of build.sh in bf5c04619.

Fixes #7688.