### PR TITLE
Fix searchable component filter overriding the initial filter on `@ObservedResults`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ x.y.z Release notes (yyyy-MM-dd)
   would throw if the Object was frozen and not thawed before hand.
 * Setting a Realm Configuration for @ObservedResults using it's initializer would be overrode by the Realm Configuration stored in
   `.environment(\.realmConfiguration, ...)` if they did not match ([Cocoa #7463](https://github.com/realm/realm-swift/issues/7463), since v10.6.0).
-* Fix searchable component filter overriding the initial filter on `@Observedresults`, (since v10.23.0).
+* Fix searchable component filter overriding the initial filter on `@ObservedResults`, (since v10.23.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ x.y.z Release notes (yyyy-MM-dd)
 ### Fixed
 * Adding a Realm Object to a `ObservedResults` or a collections using `StateRealmObject` that is managed by the same Realm 
   would throw if the Object was frozen and not thawed before hand.
+* Fix searchable component filter overriding the initial filter on `@Observedresults`, (since v10.23.0). 
+* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
+* None.
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/Tests/SwiftUITestHost/SwiftUITestHostApp.swift
+++ b/Realm/Tests/SwiftUITestHost/SwiftUITestHostApp.swift
@@ -279,7 +279,7 @@ struct ObservedResultsKeyPathTestRow: View {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct ObservedResultsSearchableTestView: View {
-    @ObservedResults(ReminderList.self) var reminders
+    @ObservedResults(ReminderList.self, where: { $0.name.starts(with: "reminder") }) var reminders
     @State var searchFilter: String = ""
 
     var body: some View {

--- a/Realm/Tests/SwiftUITestHostUITests/SwiftUITestHostUITests.swift
+++ b/Realm/Tests/SwiftUITestHostUITests/SwiftUITestHostUITests.swift
@@ -255,15 +255,22 @@ class SwiftUITests: XCTestCase {
             }
         }
 
+        (1...5).forEach { _ in
+            addButton.tap()
+        }
+
         func clearSearchBar() {
             let searchBar = app.searchFields.firstMatch
             let deleteString = String(repeating: XCUIKeyboardKey.delete.rawValue, count: (searchBar.value as? String)!.count)
             searchBar.typeText(deleteString)
         }
 
-        let searchBar = app.searchFields.firstMatch
         let table = app.tables.firstMatch
 
+        // Observed Results filter, should filter reminders without name.
+        XCTAssertEqual(table.cells.count, 20)
+
+        let searchBar = app.searchFields.firstMatch
         searchBar.tap()
 
         searchBar.typeText("reminder")

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -436,22 +436,10 @@ extension Projection: _ObservedResultsValue { }
                 value = value.sorted(byKeyPath: sortDescriptor.keyPath, ascending: sortDescriptor.ascending)
             }
 
-            if let searchFilter = searchFilter {
-                if let filter = filter {
-                    let compoundFilter = NSCompoundPredicate(andPredicateWithSubpredicates: [searchFilter, filter])
-                    value = value.filter(compoundFilter)
-                } else if let `where` = `where` {
-                    let compoundFilter = NSCompoundPredicate(andPredicateWithSubpredicates: [searchFilter, `where`])
-                    value = value.filter(compoundFilter)
-                } else {
-                    value = value.filter(searchFilter)
-                }
-            } else {
-                if let filter = filter {
-                    value = value.filter(filter)
-                } else if let `where` = `where` {
-                    value = value.filter(`where`)
-                }
+            let filters = [searchFilter, filter ?? `where`].compactMap { $0 }
+            if !filters.isEmpty {
+                let compoundFilter = NSCompoundPredicate(andPredicateWithSubpredicates: filters)
+                value = value.filter(compoundFilter)
             }
             setupHasRun = true
         }
@@ -503,6 +491,7 @@ extension Projection: _ObservedResultsValue { }
     /// to the `where` parameter.
     @State public var filter: NSPredicate? {
         willSet {
+            storage.where = nil
             storage.filter = newValue
         }
     }
@@ -514,6 +503,7 @@ extension Projection: _ObservedResultsValue { }
         // Xcode 12.5.1. So Swift Queries are supported on Xcode 13 and above
         // when used with SwiftUI.
         willSet {
+            storage.filter = nil
             storage.where = newValue != nil ? newValue!(Query()).predicate : nil
         }
     }

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -504,7 +504,7 @@ extension Projection: _ObservedResultsValue { }
         // when used with SwiftUI.
         willSet {
             storage.filter = nil
-            storage.where = newValue != nil ? newValue!(Query()).predicate : nil
+            storage.where = newValue?(Query()).predicate
         }
     }
 #endif


### PR DESCRIPTION
Fix searchable component filter overriding the initial filter on `@Observedresults`