### PR TITLE
Allow async await to be used in all supported OS's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ x.y.z Release notes (yyyy-MM-dd)
 * Add ability to use Swift Query syntax in `@ObservedResults`, which allows you 
   to filter results using the `where` parameter.
 * Add ability to use `MutableSet` with `StateRealmObject` in SwiftUI.
+* Async/Await extensions are now compatible with iOS 13 and above when building
+  with Xcode 13.3.
 
 ### Fixed
 * Adding a Realm Object to a `ObservedResults` or a collections using `StateRealmObject` that is managed by the same Realm 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ x.y.z Release notes (yyyy-MM-dd)
 * Add ability to use `MutableSet` with `StateRealmObject` in SwiftUI.
 * Async/Await extensions are now compatible with iOS 13 and above when building
   with Xcode 13.3.
+  
+### Breaking Changes
+* Xcode 13.2 is no longer supported when building with Async/Await functions. Use
+  Xcode 13.3 to build with Async/Await functionality.
 
 ### Fixed
 * Adding a Realm Object to a `ObservedResults` or a collections using `StateRealmObject` that is managed by the same Realm 

--- a/Realm/ObjectServerTests/SwiftFlexibleSyncServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftFlexibleSyncServerTests.swift
@@ -942,7 +942,7 @@ class SwiftFlexibleSyncServerTests: SwiftSyncTestCase {
 }
 
 // MARK: - Async Await
-#if swift(>=5.5.2) && canImport(_Concurrency)
+#if swift(>=5.6) && canImport(_Concurrency)
 @available(macOS 12.0.0, *)
 class SwiftAsyncFlexibleSyncTests: SwiftSyncTestCase {
     override class var defaultTestSuite: XCTestSuite {

--- a/Realm/ObjectServerTests/SwiftMongoClientTests.swift
+++ b/Realm/ObjectServerTests/SwiftMongoClientTests.swift
@@ -870,7 +870,7 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
 }
 
 // MARK: - AsyncAwaitMongoClientTests
-#if swift(>=5.5.2) && canImport(_Concurrency)
+#if swift(>=5.6) && canImport(_Concurrency)
 @available(macOS 12.0, *)
 class AsyncAwaitMongoClientTests: SwiftSyncTestCase {
     override class var defaultTestSuite: XCTestSuite {

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -2577,7 +2577,7 @@ class CombineObjectServerTests: SwiftSyncTestCase {
     }
 }
 
-#if swift(>=5.5.2) && canImport(_Concurrency)
+#if swift(>=5.6) && canImport(_Concurrency)
 
 @available(macOS 12.0, *)
 class AsyncAwaitObjectServerTests: SwiftSyncTestCase {

--- a/Realm/ObjectServerTests/SwiftSyncTestCase.swift
+++ b/Realm/ObjectServerTests/SwiftSyncTestCase.swift
@@ -256,7 +256,7 @@ open class SwiftSyncTestCase: RLMSyncTestCase {
     }
 }
 
-#if swift(>=5.5.2) && canImport(_Concurrency)
+#if swift(>=5.6) && canImport(_Concurrency)
 
 @available(macOS 12.0, *)
 extension SwiftSyncTestCase {

--- a/RealmSwift/App.swift
+++ b/RealmSwift/App.swift
@@ -563,8 +563,8 @@ public extension APIKeyAuth {
     }
 }
 
-#if swift(>=5.5.2) && canImport(_Concurrency)
-@available(macOS 12.0, tvOS 15.0, iOS 15.0, watchOS 8.0, *)
+#if swift(>=5.6) && canImport(_Concurrency)
+@available(macOS 10.15, tvOS 13.0, iOS 13.0, watchOS 6.0, *)
 extension EmailPasswordAuth {
     /// Resets the password of an email identity using the
     /// password reset function set up in the application.

--- a/RealmSwift/MongoClient.swift
+++ b/RealmSwift/MongoClient.swift
@@ -703,8 +703,8 @@ extension MongoCollection {
     }
 }
 
-#if swift(>=5.5.2) && canImport(_Concurrency)
-@available(macOS 12.0, tvOS 15.0, iOS 15.0, watchOS 8.0, *)
+#if swift(>=5.6) && canImport(_Concurrency)
+@available(macOS 10.15, tvOS 13.0, iOS 13.0, watchOS 6.0, *)
 extension MongoCollection {
     /// Encodes the provided value to BSON and inserts it. If the value is missing an identifier, one will be
     /// generated for it.

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -1034,8 +1034,8 @@ extension Realm {
 /// The type of a block to run for notification purposes when the data in a Realm is modified.
 public typealias NotificationBlock = (_ notification: Realm.Notification, _ realm: Realm) -> Void
 
-#if swift(>=5.5.2) && canImport(_Concurrency)
-@available(macOS 12.0, tvOS 15.0, iOS 15.0, watchOS 8.0, *)
+#if swift(>=5.6) && canImport(_Concurrency)
+@available(macOS 10.15, tvOS 13.0, iOS 13.0, watchOS 6.0, *)
 extension Realm {
     /// Options for when to download all data from the server before opening
     /// a synchronized Realm.

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -776,8 +776,8 @@ public extension User {
     }
 }
 
-#if swift(>=5.5.2) && canImport(_Concurrency)
-@available(macOS 12.0, tvOS 15.0, iOS 15.0, watchOS 8.0, *)
+#if swift(>=5.6) && canImport(_Concurrency)
+@available(macOS 10.15, tvOS 13.0, iOS 13.0, watchOS 6.0, *)
 public extension User {
     /// Links the currently authenticated user with a new identity, where the identity is defined by the credential
     /// specified as a parameter. This will only be successful if this `User` is the currently authenticated

--- a/RealmSwift/SyncSubscription.swift
+++ b/RealmSwift/SyncSubscription.swift
@@ -425,8 +425,8 @@ extension SyncSubscriptionSet: Sequence {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
-@available(macOS 12.0, tvOS 15.0, iOS 15.0, watchOS 8.0, *)
+#if swift(>=5.6) && canImport(_Concurrency)
+@available(macOS 10.15, tvOS 13.0, iOS 13.0, watchOS 6.0, *)
 extension SyncSubscriptionSet {
     /**
      Asynchronously creates and commit a write transaction and updates the subscription set,

--- a/RealmSwift/ThreadSafeReference.swift
+++ b/RealmSwift/ThreadSafeReference.swift
@@ -216,7 +216,7 @@ extension Realm {
     }
 }
 
-#if swift(>=5.5.2) && canImport(_Concurrency)
+#if swift(>=5.6) && canImport(_Concurrency)
 extension ThreadSafeReference: Sendable {
 }
 extension RLMThreadSafeReference: @unchecked Sendable {


### PR DESCRIPTION
Allows apps targeting iOS 13 to use async await with Realm. Note Xcode 13.3 RC must be used. Fixes https://github.com/realm/realm-swift/issues/7599