### PR TITLE
Flexible Sync V2 QBS (Proposed 2)

### DIFF
--- a/Realm/ObjectServerTests/RLMSyncTestCase.mm
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.mm
@@ -388,7 +388,7 @@ static NSURL *syncDirectoryForChildProcess() {
     NSAssert(session, @"Cannot call with invalid Realm");
     XCTestExpectation *ex = [self expectationWithDescription:@"Wait for download completion"];
     __block NSError *completionError;
-    BOOL queued = [session waitForDownloadCompletionOnQueue:nil callback:^(NSError *error) {
+    BOOL queued = [session waitForDownloadCompletionOnQueue:dispatch_get_global_queue(0, 0) callback:^(NSError *error) {
         completionError = error;
         [ex fulfill];
     }];
@@ -627,7 +627,7 @@ static NSURL *syncDirectoryForChildProcess() {
         }
         else {
             NSError *error;
-            _flexibleSyncAppId = [RealmServer.shared createAppWithQueryableFields:@[@"age", @"breed", @"partition", @"firstName", @"boolCol", @"intCol", @"stringCol", @"dateCol", @"lastName"] error:&error];
+            _flexibleSyncAppId = [RealmServer.shared createAppWithQueryableFields:@[@"age", @"breed", @"partition", @"firstName", @"name", @"species", @"lastName"] error:&error];
             if (error) {
                 NSLog(@"Failed to create app: %@", error);
                 abort();

--- a/Realm/ObjectServerTests/RealmServer.swift
+++ b/Realm/ObjectServerTests/RealmServer.swift
@@ -760,7 +760,7 @@ public class RealmServer: NSObject {
             partitionKeyType = bsonType
         } else {
             syncTypes = schema.objectSchema.filter {
-                let validSyncClasses = ["Dog", "Person", "SwiftPerson", "SwiftTypesSyncObject"]
+                let validSyncClasses = ["Dog", "Person", "SwiftPerson", "SwiftDog", "Bird"]
                 return validSyncClasses.contains($0.className)
             }
             partitionKeyType = nil

--- a/Realm/ObjectServerTests/SwiftFlexibleSyncServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftFlexibleSyncServerTests.swift
@@ -19,7 +19,6 @@
 #if os(macOS)
 import RealmSwift
 import XCTest
-import Combine
 
 #if canImport(RealmTestSupport)
 import RealmSwiftSyncTestSupport
@@ -29,16 +28,21 @@ import SwiftUI
 #endif
 
 class SwiftFlexibleSyncTests: SwiftSyncTestCase {
+    override class var defaultTestSuite: XCTestSuite {
+        // async/await is currently incompatible with thread sanitizer and will
+        // produce many false positives
+        // https://bugs.swift.org/browse/SR-15444
+        if RLMThreadSanitizerEnabled() {
+            return XCTestSuite(name: "\(type(of: self))")
+        }
+        return super.defaultTestSuite
+    }
+
     func testCreateFlexibleSyncApp() throws {
         let appId = try RealmServer.shared.createAppForSyncMode(.flx(["age"]))
         let flexibleApp = app(fromAppId: appId)
         let user = try logInUser(for: basicCredentials(app: flexibleApp), app: flexibleApp)
         XCTAssertNotNil(user)
-    }
-
-    func testFlexibleSyncOpenRealm() throws {
-        let realm = try openFlexibleSyncRealm()
-        XCTAssertNotNil(realm)
     }
 
     func testGetSubscriptionsWhenLocalRealm() throws {
@@ -53,1327 +57,347 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         assertThrows(realm.subscriptions)
     }
 
-    func testFlexibleSyncPath() throws {
+    func testOpenFlexibleSyncPath() throws {
         let user = try logInUser(for: basicCredentials(app: flexibleSyncApp), app: flexibleSyncApp)
-        let config = user.flexibleSyncConfiguration()
-        XCTAssertTrue(config.fileURL!.path.hasSuffix("mongodb-realm/\(flexibleSyncAppId)/\(user.id)/flx_sync_default.realm"))
-    }
-
-    func testGetSubscriptions() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        XCTAssertEqual(subscriptions.count, 0)
-    }
-
-    func testWriteEmptyBlock() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-        }
-
-        XCTAssertEqual(subscriptions.count, 0)
-    }
-
-    func testAddOneSubscriptionWithoutName() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(QuerySubscription<SwiftPerson> {
-                $0.age > 15
-            })
-        }
-
-        XCTAssertEqual(subscriptions.count, 1)
-    }
-
-    func testAddOneSubscriptionWithName() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age") {
-                $0.age > 15
-            })
-        }
-
-        XCTAssertEqual(subscriptions.count, 1)
-    }
-
-    func testAddSubscriptionsInDifferentBlocks() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age") {
-                $0.age > 15
-            })
-        }
-        subscriptions.update {
-            subscriptions.append(QuerySubscription<SwiftTypesSyncObject> {
-                $0.boolCol == true
-            })
-        }
-
-        XCTAssertEqual(subscriptions.count, 2)
-    }
-
-    func testAddSeveralSubscriptionsWithoutName() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(
-                QuerySubscription<SwiftPerson> {
-                    $0.age > 15
-                },
-                QuerySubscription<SwiftPerson> {
-                    $0.age > 20
-                },
-                QuerySubscription<SwiftPerson> {
-                    $0.age > 25
-                })
-        }
-
-        XCTAssertEqual(subscriptions.count, 3)
-    }
-
-    func testAddSeveralSubscriptionsWithName() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(
-                QuerySubscription<SwiftPerson>(name: "person_age_15") {
-                    $0.age > 15
-                },
-                QuerySubscription<SwiftPerson>(name: "person_age_20") {
-                    $0.age > 20
-                },
-                QuerySubscription<SwiftPerson>(name: "person_age_25") {
-                    $0.age > 25
-                })
-        }
-        XCTAssertEqual(subscriptions.count, 3)
-    }
-
-    func testAddMixedSubscriptions() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_15") {
-                $0.age > 15
-            })
-            subscriptions.append(
-                QuerySubscription<SwiftTypesSyncObject> {
-                    $0.boolCol == true
-                },
-                QuerySubscription<SwiftTypesSyncObject>(name: "object_date_now") {
-                    $0.dateCol <= Date()
-                })
-        }
-        XCTAssertEqual(subscriptions.count, 3)
-    }
-
-    func testAddDuplicateSubscriptions() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(
-                QuerySubscription<SwiftPerson> {
-                    $0.age > 15
-                },
-                QuerySubscription<SwiftPerson> {
-                    $0.age > 15
-                })
-        }
-        XCTAssertEqual(subscriptions.count, 1)
-    }
-
-    func testAddDuplicateSubscriptionWithDifferentName() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(
-                QuerySubscription<SwiftPerson>(name: "person_age_1") {
-                    $0.age > 15
-                },
-                QuerySubscription<SwiftPerson>(name: "person_age_2") {
-                    $0.age > 15
-                })
-        }
-        XCTAssertEqual(subscriptions.count, 2)
-    }
-
-    // FIXME: Using `assertThrows` within a Server test will crash on tear down
-    func skip_testSameNamedSubscriptionThrows() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_1") {
-                $0.age > 15
-            })
-            assertThrows(subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_1") {
-                $0.age > 20
-            }))
-        }
-        XCTAssertEqual(subscriptions.count, 1)
-    }
-
-    // FIXME: Using `assertThrows` within a Server test will crash on tear down
-    func skip_testAddSubscriptionOutsideWriteThrows() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        assertThrows(subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_1") {
-            $0.age > 15
-        }))
-    }
-
-    func testFindSubscriptionByName() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(
-                QuerySubscription<SwiftPerson>(name: "person_age_15") {
-                    $0.age > 15
-                },
-                QuerySubscription<SwiftPerson>(name: "person_age_20") {
-                    $0.age > 20
-                })
-        }
-        XCTAssertEqual(subscriptions.count, 2)
-
-        let foundSubscription1 = subscriptions.first(named: "person_age_15")
-        XCTAssertNotNil(foundSubscription1)
-        XCTAssertEqual(foundSubscription1!.name, "person_age_15")
-
-        let foundSubscription2 = subscriptions.first(named: "person_age_20")
-        XCTAssertNotNil(foundSubscription2)
-        XCTAssertEqual(foundSubscription2!.name, "person_age_20")
-    }
-
-    func testFindSubscriptionByQuery() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_firstname_james") {
-                $0.firstName == "James"
-            })
-            subscriptions.append(QuerySubscription<SwiftTypesSyncObject>(name: "object_int_more_than_zero") {
-                $0.intCol > 0
-            })
-        }
-        XCTAssertEqual(subscriptions.count, 2)
-
-        let foundSubscription1 = subscriptions.first(ofType: SwiftPerson.self, where: {
-            $0.firstName == "James"
-        })
-        XCTAssertNotNil(foundSubscription1)
-        XCTAssertEqual(foundSubscription1!.name, "person_firstname_james")
-
-        let foundSubscription2 = subscriptions.first(ofType: SwiftTypesSyncObject.self, where: {
-            $0.intCol > 0
-        })
-        XCTAssertNotNil(foundSubscription2)
-        XCTAssertEqual(foundSubscription2!.name, "object_int_more_than_zero")
-    }
-
-    func testRemoveSubscriptionByName() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_firstname_james") {
-                $0.firstName == "James"
-            })
-            subscriptions.append(
-                QuerySubscription<SwiftTypesSyncObject>(name: "object_int_more_than_zero") {
-                    $0.intCol > 0
-                },
-                QuerySubscription<SwiftTypesSyncObject>(name: "object_string") {
-                    $0.stringCol == "John" || $0.stringCol == "Tom"
-                })
-        }
-        XCTAssertEqual(subscriptions.count, 3)
-
-        subscriptions.update {
-            subscriptions.remove(named: "person_firstname_james")
-        }
-        XCTAssertEqual(subscriptions.count, 2)
-    }
-
-    func testRemoveSubscriptionByQuery() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(
-                QuerySubscription<SwiftPerson> {
-                    $0.firstName == "Alex"
-                },
-                QuerySubscription<SwiftPerson> {
-                    $0.firstName == "Belle"
-                },
-                QuerySubscription<SwiftPerson> {
-                    $0.firstName == "Charles"
-                })
-            subscriptions.append(QuerySubscription<SwiftTypesSyncObject> {
-                $0.intCol > 0
-            })
-        }
-        XCTAssertEqual(subscriptions.count, 4)
-
-        subscriptions.update {
-            subscriptions.remove(ofType: SwiftPerson.self, {
-                $0.firstName == "Alex"
-            })
-            subscriptions.remove(ofType: SwiftPerson.self, {
-                $0.firstName == "Belle"
-            })
-            subscriptions.remove(ofType: SwiftTypesSyncObject.self, {
-                $0.intCol > 0
-            })
-        }
-        XCTAssertEqual(subscriptions.count, 1)
-    }
-
-    func testRemoveSubscription() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_names") {
-                $0.firstName != "Alex" && $0.lastName != "Roy"
-            })
-            subscriptions.append(QuerySubscription<SwiftTypesSyncObject> {
-                $0.intCol > 0
-            })
-        }
-        XCTAssertEqual(subscriptions.count, 2)
-
-        let foundSubscription1 = subscriptions.first(named: "person_names")
-        XCTAssertNotNil(foundSubscription1)
-        subscriptions.update {
-            subscriptions.remove(foundSubscription1!)
-        }
-
-        XCTAssertEqual(subscriptions.count, 1)
-
-        let foundSubscription2 = subscriptions.first(ofType: SwiftTypesSyncObject.self, where: {
-            $0.intCol > 0
-        })
-        XCTAssertNotNil(foundSubscription2)
-        subscriptions.update {
-            subscriptions.remove(foundSubscription2!)
-        }
-
-        XCTAssertEqual(subscriptions.count, 0)
-    }
-
-    func testRemoveSubscriptionsByType() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(
-                QuerySubscription<SwiftPerson> {
-                    $0.firstName == "Alex"
-                },
-                QuerySubscription<SwiftPerson> {
-                    $0.firstName == "Belle"
-                },
-                QuerySubscription<SwiftPerson> {
-                    $0.firstName == "Charles"
-                })
-            subscriptions.append(QuerySubscription<SwiftTypesSyncObject> {
-                $0.intCol > 0
-            })
-        }
-        XCTAssertEqual(subscriptions.count, 4)
-
-        subscriptions.update {
-            subscriptions.removeAll(ofType: SwiftPerson.self)
-        }
-        XCTAssertEqual(subscriptions.count, 1)
-
-        subscriptions.update {
-            subscriptions.removeAll(ofType: SwiftTypesSyncObject.self)
-        }
-        XCTAssertEqual(subscriptions.count, 0)
-    }
-
-    func testRemoveAllSubscriptions() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(
-                QuerySubscription<SwiftPerson> {
-                    $0.firstName == "Alex"
-                },
-                QuerySubscription<SwiftPerson> {
-                    $0.firstName == "Belle"
-                },
-                QuerySubscription<SwiftPerson> {
-                    $0.firstName == "Charles"
-                })
-            subscriptions.append(QuerySubscription<SwiftTypesSyncObject> {
-                $0.intCol > 0
-            })
-        }
-        XCTAssertEqual(subscriptions.count, 4)
-
-        subscriptions.update {
-            subscriptions.removeAll()
-        }
-
-        XCTAssertEqual(subscriptions.count, 0)
-    }
-
-    func testSubscriptionSetIterate() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-
-        let numberOfSubs = 50
-        subscriptions.update {
-            for i in 1...numberOfSubs {
-                subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_\(i)") {
-                    $0.age > i
-                })
-            }
-        }
-
-        XCTAssertEqual(subscriptions.count, numberOfSubs)
-
-        var count = 0
-        for subscription in subscriptions {
-            XCTAssertNotNil(subscription)
-            count += 1
-        }
-
-        XCTAssertEqual(count, numberOfSubs)
-    }
-
-    func testSubscriptionSetFirstAndLast() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-
-        let numberOfSubs = 20
-        subscriptions.update {
-            for i in 1...numberOfSubs {
-                subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_\(i)") {
-                    $0.age > i
-                })
-            }
-        }
-
-        XCTAssertEqual(subscriptions.count, numberOfSubs)
-
-        let firstSubscription = subscriptions.first
-        XCTAssertNotNil(firstSubscription!)
-        XCTAssertEqual(firstSubscription!.name, "person_age_1")
-
-        let lastSubscription = subscriptions.last
-        XCTAssertNotNil(lastSubscription!)
-        XCTAssertEqual(lastSubscription!.name, "person_age_\(numberOfSubs)")
-    }
-
-    func testSubscriptionSetSubscript() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-
-        let numberOfSubs = 20
-        subscriptions.update {
-            for i in 1...numberOfSubs {
-                subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_\(i)") {
-                    $0.age > i
-                })
-            }
-        }
-
-        XCTAssertEqual(subscriptions.count, numberOfSubs)
-
-        let firstSubscription = subscriptions[0]
-        XCTAssertNotNil(firstSubscription!)
-        XCTAssertEqual(firstSubscription!.name, "person_age_1")
-
-        let lastSubscription = subscriptions[numberOfSubs-1]
-        XCTAssertNotNil(lastSubscription!)
-        XCTAssertEqual(lastSubscription!.name, "person_age_\(numberOfSubs)")
-    }
-
-    func testUpdateQueries() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(
-                QuerySubscription<SwiftPerson>(name: "person_age_15") {
-                    $0.age > 15
-                },
-                QuerySubscription<SwiftPerson>(name: "person_age_20") {
-                    $0.age > 20
-                })
-        }
-        XCTAssertEqual(subscriptions.count, 2)
-
-        let foundSubscription1 = subscriptions.first(named: "person_age_15")
-        let foundSubscription2 = subscriptions.first(named: "person_age_20")
-
-        subscriptions.update {
-            foundSubscription1?.updateQuery(toType: SwiftPerson.self, where: { $0.age > 0 })
-            foundSubscription2?.updateQuery(toType: SwiftPerson.self, where: { $0.age > 0 })
-        }
-
-        XCTAssertEqual(subscriptions.count, 2)
-    }
-
-    func testUpdateQueriesWithoutName() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(
-                QuerySubscription<SwiftPerson> {
-                    $0.age > 15
-                },
-                QuerySubscription<SwiftPerson> {
-                    $0.age > 20
-                })
-        }
-        XCTAssertEqual(subscriptions.count, 2)
-
-        let foundSubscription1 = subscriptions.first(ofType: SwiftPerson.self, where: {
-            $0.age > 15
-        })
-        let foundSubscription2 = subscriptions.first(ofType: SwiftPerson.self, where: {
-            $0.age > 20
-        })
-
-        subscriptions.update {
-            foundSubscription1?.updateQuery(toType: SwiftPerson.self, where: { $0.age > 0 })
-            foundSubscription2?.updateQuery(toType: SwiftPerson.self, where: { $0.age > 5 })
-        }
-
-        XCTAssertEqual(subscriptions.count, 2)
-    }
-
-    // FIXME: Using `assertThrows` within a Server test will crash on tear down
-    func skip_testFlexibleSyncAppUpdateQueryWithDifferentObjectTypeWillThrow() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(
-                QuerySubscription<SwiftPerson>(name: "person_age_15") {
-                    $0.age > 15
-                })
-        }
-        XCTAssertEqual(subscriptions.count, 1)
-
-        let foundSubscription1 = subscriptions.first(named: "person_age_15")
-
-        subscriptions.update {
-            assertThrows(foundSubscription1?.updateQuery(toType: SwiftTypesSyncObject.self, where: { $0.intCol > 0 }))
-        }
-    }
-
-
-    func testFlexibleSyncTransactionsWithPredicateFormatAndNSPredicate() throws {
-        let realm = try openFlexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        subscriptions.update {
-            subscriptions.append(
-                QuerySubscription<SwiftPerson>(name: "name_alex", where: "firstName == %@", "Alex"),
-                QuerySubscription<SwiftPerson>(name: "name_charles", where: "firstName == %@", "Charles"),
-                QuerySubscription<SwiftPerson>(where: NSPredicate(format: "firstName == 'Belle'")))
-            subscriptions.append(QuerySubscription<SwiftTypesSyncObject>(where: NSPredicate(format: "intCol > 0")))
-        }
-        XCTAssertEqual(subscriptions.count, 4)
-
-        let foundSubscription1 = subscriptions.first(ofType: SwiftPerson.self, where: "firstName == %@", "Alex")
-        XCTAssertNotNil(foundSubscription1)
-        let foundSubscription2 = subscriptions.first(ofType: SwiftTypesSyncObject.self, where: NSPredicate(format: "intCol > 0"))
-        XCTAssertNotNil(foundSubscription2)
-
-        subscriptions.update {
-            subscriptions.remove(ofType: SwiftPerson.self, where: NSPredicate(format: "firstName == 'Belle'"))
-            subscriptions.remove(ofType: SwiftPerson.self, where: "firstName == %@", "Charles")
-
-            foundSubscription1?.updateQuery(to: NSPredicate(format: "lastName == 'Wightman'"))
-            foundSubscription2?.updateQuery(to: "stringCol == %@", "string")
-        }
-
-        XCTAssertEqual(subscriptions.count, 2)
-    }
-}
-
-// MARK: - Completion Block
-class SwiftFlexibleSyncServerTests: SwiftSyncTestCase {
-    private var cancellables: Set<AnyCancellable> = []
-
-    override class var defaultTestSuite: XCTestSuite {
-        if hasCombine() {
-            return super.defaultTestSuite
-        }
-        return XCTestSuite(name: "\(type(of: self))")
-    }
-
-    override func tearDown() {
-        cancellables.forEach { $0.cancel() }
-        cancellables = []
-        super.tearDown()
-    }
-
-    func testFlexibleSyncAppWithoutQuery() throws {
-        try populateFlexibleSyncData { realm in
-            for i in 1...10 {
-                // Using firstname to query only objects from this test
-                let person = SwiftPerson(firstName: "\(#function)",
-                                         lastName: "lastname_\(i)",
-                                         age: i)
-                realm.add(person)
-            }
-        }
-
-        let realm = try flexibleSyncRealm()
-        XCTAssertNotNil(realm)
-        checkCount(expected: 0, realm, SwiftPerson.self)
-
-        let subscriptions = realm.subscriptions
-        XCTAssertNotNil(subscriptions)
-        XCTAssertEqual(subscriptions.count, 0)
-
-        waitForDownloads(for: realm)
-        checkCount(expected: 0, realm, SwiftPerson.self)
-    }
-
-    func testFlexibleSyncAppAddQuery() throws {
-        try populateFlexibleSyncData { realm in
-            for i in 1...25 {
-                let person = SwiftPerson(firstName: "\(#function)",
-                                         lastName: "lastname_\(i)",
-                                         age: i)
-                realm.add(person)
-            }
-        }
-
-        let realm = try flexibleSyncRealm()
-        XCTAssertNotNil(realm)
-        checkCount(expected: 0, realm, SwiftPerson.self)
-
-        let subscriptions = realm.subscriptions
-        XCTAssertNotNil(subscriptions)
-        XCTAssertEqual(subscriptions.count, 0)
-
-        let ex = expectation(description: "state change complete")
-        subscriptions.update({
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_15") {
-                $0.age > 15 && $0.firstName == "\(#function)"
-            })
-        }, onComplete: { error in
-            if error == nil {
-                ex.fulfill()
-            } else {
-                XCTFail("Subscription Set could not complete with \(error!)")
-            }
-        })
-
-        waitForExpectations(timeout: 20.0, handler: nil)
-
-        waitForDownloads(for: realm)
-        checkCount(expected: 10, realm, SwiftPerson.self)
-    }
-
-    func testFlexibleSyncAppMultipleQuery() throws {
-        try populateFlexibleSyncData { realm in
-            for i in 1...20 {
-                let person = SwiftPerson(firstName: "\(#function)",
-                                         lastName: "lastname_\(i)",
-                                         age: i)
-                realm.add(person)
-            }
-            let swiftTypes = SwiftTypesSyncObject()
-            swiftTypes.stringCol = "\(#function)"
-            realm.add(swiftTypes)
-        }
-
-        let realm = try flexibleSyncRealm()
-        XCTAssertNotNil(realm)
-        checkCount(expected: 0, realm, SwiftPerson.self)
-
-        let subscriptions = realm.subscriptions
-        XCTAssertNotNil(subscriptions)
-        XCTAssertEqual(subscriptions.count, 0)
-
-        let ex = expectation(description: "state change complete")
-        subscriptions.update({
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_10") {
-                $0.age > 10 && $0.firstName == "\(#function)"
-            })
-            subscriptions.append(QuerySubscription<SwiftTypesSyncObject>(name: "swift_object_equal_1") {
-                $0.intCol == 1 && $0.stringCol == "\(#function)"
-            })
-        }, onComplete: { error in
-            if error == nil {
-                ex.fulfill()
-            } else {
-                XCTFail("Subscription Set could not complete with \(error!)")
-            }
-        })
-        waitForExpectations(timeout: 20.0, handler: nil)
-
-        waitForDownloads(for: realm)
-        checkCount(expected: 10, realm, SwiftPerson.self)
-        checkCount(expected: 1, realm, SwiftTypesSyncObject.self)
-    }
-
-    func testFlexibleSyncAppRemoveQuery() throws {
-        try populateFlexibleSyncData { realm in
-            for i in 1...30 {
-                let person = SwiftPerson(firstName: "\(#function)",
-                                         lastName: "lastname_\(i)",
-                                         age: i)
-                realm.add(person)
-            }
-            let swiftTypes = SwiftTypesSyncObject()
-            swiftTypes.stringCol = "\(#function)"
-            realm.add(swiftTypes)
-        }
-
-        let realm = try flexibleSyncRealm()
-        XCTAssertNotNil(realm)
-        checkCount(expected: 0, realm, SwiftPerson.self)
-
-        let subscriptions = realm.subscriptions
-        XCTAssertNotNil(subscriptions)
-        XCTAssertEqual(subscriptions.count, 0)
-
-        let ex = expectation(description: "state change complete")
-        subscriptions.update({
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_5") {
-                $0.age > 5 && $0.firstName == "\(#function)"
-            })
-            subscriptions.append(QuerySubscription<SwiftTypesSyncObject>(name: "swift_object_equal_1") {
-                $0.intCol == 1 && $0.stringCol == "\(#function)"
-            })
-        }, onComplete: { error in
-            if error == nil {
-                ex.fulfill()
-            } else {
-                XCTFail("Subscription Set could not complete with \(error!)")
-            }
-        })
-        waitForExpectations(timeout: 20.0, handler: nil)
-
-        waitForDownloads(for: realm)
-        checkCount(expected: 25, realm, SwiftPerson.self)
-        checkCount(expected: 1, realm, SwiftTypesSyncObject.self)
-
-        let ex2 = expectation(description: "state change complete")
-        subscriptions.update({
-            subscriptions.remove(named: "person_age_5")
-        }, onComplete: { error in
-            if error == nil {
-                ex2.fulfill()
-            } else {
-                XCTFail("Subscription Set could not complete with \(error!)")
-            }
-        })
-        waitForExpectations(timeout: 20.0, handler: nil)
-
-        waitForDownloads(for: realm)
-        checkCount(expected: 0, realm, SwiftPerson.self)
-        checkCount(expected: 1, realm, SwiftTypesSyncObject.self)
-    }
-
-    func testFlexibleSyncAppRemoveAllQueries() throws {
-        try populateFlexibleSyncData { realm in
-            for i in 1...25 {
-                let person = SwiftPerson(firstName: "\(#function)",
-                                         lastName: "lastname_\(i)",
-                                         age: i)
-                realm.add(person)
-            }
-            let swiftTypes = SwiftTypesSyncObject()
-            swiftTypes.stringCol = "\(#function)"
-            realm.add(swiftTypes)
-        }
-
-        let realm = try flexibleSyncRealm()
-        XCTAssertNotNil(realm)
-        checkCount(expected: 0, realm, SwiftPerson.self)
-
-        let subscriptions = realm.subscriptions
-        XCTAssertNotNil(subscriptions)
-        XCTAssertEqual(subscriptions.count, 0)
-
-        let ex = expectation(description: "state change complete")
-        subscriptions.update({
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_5") {
-                $0.age > 5 && $0.firstName == "\(#function)"
-            })
-            subscriptions.append(QuerySubscription<SwiftTypesSyncObject>(name: "swift_object_equal_1") {
-                $0.intCol == 1 && $0.stringCol == "\(#function)"
-            })
-        }, onComplete: { error in
-            if error == nil {
-                ex.fulfill()
-            } else {
-                XCTFail("Subscription Set could not complete with \(error!)")
-            }
-        })
-
-        waitForExpectations(timeout: 20.0, handler: nil)
-
-        waitForDownloads(for: realm)
-        checkCount(expected: 20, realm, SwiftPerson.self)
-        checkCount(expected: 1, realm, SwiftTypesSyncObject.self)
-
-        let ex2 = expectation(description: "state change complete")
-        subscriptions.update({
-            subscriptions.removeAll()
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_20") {
-                $0.age > 20 && $0.firstName == "\(#function)"
-            })
-        }, onComplete: { error in
-            if error == nil {
-                ex2.fulfill()
-            } else {
-                XCTFail("Subscription Set could not complete with \(error!)")
-            }
-        })
-        waitForExpectations(timeout: 20.0, handler: nil)
-
-        waitForDownloads(for: realm)
-        checkCount(expected: 5, realm, SwiftPerson.self)
-        checkCount(expected: 0, realm, SwiftTypesSyncObject.self)
-    }
-
-    func testFlexibleSyncAppRemoveQueriesByType() throws {
-        try populateFlexibleSyncData { realm in
-            for i in 1...21 {
-                let person = SwiftPerson(firstName: "\(#function)",
-                                         lastName: "lastname_\(i)",
-                                         age: i)
-                realm.add(person)
-            }
-            let swiftTypes = SwiftTypesSyncObject()
-            swiftTypes.stringCol = "\(#function)"
-            realm.add(swiftTypes)
-        }
-
-        let realm = try flexibleSyncRealm()
-        XCTAssertNotNil(realm)
-        checkCount(expected: 0, realm, SwiftPerson.self)
-
-        let subscriptions = realm.subscriptions
-        XCTAssertNotNil(subscriptions)
-        XCTAssertEqual(subscriptions.count, 0)
-
-        let ex = expectation(description: "state change complete")
-        subscriptions.update({
-            subscriptions.append(
-                QuerySubscription<SwiftPerson>(name: "person_age_5") {
-                    $0.age > 20 && $0.firstName == "\(#function)"
-                },
-                QuerySubscription<SwiftPerson>(name: "person_age_10") {
-                    $0.lastName == "lastname_1" && $0.firstName == "\(#function)"
-                })
-            subscriptions.append(QuerySubscription<SwiftTypesSyncObject>(name: "swift_object_equal_1") {
-                $0.intCol == 1 && $0.stringCol == "\(#function)"
-            })
-        }, onComplete: { error in
-            if error == nil {
-                ex.fulfill()
-            } else {
-                XCTFail("Subscription Set could not complete with \(error!)")
-            }
-        })
-        waitForExpectations(timeout: 20.0, handler: nil)
-
-        waitForDownloads(for: realm)
-        checkCount(expected: 2, realm, SwiftPerson.self)
-        checkCount(expected: 1, realm, SwiftTypesSyncObject.self)
-
-        let ex2 = expectation(description: "state change complete")
-        subscriptions.update({
-            subscriptions.removeAll(ofType: SwiftPerson.self)
-        }, onComplete: { error in
-            if error == nil {
-                ex2.fulfill()
-            } else {
-                XCTFail("Subscription Set could not complete with \(error!)")
-            }
-        })
-        waitForExpectations(timeout: 20.0, handler: nil)
-
-        waitForDownloads(for: realm)
-        checkCount(expected: 0, realm, SwiftPerson.self)
-        checkCount(expected: 1, realm, SwiftTypesSyncObject.self)
-    }
-
-    func testFlexibleSyncAppUpdateQuery() throws {
-        try populateFlexibleSyncData { realm in
-            for i in 1...25 {
-                let person = SwiftPerson(firstName: "\(#function)",
-                                         lastName: "lastname_\(i)",
-                                         age: i)
-                realm.add(person)
-            }
-        }
-
-        let realm = try flexibleSyncRealm()
-        XCTAssertNotNil(realm)
-        checkCount(expected: 0, realm, SwiftPerson.self)
-
-        let subscriptions = realm.subscriptions
-        XCTAssertNotNil(subscriptions)
-        XCTAssertEqual(subscriptions.count, 0)
-
-        let ex = expectation(description: "state change complete")
-        subscriptions.update({
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age") {
-                $0.age > 20 && $0.firstName == "\(#function)"
-            })
-        }, onComplete: { error in
-            if error == nil {
-                ex.fulfill()
-            } else {
-                XCTFail("Subscription Set could not complete with \(error!)")
-            }
-        })
-        waitForExpectations(timeout: 20.0, handler: nil)
-
-        waitForDownloads(for: realm)
-        checkCount(expected: 5, realm, SwiftPerson.self)
-
-        let foundSubscription = subscriptions.first(named: "person_age")
-        XCTAssertNotNil(foundSubscription)
-
-        let ex2 = expectation(description: "state change complete")
-        subscriptions.update({
-            foundSubscription?.updateQuery(toType: SwiftPerson.self, where: {
-                $0.age > 5 && $0.firstName == "\(#function)"
-            })
-        }, onComplete: { error in
-            if error == nil {
-                ex2.fulfill()
-            } else {
-                XCTFail("Subscription Set could not complete with \(error!)")
-            }
-        })
-        waitForExpectations(timeout: 20.0, handler: nil)
-
-        waitForDownloads(for: realm)
-        checkCount(expected: 20, realm, SwiftPerson.self)
-    }
-
-    func testFlexibleSyncInitialSubscriptions() throws {
-        try populateFlexibleSyncData { realm in
-            for i in 1...20 {
-                let person = SwiftPerson(firstName: "\(#function)",
-                                         lastName: "lastname_\(i)",
-                                         age: i)
-                realm.add(person)
-            }
-        }
-
-        let user = try logInUser(for: basicCredentials(app: self.flexibleSyncApp), app: self.flexibleSyncApp)
-        var config = user.flexibleSyncConfiguration(initialSubscriptions: { subscriptions in
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_10") {
-                $0.age > 10 && $0.firstName == "\(#function)"
-            })
-        })
-        if config.objectTypes == nil {
-            config.objectTypes = [SwiftPerson.self,
-                                  SwiftTypesSyncObject.self]
-        }
-        let realm = try Realm(configuration: config)
-        let subscriptions = realm.subscriptions
-        XCTAssertNotNil(subscriptions)
-        XCTAssertEqual(subscriptions.count, 1)
-
-        checkCount(expected: 0, realm, SwiftPerson.self)
-
-        let start = Date()
-        while subscriptions.state != .complete && start.timeIntervalSinceNow > -5.0 {
-            sleep(1) // wait until state is on complete state
-        }
-        XCTAssertEqual(subscriptions.state, .complete)
-
-        waitForDownloads(for: realm)
-        checkCount(expected: 10, realm, SwiftPerson.self)
+        var configuration = user.flexibleSyncConfiguration()
+        configuration.objectTypes = [SwiftPerson.self, SwiftDog.self, Bird.self]
+        let realm = try Realm(configuration: configuration)
+        XCTAssertTrue(realm.configuration.fileURL!.path.hasSuffix("mongodb-realm/\(flexibleSyncAppId)/\(user.id)/flx_sync_default.realm"))
     }
 }
 
 // MARK: - Async Await
+
 #if swift(>=5.6) && canImport(_Concurrency)
 @available(macOS 12.0, *)
-class SwiftAsyncFlexibleSyncTests: SwiftSyncTestCase {
-    override class var defaultTestSuite: XCTestSuite {
-        // async/await is currently incompatible with thread sanitizer and will
-        // produce many false positives
-        // https://bugs.swift.org/browse/SR-15444
-        if RLMThreadSanitizerEnabled() {
-            return XCTestSuite(name: "\(type(of: self))")
-        }
-        return super.defaultTestSuite
-    }
-}
-
-@available(macOS 12.0, *)
-extension SwiftFlexibleSyncServerTests {
-    func flexibleSyncConfig() async throws -> Realm.Configuration {
-        var config = (try await self.flexibleSyncApp.login(credentials: basicCredentials(app: flexibleSyncApp))).flexibleSyncConfiguration()
-        if config.objectTypes == nil {
-            config.objectTypes = [SwiftPerson.self,
-                                  SwiftTypesSyncObject.self]
-        }
-        return config
-    }
-
-    func flexibleSyncRealm() async throws -> Realm {
-        let realm = try await Realm(configuration: flexibleSyncConfig())
-        return realm
-    }
-
+extension SwiftFlexibleSyncTests {
     @MainActor
-    private func populateFlexibleSyncData(_ block: @escaping (Realm) -> Void) async throws {
-        let realm = try await flexibleSyncRealm()
-        let subscriptions = realm.subscriptions
-        try await subscriptions.update {
-            subscriptions.append(QuerySubscription<SwiftPerson>())
-            subscriptions.append(QuerySubscription<SwiftTypesSyncObject>())
-        }
+    private func populateFlexibleSyncDataForType<T: RealmFetchable>(_ type: T.Type, app: RealmSwift.App? = nil, block: @escaping (Realm) -> Void) async throws {
+        let app = app ?? flexibleSyncApp
+        let user = try await app.login(credentials: basicCredentials(usernameSuffix: "", app: app))
+        var configuration = user.flexibleSyncConfiguration()
+        configuration.objectTypes = [SwiftPerson.self, SwiftDog.self, Bird.self]
+        let realm = try await Realm(configuration: configuration)
 
+        _ = try await realm.objects(type)
         try realm.write {
             block(realm)
         }
+        waitForUploads(for: realm)
     }
 
     @MainActor
-    func testFlexibleSyncAppAddQueryAsyncAwait() async throws {
-        try await populateFlexibleSyncData { realm in
-            for i in 1...25 {
-                let person = SwiftPerson(firstName: "\(#function)",
-                                         lastName: "lastname_\(i)",
-                                         age: i)
+    func testFlexibleSyncResults() async throws {
+        try await populateFlexibleSyncDataForType(SwiftPerson.self) { realm in
+            for i in 1...21 {
+                let person = SwiftPerson(firstName: "\(#function)", lastName: "lastname_\(i)", age: i)
                 realm.add(person)
             }
         }
 
-        let realm = try await flexibleSyncRealm()
-        XCTAssertNotNil(realm)
-        checkCount(expected: 0, realm, SwiftPerson.self)
+        let user = try await self.flexibleSyncApp.login(credentials: basicCredentials(usernameSuffix: "", app: flexibleSyncApp))
+        var configuration = user.flexibleSyncConfiguration()
+        configuration.objectTypes = [SwiftPerson.self, SwiftDog.self, Bird.self]
+        let realm = try await Realm(configuration: configuration)
+        let persons = try await realm.objects(SwiftPerson.self, where: { $0.age > 18 && $0.firstName == "\(#function)" })
+        XCTAssertEqual(realm.subscriptions.count, 1)
+        waitForDownloads(for: realm)
+        XCTAssertEqual(persons.count, 3)
 
-        let subscriptions = realm.subscriptions
-        XCTAssertNotNil(subscriptions)
-        XCTAssertEqual(subscriptions.count, 0)
+        // This will trigger a client reset, which will result in the server not responding to any instruction, this is not removing the object from the database.
+//        let newPerson = SwiftPerson()
+//        newPerson.age = 10
+//        try realm.write {
+//            realm.add(newPerson)
+//        }
+//        XCTAssertEqual(persons.count, 3)
 
-        try await subscriptions.update {
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_15") {
-                $0.age > 15 && $0.firstName == "\(#function)"
-            })
+        let newPerson = SwiftPerson(firstName: "\(#function)", lastName: "lastname_\(19)", age: 19)
+        try realm.write {
+            realm.add(newPerson)
         }
+        XCTAssertEqual(persons.count, 4)
 
-        checkCount(expected: 10, realm, SwiftPerson.self)
+        try await persons.unsubscribe()
+        XCTAssertEqual(realm.subscriptions.count, 0)
+        waitForDownloads(for: realm)
+        waitForUploads(for: realm)
+        XCTAssertEqual(persons.count, 0)
     }
 
     @MainActor
-    func testStates() async throws {
-        let realm = try await flexibleSyncRealm()
-        XCTAssertNotNil(realm)
-
-        let subscriptions = realm.subscriptions
-        XCTAssertEqual(subscriptions.count, 0)
-
-        // should complete
-        try await subscriptions.update {
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_15") {
-                $0.age > 15 && $0.firstName == "\(#function)"
-            })
-        }
-        XCTAssertEqual(subscriptions.state, .complete)
-        // should error
-        do {
-            try await subscriptions.update {
-                subscriptions.append(QuerySubscription<SwiftTypesSyncObject>(name: "swiftObject_longCol") {
-                    $0.longCol == Int64(1)
-                })
-            }
-            XCTFail("Invalid query should have failed")
-        } catch let error {
-            if let error = error as NSError? {
-                XCTAssertTrue(error.domain == RLMFlexibleSyncErrorDomain)
-                XCTAssertTrue(error.code == 2)
-            }
-
-            guard case .error = subscriptions.state else {
-                return XCTFail("Adding a query for a not queryable field should change the subscription set state to error")
+    func testFlexibleSyncResultsForAllCollection() async throws {
+        try await populateFlexibleSyncDataForType(SwiftPerson.self) { realm in
+            realm.deleteAll() // Remove all objects from that type
+            for i in 1...9 {
+                let person = SwiftPerson(firstName: "\(#function)", lastName: "lastname_\(i)", age: i)
+                realm.add(person)
             }
         }
+        try await populateFlexibleSyncDataForType(SwiftDog.self) { realm in
+            realm.deleteAll() // Remove all objects from that type
+            for _ in 1...8 {
+                let dog = SwiftDog(name: "\(#function)", breed: ["bulldog", "poodle", "boxer", "beagle"].randomElement()!)
+                realm.add(dog)
+            }
+        }
+
+        let user = try await self.flexibleSyncApp.login(credentials: basicCredentials(usernameSuffix: "", app: self.flexibleSyncApp))
+        var configuration = user.flexibleSyncConfiguration()
+        configuration.objectTypes = [SwiftPerson.self, SwiftDog.self, Bird.self]
+        let realm = try await Realm(configuration: configuration)
+
+        let persons = try await realm.objects(SwiftPerson.self)
+        let dogs = try await realm.objects(SwiftDog.self)
+        waitForDownloads(for: realm)
+        XCTAssertEqual(persons.count, 9)
+        XCTAssertEqual(dogs.count, 8)
+        XCTAssertEqual(realm.subscriptions.count, 2)
+
+        try await persons.unsubscribe()
+        try await dogs.unsubscribe()
     }
 
     @MainActor
-    func testFlexibleSyncAllDocumentsForType() async throws {
-        try await populateFlexibleSyncData { realm in
-            realm.deleteAll() // Remove all objects for a clean state
-            for i in 1...28 {
-                let person = SwiftPerson(firstName: "\(#function)",
-                                         lastName: "lastname_\(i)",
-                                         age: i)
+    func testFlexibleSyncResultsWithDuplicateQuery() async throws {
+        try await populateFlexibleSyncDataForType(SwiftPerson.self) { realm in
+            for i in 1...21 {
+                let person = SwiftPerson(firstName: "\(#function)", lastName: "lastname_\(i)", age: i)
                 realm.add(person)
             }
         }
 
-        let realm = try await flexibleSyncRealm()
-        XCTAssertNotNil(realm)
-        checkCount(expected: 0, realm, SwiftPerson.self)
+        let user = try await self.flexibleSyncApp.login(credentials: basicCredentials(usernameSuffix: "", app: flexibleSyncApp))
+        var configuration = user.flexibleSyncConfiguration()
+        configuration.objectTypes = [SwiftPerson.self, SwiftDog.self, Bird.self]
+        let realm = try await Realm(configuration: configuration)
 
-        let subscriptions = realm.subscriptions
-        XCTAssertNotNil(subscriptions)
-        XCTAssertEqual(subscriptions.count, 0)
+        let persons = try await realm.objects(SwiftPerson.self, where: { $0.age > 18 && $0.firstName == "\(#function)" })
 
-        try await subscriptions.update {
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_all"))
+        waitForDownloads(for: realm)
+        XCTAssertEqual(persons.count, 3)
+        let persons2 = try await realm.objects(SwiftPerson.self, where: { $0.age > 18 && $0.firstName == "\(#function)" })
+        waitForDownloads(for: realm)
+        XCTAssertEqual(persons2.count, 3)
+
+        // The results are pointing to the same subscription, which means the data on both will be the same
+        XCTAssertEqual(realm.subscriptions.count, 1)
+        XCTAssertEqual(persons.count, persons2.count)
+
+        let newPerson = SwiftPerson(firstName: "\(#function)", lastName: "", age: 19)
+        try realm.write {
+            realm.add(newPerson)
         }
-        XCTAssertEqual(subscriptions.state, .complete)
-        XCTAssertEqual(subscriptions.count, 1)
-        checkCount(expected: 28, realm, SwiftPerson.self)
+        XCTAssertEqual(persons.count, 4)
+        XCTAssertEqual(persons2.count, 4)
+        XCTAssertEqual(persons.count, persons2.count)
+        XCTAssertEqual(realm.subscriptions.count, 1)
+
+        try await persons.unsubscribe()
+        XCTAssertEqual(realm.subscriptions.count, 0)
+
+        waitForDownloads(for: realm)
+        XCTAssertEqual(persons.count, 0)
+        XCTAssertEqual(persons2.count, 0)
+
     }
 
     @MainActor
-    func testFlexibleSyncNotInitialSubscriptions() async throws {
-        let config = try await flexibleSyncConfig()
-        let realm = try await Realm(configuration: config, downloadBeforeOpen: .always)
-        XCTAssertNotNil(realm)
+    func testFlexibleSyncWithSameType() async throws {
+        try await populateFlexibleSyncDataForType(SwiftPerson.self) { realm in
+            for i in 1...21 {
+                let person = SwiftPerson(firstName: "\(#function)", lastName: "lastname_\(i)", age: i)
+                realm.add(person)
+            }
+        }
 
+        let user = try await self.flexibleSyncApp.login(credentials: basicCredentials(usernameSuffix: "", app: flexibleSyncApp))
+        var configuration = user.flexibleSyncConfiguration()
+        configuration.objectTypes = [SwiftPerson.self, SwiftDog.self, Bird.self]
+        let realm = try await Realm(configuration: configuration)
+
+        let personsAge15 = try await realm.objects(SwiftPerson.self, where: { $0.age > 15 && $0.firstName == "\(#function)" })
+        let personsAge10 = try await realm.objects(SwiftPerson.self, where: { $0.age > 10 && $0.firstName == "\(#function)" })
+        let personsAge5 = try await realm.objects(SwiftPerson.self, where: { $0.age > 5 && $0.firstName == "\(#function)" })
+        let personsAge0 = try await realm.objects(SwiftPerson.self, where: { $0.age > 0 && $0.firstName == "\(#function)" })
+        waitForDownloads(for: realm)
+        XCTAssertEqual(personsAge0.count, 21)
+        XCTAssertEqual(personsAge5.count, 16)
+        XCTAssertEqual(personsAge10.count, 11)
+        XCTAssertEqual(personsAge15.count, 6)
+        XCTAssertEqual(realm.subscriptions.count, 4)
+    }
+
+    @MainActor
+    func testFlexibleSyncSearchSubscription() async throws {
+        try await populateFlexibleSyncDataForType(SwiftPerson.self) { realm in
+            for i in 1...21 {
+                let person = SwiftPerson(firstName: "\(#function)", lastName: "lastname_\(i)", age: i)
+                realm.add(person)
+            }
+        }
+        try await populateFlexibleSyncDataForType(SwiftDog.self) { realm in
+            for _ in 1...15 {
+                let dog = SwiftDog(name: "\(#function)", breed: ["bulldog", "poodle", "boxer", "beagle"].randomElement()!)
+                realm.add(dog)
+            }
+        }
+        try await populateFlexibleSyncDataForType(Bird.self) { realm in
+            for _ in 1...10 {
+                let bird = Bird(name: "\(#function)", species: [.magpie, .owl, .penguin, .duck].randomElement()!)
+                realm.add(bird)
+            }
+        }
+
+        let user = try await self.flexibleSyncApp.login(credentials: basicCredentials(usernameSuffix: "", app: flexibleSyncApp))
+        var configuration = user.flexibleSyncConfiguration()
+        configuration.objectTypes = [SwiftPerson.self, SwiftDog.self, Bird.self]
+        let realm = try await Realm(configuration: configuration)
+
+        let persons = try await realm.objects(SwiftPerson.self, where: { $0.age > 12 && $0.firstName == "\(#function)" })
+        let dogs = try await realm.objects(SwiftDog.self, where: { $0.breed != "labradoodle" && $0.name == "\(#function)" })
+        let birds = try await realm.objects(Bird.self, where: { $0.species.in(BirdSpecies.allCases) && $0.name == "\(#function)" })
+        waitForDownloads(for: realm)
+        XCTAssertEqual(persons.count, 9)
+        XCTAssertEqual(dogs.count, 15)
+        XCTAssertEqual(birds.count, 10)
+        XCTAssertEqual(realm.subscriptions.count, 3)
+
+        try await realm.subscriptions.unsubscribeAll()
+        XCTAssertEqual(persons.count, 0)
+        XCTAssertEqual(dogs.count, 0)
+        XCTAssertEqual(birds.count, 0)
         XCTAssertEqual(realm.subscriptions.count, 0)
     }
 
     @MainActor
-    func testFlexibleSyncInitialSubscriptionsAsync() async throws {
-        try await populateFlexibleSyncData { realm in
-            for i in 1...20 {
-                let person = SwiftPerson(firstName: "\(#function)",
-                                         lastName: "lastname_\(i)",
-                                         age: i)
+    func testFlexibleSyncUnsubscribeByType() async throws {
+        try await populateFlexibleSyncDataForType(SwiftPerson.self) { realm in
+            for i in 1...21 {
+                let person = SwiftPerson(firstName: "\(#function)", lastName: "lastname_\(i)", age: i)
+                realm.add(person)
+            }
+        }
+        try await populateFlexibleSyncDataForType(SwiftDog.self) { realm in
+            for _ in 1...15 {
+                let dog = SwiftDog(name: "\(#function)", breed: ["bulldog", "poodle", "boxer", "beagle"].randomElement()!)
+                realm.add(dog)
+            }
+        }
+        try await populateFlexibleSyncDataForType(Bird.self) { realm in
+            for _ in 1...10 {
+                let bird = Bird(name: "\(#function)", species: [.magpie, .owl, .penguin, .duck].randomElement()!)
+                realm.add(bird)
+            }
+        }
+
+        let user = try await self.flexibleSyncApp.login(credentials: basicCredentials(usernameSuffix: "", app: flexibleSyncApp))
+        var configuration = user.flexibleSyncConfiguration()
+        configuration.objectTypes = [SwiftPerson.self, SwiftDog.self, Bird.self]
+        let realm = try await Realm(configuration: configuration)
+
+        let personsAge15 = try await realm.objects(SwiftPerson.self, where: { $0.age > 15 && $0.firstName == "\(#function)" })
+        let personsAge10 = try await realm.objects(SwiftPerson.self, where: { $0.age > 10 && $0.firstName == "\(#function)" })
+        let personsAge5 = try await realm.objects(SwiftPerson.self, where: { $0.age > 5 && $0.firstName == "\(#function)" })
+        let personsAge0 = try await realm.objects(SwiftPerson.self, where: { $0.age > 0 && $0.firstName == "\(#function)" })
+        let dogs = try await realm.objects(SwiftDog.self, where: { $0.breed != "labradoodle" && $0.name == "\(#function)" })
+        let birds = try await realm.objects(Bird.self, where: { $0.species.in(BirdSpecies.allCases) && $0.name == "\(#function)" })
+        XCTAssertEqual(personsAge0.count, 21)
+        XCTAssertEqual(personsAge5.count, 16)
+        XCTAssertEqual(personsAge10.count, 11)
+        XCTAssertEqual(personsAge15.count, 6)
+        XCTAssertEqual(dogs.count, 15)
+        XCTAssertEqual(birds.count, 10)
+        XCTAssertEqual(realm.subscriptions.count, 6)
+
+        try await realm.subscriptions.unsubscribeAll(ofType: SwiftPerson.self)
+        waitForDownloads(for: realm)
+        XCTAssertEqual(personsAge0.count, 0)
+        XCTAssertEqual(personsAge5.count, 0)
+        XCTAssertEqual(personsAge10.count, 0)
+        XCTAssertEqual(personsAge15.count, 0)
+        XCTAssertEqual(dogs.count, 15)
+        XCTAssertEqual(birds.count, 10)
+        XCTAssertEqual(realm.subscriptions.count, 2)
+    }
+
+    @MainActor
+    func testFlexibleSyncWithDifferentTypes() async throws {
+        try await populateFlexibleSyncDataForType(SwiftPerson.self) { realm in
+            for i in 1...21 {
+                let person = SwiftPerson(firstName: "\(#function)", lastName: "lastname_\(i)", age: i)
+                realm.add(person)
+            }
+        }
+        try await populateFlexibleSyncDataForType(SwiftDog.self) { realm in
+            for _ in 1...15 {
+                let dog = SwiftDog(name: "\(#function)", breed: ["bulldog", "poodle", "boxer", "beagle"].randomElement()!)
+                realm.add(dog)
+            }
+        }
+        try await populateFlexibleSyncDataForType(Bird.self) { realm in
+            for _ in 1...10 {
+                let bird = Bird(name: "\(#function)", species: [.magpie, .owl, .penguin, .duck].randomElement()!)
+                realm.add(bird)
+            }
+        }
+
+        let user = try await self.flexibleSyncApp.login(credentials: basicCredentials(usernameSuffix: "", app: flexibleSyncApp))
+        var configuration = user.flexibleSyncConfiguration()
+        configuration.objectTypes = [SwiftPerson.self, SwiftDog.self, Bird.self]
+        let realm = try await Realm(configuration: configuration)
+
+        let persons = try await realm.objects(SwiftPerson.self, where: { $0.age > 12 && $0.firstName == "\(#function)" })
+        let dogs = try await realm.objects(SwiftDog.self, where: { $0.breed != "labradoodle" && $0.name == "\(#function)" })
+        let birds = try await realm.objects(Bird.self, where: { $0.species.in(BirdSpecies.allCases) && $0.name == "\(#function)" })
+        waitForDownloads(for: realm)
+        XCTAssertEqual(persons.count, 9)
+        XCTAssertEqual(dogs.count, 15)
+        XCTAssertEqual(birds.count, 10)
+        XCTAssertEqual(realm.subscriptions.count, 3)
+    }
+
+    @MainActor
+    func testFlexibleSyncUpdateFilter() async throws {
+        try await populateFlexibleSyncDataForType(SwiftPerson.self) { realm in
+            for i in 1...21 {
+                let person = SwiftPerson(firstName: "\(#function)", lastName: "lastname_\(i)", age: i)
                 realm.add(person)
             }
         }
 
-        let user = try await logInUser(for: basicCredentials(app: self.flexibleSyncApp), app: self.flexibleSyncApp)
-        var config = user.flexibleSyncConfiguration(initialSubscriptions: { subscriptions in
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_10") {
-                $0.age > 10 && $0.firstName == "\(#function)"
-            })
-        })
+        let user = try await self.flexibleSyncApp.login(credentials: basicCredentials(usernameSuffix: "", app: flexibleSyncApp))
+        var configuration = user.flexibleSyncConfiguration()
+        configuration.objectTypes = [SwiftPerson.self, SwiftDog.self, Bird.self]
+        let realm = try await Realm(configuration: configuration)
 
-        if config.objectTypes == nil {
-            config.objectTypes = [SwiftPerson.self]
-        }
-        let realm = try await Realm(configuration: config, downloadBeforeOpen: .once)
-        XCTAssertNotNil(realm)
-
-        XCTAssertEqual(realm.subscriptions.count, 1)
-        checkCount(expected: 10, realm, SwiftPerson.self)
-    }
-
-    @MainActor
-    func testFlexibleSyncInitialSubscriptionsNotRerunOnOpen() async throws {
-        let user = try await logInUser(for: basicCredentials(app: self.flexibleSyncApp), app: self.flexibleSyncApp)
-        var config = user.flexibleSyncConfiguration(initialSubscriptions: { subscriptions in
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_10") {
-                $0.age > 10 && $0.firstName == "\(#function)"
-            })
-        })
-
-        if config.objectTypes == nil {
-            config.objectTypes = [SwiftPerson.self]
-        }
-        let realm = try await Realm(configuration: config, downloadBeforeOpen: .once)
-        XCTAssertNotNil(realm)
+        let personsAge15 = try await realm.objects(SwiftPerson.self, where: { $0.age > 0 && $0.firstName == "\(#function)" })
+        waitForDownloads(for: realm)
+        XCTAssertEqual(personsAge15.count, 21)
         XCTAssertEqual(realm.subscriptions.count, 1)
 
-        let realm2 = try await Realm(configuration: config, downloadBeforeOpen: .once)
-        XCTAssertNotNil(realm2)
+        let personsAge10 = try await personsAge15.where { $0.age > 10 && $0.firstName == "\(#function)" }
+        waitForDownloads(for: realm)
+        XCTAssertEqual(personsAge10.count, 11)
         XCTAssertEqual(realm.subscriptions.count, 1)
     }
 
     @MainActor
-    func testFlexibleSyncInitialSubscriptionsRerunOnOpenNamedQuery() async throws {
-        let user = try await logInUser(for: basicCredentials(app: self.flexibleSyncApp), app: self.flexibleSyncApp)
-        var config = user.flexibleSyncConfiguration(initialSubscriptions: { subscriptions in
-            if subscriptions.first(named: "person_age_10") == nil {
-                subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_10") {
-                    $0.age > 20 && $0.firstName == "\(#function)"
-                })
-            }
-        }, rerunOnOpen: true)
+    func testFlexibleSyncQueryThrowsError() async throws {
+        let user = try await self.flexibleSyncApp.login(credentials: basicCredentials(usernameSuffix: "", app: flexibleSyncApp))
+        var configuration = user.flexibleSyncConfiguration()
+        configuration.objectTypes = [SwiftPerson.self, SwiftDog.self, Bird.self]
+        let realm = try await Realm(configuration: configuration)
 
-        if config.objectTypes == nil {
-            config.objectTypes = [SwiftPerson.self]
-        }
-        let realm = try await Realm(configuration: config, downloadBeforeOpen: .once)
-        XCTAssertNotNil(realm)
-        XCTAssertEqual(realm.subscriptions.count, 1)
-
-        let realm2 = try await Realm(configuration: config, downloadBeforeOpen: .once)
-        XCTAssertNotNil(realm2)
-        XCTAssertEqual(realm.subscriptions.count, 1)
-    }
-
-    @MainActor
-    func testFlexibleSyncInitialSubscriptionsRerunOnOpenUnnamedQuery() async throws {
-        try await populateFlexibleSyncData { realm in
-            for i in 1...30 {
-                let object = SwiftTypesSyncObject()
-                object.dateCol = Calendar.current.date(
-                    byAdding: .hour,
-                    value: -i,
-                    to: Date())!
-                realm.add(object)
-            }
-        }
-        let user = try await logInUser(for: basicCredentials(app: self.flexibleSyncApp), app: self.flexibleSyncApp)
-        var isFirstOpen = true
-        var config = user.flexibleSyncConfiguration(initialSubscriptions: { subscriptions in
-            subscriptions.append(QuerySubscription<SwiftTypesSyncObject>(query: {
-                let date = isFirstOpen ? Calendar.current.date(
-                    byAdding: .hour,
-                    value: -10,
-                    to: Date()) : Calendar.current.date(
-                        byAdding: .hour,
-                        value: -20,
-                        to: Date())
-                isFirstOpen = false
-                return $0.dateCol < Date() && $0.dateCol > date!
-            }))
-        }, rerunOnOpen: true)
-
-        if config.objectTypes == nil {
-            config.objectTypes = [SwiftTypesSyncObject.self, SwiftPerson.self]
-        }
-        let c = config
-        _ = try await Task { @MainActor in
-            let realm = try await Realm(configuration: c, downloadBeforeOpen: .always)
-            XCTAssertNotNil(realm)
-            XCTAssertEqual(realm.subscriptions.count, 1)
-            checkCount(expected: 9, realm, SwiftTypesSyncObject.self)
-        }.value
-
-        _ = try await Task { @MainActor in
-            let realm = try await Realm(configuration: c, downloadBeforeOpen: .always)
-            XCTAssertNotNil(realm)
-            XCTAssertEqual(realm.subscriptions.count, 2)
-            checkCount(expected: 19, realm, SwiftTypesSyncObject.self)
-        }.value
-    }
-
-    @MainActor
-    func testFlexibleSyncInitialSubscriptionsThrows() async throws {
-        let user = try await logInUser(for: basicCredentials(app: self.flexibleSyncApp), app: self.flexibleSyncApp)
-        var config = user.flexibleSyncConfiguration(initialSubscriptions: { subscriptions in
-            if subscriptions.first(named: "query_uuid") == nil {
-                subscriptions.append(QuerySubscription<SwiftTypesSyncObject>(query: {
-                    $0.uuidCol == UUID()
-                }))
-            }
-        })
-
-        if config.objectTypes == nil {
-            config.objectTypes = [SwiftTypesSyncObject.self, SwiftPerson.self]
-        }
+        // This throws because the property is not included as a queryable field
         do {
-           _ = try await Realm(configuration: config, downloadBeforeOpen: .once)
+            let _: Results<SwiftDog> = try await realm.objects(SwiftDog.self, where: { $0.gender == .female })
+            XCTFail("Querying on a property which is not included as a queryable field should fail")
         } catch {
             XCTAssertNotNil(error)
-            let nsError = error as NSError
-            XCTAssertEqual(nsError.code, 2)
-            XCTAssertEqual(nsError.domain, "io.realm.sync.flx")
         }
-    }
-
-    @MainActor
-    func testFlexibleSyncInitialSubscriptionsDefaultConfiguration() async throws {
-        let user = try await logInUser(for: basicCredentials(app: self.flexibleSyncApp), app: self.flexibleSyncApp)
-        var config = user.flexibleSyncConfiguration(initialSubscriptions: { subscriptions in
-            subscriptions.append(QuerySubscription<SwiftTypesSyncObject>())
-        })
-
-        if config.objectTypes == nil {
-            config.objectTypes = [SwiftTypesSyncObject.self, SwiftPerson.self]
-        }
-        Realm.Configuration.defaultConfiguration = config
-
-        let realm = try await Realm(downloadBeforeOpen: .once)
-        XCTAssertEqual(realm.subscriptions.count, 1)
     }
 }
+
 #endif // canImport(_Concurrency)
-
-// MARK: - Combine
-#if !(os(iOS) && (arch(i386) || arch(arm)))
-@available(macOS 10.15, *)
-extension SwiftFlexibleSyncServerTests {
-    func testFlexibleSyncCombineWrite() throws {
-        try populateFlexibleSyncData { realm in
-            for i in 1...25 {
-                let person = SwiftPerson(firstName: "\(#function)",
-                                         lastName: "lastname_\(i)",
-                                         age: i)
-                realm.add(person)
-            }
-        }
-
-        let realm = try flexibleSyncRealm()
-        XCTAssertNotNil(realm)
-        checkCount(expected: 0, realm, SwiftPerson.self)
-
-        let subscriptions = realm.subscriptions
-        XCTAssertNotNil(subscriptions)
-        XCTAssertEqual(subscriptions.count, 0)
-
-        let ex = expectation(description: "state change complete")
-        subscriptions.updateSubscriptions {
-            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_10") {
-                $0.age > 10 && $0.firstName == "\(#function)"
-            })
-        }
-        .sink(receiveCompletion: { _ in },
-              receiveValue: { _ in
-            ex.fulfill()
-        }).store(in: &cancellables)
-
-        waitForExpectations(timeout: 20.0, handler: nil)
-
-        waitForDownloads(for: realm)
-        checkCount(expected: 15, realm, SwiftPerson.self)
-    }
-
-    func testFlexibleSyncCombineWriteFails() throws {
-        let realm = try flexibleSyncRealm()
-        XCTAssertNotNil(realm)
-        checkCount(expected: 0, realm, SwiftPerson.self)
-
-        let subscriptions = realm.subscriptions
-        XCTAssertNotNil(subscriptions)
-        XCTAssertEqual(subscriptions.count, 0)
-
-        let ex = expectation(description: "state change error")
-        subscriptions.updateSubscriptions {
-            subscriptions.append(QuerySubscription<SwiftTypesSyncObject>(name: "swiftObject_longCol") {
-                $0.longCol == Int64(1)
-            })
-        }
-        .sink(receiveCompletion: { result in
-            if case .failure(let error) = result {
-                if let error = error as NSError? {
-                    XCTAssertTrue(error.domain == RLMFlexibleSyncErrorDomain)
-                    XCTAssertTrue(error.code == 2)
-                }
-
-                guard case .error = subscriptions.state else {
-                    return XCTFail("Adding a query for a not queryable field should change the subscription set state to error")
-                }
-                ex.fulfill()
-            }
-        }, receiveValue: { _ in })
-        .store(in: &cancellables)
-
-        waitForExpectations(timeout: 20.0, handler: nil)
-
-        waitForDownloads(for: realm)
-        checkCount(expected: 0, realm, SwiftPerson.self)
-    }
-}
-#endif // canImport(Combine)
 #endif // os(macOS)

--- a/Realm/ObjectServerTests/SwiftFlexibleSyncServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftFlexibleSyncServerTests.swift
@@ -105,12 +105,12 @@ extension SwiftFlexibleSyncTests {
         XCTAssertEqual(persons.count, 3)
 
         // This will trigger a client reset, which will result in the server not responding to any instruction, this is not removing the object from the database.
-//        let newPerson = SwiftPerson()
-//        newPerson.age = 10
-//        try realm.write {
-//            realm.add(newPerson)
-//        }
-//        XCTAssertEqual(persons.count, 3)
+        //        let newPerson = SwiftPerson()
+        //        newPerson.age = 10
+        //        try realm.write {
+        //            realm.add(newPerson)
+        //        }
+        //        XCTAssertEqual(persons.count, 3)
 
         let newPerson = SwiftPerson(firstName: "\(#function)", lastName: "lastname_\(19)", age: 19)
         try realm.write {
@@ -396,6 +396,146 @@ extension SwiftFlexibleSyncTests {
         } catch {
             XCTAssertNotNil(error)
         }
+    }
+
+    @MainActor
+    func testFlexibleSyncInitialSubscriptionsAsync() async throws {
+        try await populateFlexibleSyncDataForType(SwiftPerson.self) { realm in
+            for i in 1...20 {
+                let person = SwiftPerson(firstName: "\(#function)", lastName: "lastname_\(i)", age: i)
+                realm.add(person)
+            }
+        }
+
+        let user = try await logInUser(for: basicCredentials(app: self.flexibleSyncApp), app: self.flexibleSyncApp)
+        var config = user.flexibleSyncConfiguration(initialSubscriptions: { subscriptions in
+            subscriptions.append(ofType: SwiftPerson.self,
+                                 where: { $0.age > 10 && $0.firstName == "\(#function)" })
+        })
+
+        if config.objectTypes == nil {
+            config.objectTypes = [SwiftPerson.self]
+        }
+        let realm = try await Realm(configuration: config, downloadBeforeOpen: .once)
+        XCTAssertNotNil(realm)
+
+        XCTAssertEqual(realm.subscriptions.count, 1)
+        // Adding this sleep, because there seems to be a timing issue after this commit in baas
+        // https://github.com/10gen/baas/commit/64e75b3f1fe8a6f8704d1597de60f9dda401ccce,
+        // data take a little longer to be downloaded to the realm even though the
+        // sync client changed the subscription state to completed.
+        sleep(1)
+        checkCount(expected: 10, realm, SwiftPerson.self)
+    }
+
+    @MainActor
+    func testFlexibleSyncInitialSubscriptionsNotRerunOnOpen() async throws {
+        let user = try await logInUser(for: basicCredentials(app: self.flexibleSyncApp), app: self.flexibleSyncApp)
+        var config = user.flexibleSyncConfiguration(initialSubscriptions: { subscriptions in
+            subscriptions.append(ofType: SwiftPerson.self,
+                                 where: { $0.age > 10 && $0.firstName == "\(#function)" })
+        })
+
+        if config.objectTypes == nil {
+            config.objectTypes = [SwiftPerson.self]
+        }
+        let realm = try await Realm(configuration: config, downloadBeforeOpen: .once)
+        XCTAssertNotNil(realm)
+        XCTAssertEqual(realm.subscriptions.count, 1)
+
+        let realm2 = try await Realm(configuration: config, downloadBeforeOpen: .once)
+        XCTAssertNotNil(realm2)
+        XCTAssertEqual(realm.subscriptions.count, 1)
+    }
+
+    @MainActor
+    func testFlexibleSyncInitialSubscriptionsRerunOnOpen() async throws {
+        try await populateFlexibleSyncDataForType(SwiftTypesSyncObject.self) { realm in
+            for i in 1...30 {
+                let object = SwiftTypesSyncObject()
+                object.dateCol = Calendar.current.date(
+                    byAdding: .hour,
+                    value: -i,
+                    to: Date())!
+                realm.add(object)
+            }
+        }
+
+        let user = try await logInUser(for: basicCredentials(app: self.flexibleSyncApp), app: self.flexibleSyncApp)
+        var isFirstOpen = true
+        var config = user.flexibleSyncConfiguration(initialSubscriptions: { subscriptions in
+            subscriptions.append(ofType: SwiftTypesSyncObject.self,
+                                 where: {
+                let date = isFirstOpen ? Calendar.current.date(
+                    byAdding: .hour,
+                    value: -10,
+                    to: Date()) : Calendar.current.date(
+                        byAdding: .hour,
+                        value: -20,
+                        to: Date())
+                isFirstOpen = false
+                return $0.dateCol < Date() && $0.dateCol > date! })
+        }, rerunOnOpen: true)
+
+        if config.objectTypes == nil {
+            config.objectTypes = [SwiftTypesSyncObject.self, SwiftPerson.self]
+        }
+        let c = config
+        _ = try await Task { @MainActor in
+            let realm = try await Realm(configuration: c, downloadBeforeOpen: .always)
+            XCTAssertNotNil(realm)
+            XCTAssertEqual(realm.subscriptions.count, 1)
+            // Adding this sleep, because there seems to be a timing issue after this commit in baas
+            // https://github.com/10gen/baas/commit/64e75b3f1fe8a6f8704d1597de60f9dda401ccce,
+            // data take a little longer to be downloaded to the realm even though the
+            // sync client changed the subscription state to completed.
+            sleep(1)
+            checkCount(expected: 9, realm, SwiftTypesSyncObject.self)
+        }.value
+
+        _ = try await Task { @MainActor in
+            let realm = try await Realm(configuration: c, downloadBeforeOpen: .always)
+            XCTAssertNotNil(realm)
+            XCTAssertEqual(realm.subscriptions.count, 2)
+            checkCount(expected: 19, realm, SwiftTypesSyncObject.self)
+        }.value
+    }
+
+    @MainActor
+    func testFlexibleSyncInitialSubscriptionsThrows() async throws {
+        let user = try await logInUser(for: basicCredentials(app: self.flexibleSyncApp), app: self.flexibleSyncApp)
+        var config = user.flexibleSyncConfiguration(initialSubscriptions: { subscriptions in
+            subscriptions.append(ofType: SwiftTypesSyncObject.self,
+                                 where: { $0.uuidCol == UUID() })
+        })
+
+        if config.objectTypes == nil {
+            config.objectTypes = [SwiftTypesSyncObject.self, SwiftPerson.self]
+        }
+        do {
+            _ = try await Realm(configuration: config, downloadBeforeOpen: .once)
+        } catch {
+            XCTAssertNotNil(error)
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.code, 2)
+            XCTAssertEqual(nsError.domain, "io.realm.sync.flx")
+        }
+    }
+
+    @MainActor
+    func testFlexibleSyncInitialSubscriptionsDefaultConfiguration() async throws {
+        let user = try await logInUser(for: basicCredentials(app: self.flexibleSyncApp), app: self.flexibleSyncApp)
+        var config = user.flexibleSyncConfiguration(initialSubscriptions: { subscriptions in
+            subscriptions.append(ofType: SwiftTypesSyncObject.self)
+        })
+
+        if config.objectTypes == nil {
+            config.objectTypes = [SwiftTypesSyncObject.self, SwiftPerson.self]
+        }
+        Realm.Configuration.defaultConfiguration = config
+
+        let realm = try await Realm(downloadBeforeOpen: .once)
+        XCTAssertEqual(realm.subscriptions.count, 1)
     }
 }
 

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -2786,7 +2786,6 @@ class CombineObjectServerTests: SwiftSyncTestCase {
 }
 
 #if swift(>=5.6) && canImport(_Concurrency)
-
 @available(macOS 12.0, *)
 class AsyncAwaitObjectServerTests: SwiftSyncTestCase {
     override class var defaultTestSuite: XCTestSuite {
@@ -2807,7 +2806,8 @@ class AsyncAwaitObjectServerTests: SwiftSyncTestCase {
             }
         }
         let realm = try await Realm()
-        XCTAssertEqual(realm.objects(SwiftPerson.self).count, 10)
+        let results = try await realm.objects(SwiftPerson.self)
+        XCTAssertEqual(results.count, 10)
     }
 
     @MainActor func testAsyncOpenSync() async throws {
@@ -2822,7 +2822,8 @@ class AsyncAwaitObjectServerTests: SwiftSyncTestCase {
         let user2 = try await app.login(credentials: .anonymous)
         let realm2 = try await Realm(configuration: user2.configuration(testName: #function),
                                     downloadBeforeOpen: .once)
-        XCTAssertEqual(realm2.objects(SwiftHugeSyncObject.self).count, 2)
+        let results = try await realm2.objects(SwiftHugeSyncObject.self)
+        XCTAssertEqual(results.count, 2)
     }
 
     @MainActor func testAsyncOpenDownloadBehaviorNever() async throws {
@@ -2839,7 +2840,8 @@ class AsyncAwaitObjectServerTests: SwiftSyncTestCase {
         let user2 = try await app.login(credentials: .anonymous)
         let realm2 = try await Realm(configuration: user2.configuration(testName: #function),
                                     downloadBeforeOpen: .never)
-        XCTAssertEqual(realm2.objects(SwiftHugeSyncObject.self).count, 0)
+        let results = try await realm2.objects(SwiftHugeSyncObject.self)
+        XCTAssertEqual(results.count, 0)
     }
 
     @MainActor func testAsyncOpenDownloadBehaviorOnce() async throws {
@@ -2856,7 +2858,9 @@ class AsyncAwaitObjectServerTests: SwiftSyncTestCase {
         let user2 = try await app.login(credentials: .anonymous)
         let realm2 = try await Realm(configuration: user2.configuration(testName: #function),
                                      downloadBeforeOpen: .once)
-        XCTAssertEqual(realm2.objects(SwiftHugeSyncObject.self).count, 2)
+
+        let results = try await realm2.objects(SwiftHugeSyncObject.self)
+        XCTAssertEqual(results.count, 2)
         realm2.syncSession?.suspend()
 
         // Add some more objects
@@ -2869,7 +2873,8 @@ class AsyncAwaitObjectServerTests: SwiftSyncTestCase {
         // Will not wait for the new objects to download
         let realm3 = try await Realm(configuration: user2.configuration(testName: #function),
                                      downloadBeforeOpen: .once)
-        XCTAssertEqual(realm3.objects(SwiftHugeSyncObject.self).count, 2)
+        let results3 = try await realm3.objects(SwiftHugeSyncObject.self)
+        XCTAssertEqual(results3.count, 2)
     }
 
 
@@ -2887,7 +2892,9 @@ class AsyncAwaitObjectServerTests: SwiftSyncTestCase {
         let user2 = try await app.login(credentials: .anonymous)
         let realm2 = try await Realm(configuration: user2.configuration(testName: #function),
                                      downloadBeforeOpen: .always)
-        XCTAssertEqual(realm2.objects(SwiftHugeSyncObject.self).count, 2)
+
+        let results = try await realm2.objects(SwiftHugeSyncObject.self)
+        XCTAssertEqual(results.count, 2)
         realm2.syncSession?.suspend()
 
         // Add some more objects
@@ -2900,7 +2907,8 @@ class AsyncAwaitObjectServerTests: SwiftSyncTestCase {
         // Should wait for the new objects to download
         let realm3 = try await Realm(configuration: user2.configuration(testName: #function),
                                      downloadBeforeOpen: .always)
-        XCTAssertEqual(realm3.objects(SwiftHugeSyncObject.self).count, 4)
+        let results3 = try await realm3.objects(SwiftHugeSyncObject.self)
+        XCTAssertEqual(results3.count, 4)
     }
 
     func testCallResetPasswordAsyncAwait() async throws {

--- a/Realm/ObjectServerTests/SwiftServerObjects.swift
+++ b/Realm/ObjectServerTests/SwiftServerObjects.swift
@@ -43,6 +43,43 @@ public class LinkToSwiftPerson: Object {
 @available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
 extension SwiftPerson: ObjectKeyIdentifiable {}
 
+public class SwiftDog: Object {
+    public enum Gender: Int, PersistableEnum {
+        case male
+        case female
+        case unknown
+    }
+    @Persisted(primaryKey: true) public var _id: ObjectId = ObjectId.generate()
+    @Persisted public var name: String
+    @Persisted public var breed: String
+    @Persisted public var gender: Gender
+
+    public convenience init(name: String, breed: String, gender: Gender? = .unknown) {
+        self.init()
+        self.name = name
+        self.breed = breed
+    }
+}
+
+public enum BirdSpecies: Int, PersistableEnum {
+    case magpie
+    case owl
+    case penguin
+    case duck
+}
+
+public class Bird: Object {
+    @Persisted(primaryKey: true) public var _id: ObjectId = ObjectId.generate()
+    @Persisted public var name: String
+    @Persisted public var species: BirdSpecies
+
+    public convenience init(name: String, species: BirdSpecies) {
+        self.init()
+        self.name = name
+        self.species = species
+    }
+}
+
 public class SwiftTypesSyncObject: Object {
     @Persisted(primaryKey: true) public var _id: ObjectId
     @Persisted public var boolCol: Bool = true

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -393,8 +393,4 @@ static bool isSync(realm::Realm::Config const& config) {
     return config;
 }
 
-- (bool)isFlexibleSyncConfiguration {
-    return [self config].sync_config->flx_sync_requested;
-}
-
 @end

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -393,4 +393,8 @@ static bool isSync(realm::Realm::Config const& config) {
     return config;
 }
 
+- (bool)isFlexibleSyncConfiguration {
+    return [self config].sync_config->flx_sync_requested;
+}
+
 @end

--- a/Realm/RLMRealmConfiguration_Private.h
+++ b/Realm/RLMRealmConfiguration_Private.h
@@ -34,8 +34,9 @@ NS_ASSUME_NONNULL_BEGIN
 // Flexible Sync
 @property (nonatomic, readwrite, nullable) RLMFlexibleSyncInitialSubscriptionsBlock initialSubscriptions;
 @property (nonatomic, readwrite) BOOL rerunOnOpen;
+@property (nonatomic, readonly) bool isFlexibleSyncConfiguration;
 
-// Get the default configuration without copying it
+// Get the default confiugration without copying it
 + (RLMRealmConfiguration *)rawDefaultConfiguration;
 
 + (void)resetRealmConfigurationState;

--- a/Realm/RLMSyncSubscription.h
+++ b/Realm/RLMSyncSubscription.h
@@ -335,6 +335,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (id)objectAtIndexedSubscript:(NSUInteger)index;
 
+- (void)waitForCompletion:(void(^)(NSError * _Nullable))block;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Realm/RLMSyncSubscription.h
+++ b/Realm/RLMSyncSubscription.h
@@ -335,8 +335,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (id)objectAtIndexedSubscript:(NSUInteger)index;
 
-- (void)waitForCompletion:(void(^)(NSError * _Nullable))block;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Realm/RLMSyncSubscription.mm
+++ b/Realm/RLMSyncSubscription.mm
@@ -521,4 +521,16 @@ NSUInteger RLMFastEnumerate(NSFastEnumerationState *state,
     }
 }
 
+- (void)waitForCompletion:(void(^)(NSError * _Nullable))block {
+    _subscriptionSet->get_state_change_notification(realm::sync::SubscriptionSet::State::Complete)
+        .get_async([block](realm::StatusWith<realm::sync::SubscriptionSet::State> state) mutable noexcept {
+        if (state.is_ok()) {
+            block(nil);
+        } else {
+            NSError* error = [[NSError alloc] initWithDomain:RLMFlexibleSyncErrorDomain code:state.get_status().code() userInfo:@{@"reason": @(state.get_status().reason().c_str())}];
+            block(error);
+        }
+    });
+}
+
 @end

--- a/Realm/RLMSyncSubscription.mm
+++ b/Realm/RLMSyncSubscription.mm
@@ -233,6 +233,12 @@ NSUInteger RLMFastEnumerate(NSFastEnumerationState *state,
 }
 
 - (void)update:(__attribute__((noescape)) void(^)(void))block onComplete:(void(^)(NSError *))completionBlock {
+    return [self update:block queue:nil onComplete:completionBlock];
+}
+
+- (void)update:(__attribute__((noescape)) void(^)(void))block
+        queue:(nullable dispatch_queue_t)queue
+   onComplete:(void(^)(NSError *))completionBlock {
     if (_mutableSubscriptionSet != nil) {
         @throw RLMException(@"Cannot initiate a write transaction on subscription set that is already been updated.");
     }
@@ -272,6 +278,19 @@ NSUInteger RLMFastEnumerate(NSFastEnumerationState *state,
             }
         });
 }
+
+- (void)waitForCompletion:(void(^)(NSError * _Nullable))block {
+     _subscriptionSet->get_state_change_notification(realm::sync::SubscriptionSet::State::Complete)
+         .get_async([block](realm::StatusWith<realm::sync::SubscriptionSet::State> state) mutable noexcept {
+         if (state.is_ok()) {
+             block(nil);
+         } else {
+             NSError* error = [[NSError alloc] initWithDomain:RLMFlexibleSyncErrorDomain code:state.get_status().code() userInfo:@{@"reason": @(state.get_status().reason().c_str())}];
+             block(error);
+         }
+     });
+ }
+
 
 #pragma mark - Find subscription
 
@@ -352,7 +371,7 @@ NSUInteger RLMFastEnumerate(NSFastEnumerationState *state,
     [self addSubscriptionWithClassName:objectClassName
                       subscriptionName:name
                              predicate:[NSPredicate predicateWithFormat:predicateFormat arguments:args]];
-    
+
 }
 
 - (void)addSubscriptionWithClassName:(NSString *)objectClassName
@@ -376,10 +395,10 @@ NSUInteger RLMFastEnumerate(NSFastEnumerationState *state,
                            predicate:(NSPredicate *)predicate
                       updateExisting:(BOOL)updateExisting {
     [self verifyInWriteTransaction];
-    
+
     RLMClassInfo& info = _realm->_info[objectClassName];
     auto query = RLMPredicateToQuery(predicate, info.rlmObjectSchema, _realm.schema, _realm.group);
-    
+
     if (name) {
         if (updateExisting || _mutableSubscriptionSet->find(name.UTF8String) == _mutableSubscriptionSet->end()) {
             _mutableSubscriptionSet->insert_or_assign(name.UTF8String, query);
@@ -424,7 +443,7 @@ NSUInteger RLMFastEnumerate(NSFastEnumerationState *state,
 - (void)removeSubscriptionWithClassName:(NSString *)objectClassName
                               predicate:(NSPredicate *)predicate {
     [self verifyInWriteTransaction];
-    
+
     RLMClassInfo& info = _realm->_info[objectClassName];
     auto query = RLMPredicateToQuery(predicate, info.rlmObjectSchema, _realm.schema, _realm.group);
     auto iterator = _mutableSubscriptionSet->find(query);
@@ -454,7 +473,7 @@ NSUInteger RLMFastEnumerate(NSFastEnumerationState *state,
 
 - (void)removeAllSubscriptionsWithClassName:(NSString *)className {
     [self verifyInWriteTransaction];
-    
+
     for (auto it = _mutableSubscriptionSet->begin(); it != _mutableSubscriptionSet->end();) {
         if (it->object_class_name() == [className UTF8String]) {
             it = _mutableSubscriptionSet->erase(it);
@@ -481,7 +500,7 @@ NSUInteger RLMFastEnumerate(NSFastEnumerationState *state,
         @throw RLMException(@"Index %llu is out of bounds (must be less than %llu).",
                             (unsigned long long)index, (unsigned long long)size);
     }
-    
+
     return [[RLMSyncSubscription alloc]initWithSubscription:_subscriptionSet->at(size_t(index))
                                             subscriptionSet:self];
 }
@@ -498,7 +517,7 @@ NSUInteger RLMFastEnumerate(NSFastEnumerationState *state,
     if (_subscriptionSet->size() < 1) {
         return nil;
     }
-    
+
     return [[RLMSyncSubscription alloc]initWithSubscription:_subscriptionSet->at(_subscriptionSet->size()-1)
                                             subscriptionSet:self];
 }
@@ -519,18 +538,6 @@ NSUInteger RLMFastEnumerate(NSFastEnumerationState *state,
     if (_mutableSubscriptionSet == nil) {
         @throw RLMException(@"Can only add, remove, or update subscriptions within a write subscription block.");
     }
-}
-
-- (void)waitForCompletion:(void(^)(NSError * _Nullable))block {
-    _subscriptionSet->get_state_change_notification(realm::sync::SubscriptionSet::State::Complete)
-        .get_async([block](realm::StatusWith<realm::sync::SubscriptionSet::State> state) mutable noexcept {
-        if (state.is_ok()) {
-            block(nil);
-        } else {
-            NSError* error = [[NSError alloc] initWithDomain:RLMFlexibleSyncErrorDomain code:state.get_status().code() userInfo:@{@"reason": @(state.get_status().reason().c_str())}];
-            block(error);
-        }
-    });
 }
 
 @end

--- a/Realm/RLMSyncSubscription_Private.h
+++ b/Realm/RLMSyncSubscription_Private.h
@@ -51,6 +51,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly) uint64_t version;
 
+- (void)update:(__attribute__((noescape)) void(^)(void))block queue:(nullable dispatch_queue_t)queue onComplete:(void(^)(NSError *))completionBlock;
+
 - (void)addSubscriptionWithClassName:(NSString *)objectClassName
                     subscriptionName:(nullable NSString *)name
                            predicate:(NSPredicate *)predicate

--- a/Realm/Tests/SwiftUISyncTestHostUITests/SwiftUISyncTestHostUITests.swift
+++ b/Realm/Tests/SwiftUISyncTestHostUITests/SwiftUISyncTestHostUITests.swift
@@ -384,33 +384,25 @@ extension SwiftUISyncTestHostUITests {
 
 // MARK: - Flexible Sync
 extension SwiftUISyncTestHostUITests {
-    private func populateFlexibleSyncForEmail(_ email: String, n: Int, _ block: @escaping (Realm) -> Void) throws {
+    @MainActor private func populateFlexibleSyncForEmail(_ email: String, _ block: @escaping (Realm) -> Void) async throws {
         let user = logInUser(for: basicCredentials(name: email, register: true, app: flexibleSyncApp), app: flexibleSyncApp)
 
         let config = user.flexibleSyncConfiguration()
-        let realm = try Realm(configuration: config)
-        let subs = realm.subscriptions
-        let ex = expectation(description: "state change complete")
-        subs.update({
-            subs.append(QuerySubscription<SwiftPerson>(name: "person_age", where: "TRUEPREDICATE"))
-        }, onComplete: { error in
-            if error == nil {
-                ex.fulfill()
-            } else {
-                XCTFail("Subscription Set could not complete with \(error!)")
-            }
-        })
-        waitForExpectations(timeout: 20.0, handler: nil)
+
+        let realm = try await Realm(configuration: config, downloadBeforeOpen: .never)
+        _ = try await realm.objects(SwiftPerson.self)
 
         try realm.write {
-            block(realm)
+            for index in (1...20) {
+                realm.add(SwiftPerson(firstName: "\(#function)", lastName: "Smith", age: index))
+            }
         }
         waitForUploads(for: realm)
     }
 
-    func testFlexibleSyncAsyncOpenRoundTrip() throws {
+    func testFlexibleSyncAsyncOpenRoundTrip() async throws {
         let email = "realm_tests_do_autoverify\(randomString(7))@\(randomString(7)).com"
-        try populateFlexibleSyncForEmail(email, n: 10) { realm in
+        try await populateFlexibleSyncForEmail(email) { realm in
             for index in (1...10) {
                 realm.add(SwiftPerson(firstName: "\(#function)", lastName: "Smith", age: index))
             }
@@ -436,9 +428,9 @@ extension SwiftUISyncTestHostUITests {
         XCTAssertEqual(table.cells.count, 5)
     }
 
-    func testFlexibleSyncAutoOpenRoundTrip() throws {
+    func testFlexibleSyncAutoOpenRoundTrip() async throws {
         let email = "realm_tests_do_autoverify\(randomString(7))@\(randomString(7)).com"
-        try populateFlexibleSyncForEmail(email, n: 10) { realm in
+        try await populateFlexibleSyncForEmail(email) { realm in
             for index in (1...20) {
                 realm.add(SwiftPerson(firstName: "\(#function)", lastName: "Smith", age: index))
             }
@@ -462,5 +454,99 @@ extension SwiftUISyncTestHostUITests {
         let table = application.tables.firstMatch
         XCTAssertTrue(table.waitForExistence(timeout: 6))
         XCTAssertEqual(table.cells.count, 18)
+    }
+
+    func testObservedQueryResultsState() async throws {
+        let email = "realm_tests_do_autoverify\(randomString(7))@\(randomString(7)).com"
+        try await populateFlexibleSyncForEmail(email) { realm in
+            for i in 1...21 {
+                let person = SwiftPerson(firstName: "\(#function)",
+                                         lastName: "lastname_\(i)",
+                                         age: i)
+                realm.add(person)
+            }
+        }
+
+        application.launchEnvironment["email1"] = email
+        application.launchEnvironment["async_view_type"] = "flexible_sync_observed_query_results_state"
+        // Override appId for flexible app Id
+        application.launchEnvironment["app_id"] = flexibleSyncAppId
+        application.launchEnvironment["firstName"] = "\(#function)"
+        application.launch()
+
+        asyncOpen()
+
+        // Query for button to start syncing
+        let syncButtonView = application.buttons["flexible_sync_button"]
+        XCTAssertTrue(syncButtonView.waitForExistence(timeout: 2))
+        syncButtonView.tap()
+
+        // Test show ListView after syncing realm
+        let table = application.tables.firstMatch
+        XCTAssertTrue(table.waitForExistence(timeout: 10))
+        XCTAssertEqual(table.cells.count, 3)
+
+        try await populateFlexibleSyncForEmail(email) { realm in
+            for i in 22...30 {
+                let person = SwiftPerson(firstName: "\(#function)",
+                                         lastName: "lastname_\(i)",
+                                         age: i)
+                realm.add(person)
+            }
+        }
+
+        XCTAssertTrue(table.waitForExistence(timeout: 6))
+        XCTAssertEqual(table.cells.count, 12)
+
+        // Query for button to unsubscribe from query
+        let unsubscribeButtonView = application.buttons["unsubscribe_button"]
+        XCTAssertTrue(unsubscribeButtonView.waitForExistence(timeout: 2))
+        unsubscribeButtonView.tap()
+
+        XCTAssertTrue(table.waitForExistence(timeout: 6))
+        XCTAssertEqual(table.cells.count, 0)
+    }
+
+    func testObservedQueryResults() async throws {
+        let email = "realm_tests_do_autoverify\(randomString(7))@\(randomString(7)).com"
+        try await populateFlexibleSyncForEmail(email) { realm in
+            for i in 1...21 {
+                let person = SwiftPerson(firstName: "\(#function)",
+                                         lastName: "lastname_\(i)",
+                                         age: i)
+                realm.add(person)
+            }
+        }
+
+        application.launchEnvironment["email1"] = email
+        application.launchEnvironment["async_view_type"] = "flexible_sync_observed_query_results"
+        // Override appId for flexible app Id
+        application.launchEnvironment["app_id"] = flexibleSyncAppId
+        application.launchEnvironment["firstName"] = "\(#function)"
+        application.launch()
+
+        asyncOpen()
+
+        // Query for button to start syncing
+        let syncButtonView = application.buttons["flexible_sync_button"]
+        XCTAssertTrue(syncButtonView.waitForExistence(timeout: 2))
+        syncButtonView.tap()
+
+        // Test show ListView after syncing realm
+        let table = application.tables.firstMatch
+        XCTAssertTrue(table.waitForExistence(timeout: 10))
+        XCTAssertEqual(table.cells.count, 7)
+
+        try await populateFlexibleSyncForEmail(email) { realm in
+            for i in 22...30 {
+                let person = SwiftPerson(firstName: "\(#function)",
+                                         lastName: "lastname_\(i)",
+                                         age: i)
+                realm.add(person)
+            }
+        }
+
+        XCTAssertTrue(table.waitForExistence(timeout: 6))
+        XCTAssertEqual(table.cells.count, 16)
     }
 }

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -1211,6 +1211,16 @@ extension Realm {
         self.init(rlmRealm!)
     }
 }
+
+// MARK: Query Based Sync
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+extension Realm {
+    public func objects<Element: RealmFetchable>(_ type: Element.Type) async throws -> Results<Element> {
+        return try await Results(RLMGetObjects(rlmRealm, type.className(), nil))
+    }
+}
+
 #endif // swift(>=5.5)
 
 /**

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -452,7 +452,7 @@ extension Projection: _ObservedResultsValue { }
             if let configuration = configuration,
                configuration.syncConfiguration?.isFlexibleSync ?? false {
 #if swift(>=5.6) && canImport(_Concurrency)
-                Task {
+                Task { @MainActor in
                     do {
                         let realm = try await Realm(configuration: configuration)
                         let filter = filter ?? `where` ?? NSPredicate(format: "TRUEPREDICATE")
@@ -1192,7 +1192,9 @@ private class ObservableAsyncOpenStorage: ObservableObject {
         }
 
         // Use the user configuration by default or set configuration with the current user `syncConfiguration`'s.
-        if var configuration = configuration {
+        if var configuration = configuration,
+           let syncConfiguration = configuration.syncConfiguration,
+            syncConfiguration.user.id == user.id {
             let userSyncConfig = config.syncConfiguration
             configuration.syncConfiguration = userSyncConfig
             config = configuration

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -276,6 +276,13 @@ public enum ClientResetMode {
     }
 
     /**
+     Returns true if the sync configuration corresponds to a flexible sync App.
+     */
+    internal var isFlexibleSync: Bool {
+        return config.enableFlexibleSync
+    }
+
+    /**
      An enum which determines file recovery behvaior in the event of a client reset.
      - note: Defaults to `.manual`
 

--- a/RealmSwift/SyncSubscription.swift
+++ b/RealmSwift/SyncSubscription.swift
@@ -264,7 +264,7 @@ import Combine
                         the subscription by query and/or name.
      - returns: A query builder that produces a subscription which can used to search for the subscription.
      */
-    public func first<T: Object>(ofType type: T.Type, `where` query: @escaping (Query<T>) -> Query<Bool>) -> SyncSubscription? {
+    public func first<T: RealmCollectionValue>(ofType type: T.Type, `where` query: @escaping (Query<T>) -> Query<Bool>) -> SyncSubscription? {
         return rlmSyncSubscriptionSet.subscription(withClassName: "\(T.self)", predicate: query(Query()).predicate).map(SyncSubscription.init)
     }
 
@@ -276,7 +276,7 @@ import Combine
                         the subscription by query and/or name.
      - returns: A query builder that produces a subscription which can used to search for the subscription.
      */
-    public func first<T: Object>(ofType type: T.Type, `where` predicateFormat: String, _ args: Any...) -> SyncSubscription? {
+    public func first<T: RealmCollectionValue>(ofType type: T.Type, `where` predicateFormat: String, _ args: Any...) -> SyncSubscription? {
         return rlmSyncSubscriptionSet.subscription(withClassName: "\(T.self)", predicate: NSPredicate(format: predicateFormat, argumentArray: unwrapOptionals(in: args))).map(SyncSubscription.init)
     }
 
@@ -288,7 +288,7 @@ import Combine
                         the subscription by query and/or name.
      - returns: A query builder that produces a subscription which can used to search for the subscription.
      */
-    public func first<T: Object>(ofType type: T.Type, `where` predicate: NSPredicate) -> SyncSubscription? {
+    public func first<T: RealmCollectionValue>(ofType type: T.Type, `where` predicate: NSPredicate) -> SyncSubscription? {
         return rlmSyncSubscriptionSet.subscription(withClassName: "\(T.self)", predicate: predicate).map(SyncSubscription.init)
     }
 

--- a/examples/ios/swift/Chirp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/examples/ios/swift/Chirp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios/swift/Chirp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/ios/swift/Chirp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,93 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios/swift/Chirp/Assets.xcassets/Contents.json
+++ b/examples/ios/swift/Chirp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios/swift/Chirp/ChirpApp.swift
+++ b/examples/ios/swift/Chirp/ChirpApp.swift
@@ -35,7 +35,7 @@ struct AppState {
     static var shared: AppState = .init()
 
     var currentUser: ChirpUser?
-    var app = App(id: "")
+    var app = App(id: "<App id>")
 }
 
 struct ChirpView: View {
@@ -71,7 +71,7 @@ struct ChirpUserView: View {
                     currentUser.following.remove(user)
                 }
                 Task {
-                    try await subscribedUsers.update {
+                    try await subscribedUsers.where {
                         $0.in(currentUser.following)
                     }
                 }
@@ -85,7 +85,7 @@ struct ChirpDeckView: View {
     var subscribedUsers
 
     var body: some View {
-        if case .subscribing = $subscribedUsers.state {
+        if case .pending = $subscribedUsers.state {
             ProgressView()
         } else if case let .error(error) = $subscribedUsers.state {
             Text("Error: \(error.localizedDescription)")

--- a/examples/ios/swift/Chirp/ChirpApp.swift
+++ b/examples/ios/swift/Chirp/ChirpApp.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+import RealmSwift
+
+extension URL: CustomPersistable {
+    public typealias PersistedType = String
+
+    public init(persistedValue: String) {
+        self.init(string: persistedValue)!
+    }
+
+    public var persistableValue: String {
+        self.absoluteString
+    }
+}
+
+class Chirp: Object, Identifiable {
+    @Persisted(primaryKey: true) var _id: String
+    @Persisted var text: String
+    @Persisted var user: ChirpUser?
+    @Persisted var media: URL?
+    @Persisted var date: Date
+}
+
+class ChirpUser: Object, Identifiable {
+    @Persisted(primaryKey: true) var _id: String
+    @Persisted var username: String
+    @Persisted var bio: String
+    @Persisted var profilePicture: URL?
+    @Persisted var following: RealmSwift.MutableSet<ChirpUser>
+    @Persisted var followers: RealmSwift.MutableSet<ChirpUser>
+    @Persisted var chirps: RealmSwift.MutableSet<Chirp>
+}
+
+struct AppState {
+    static var shared: AppState = .init()
+
+    var currentUser: ChirpUser?
+    var app = App(id: "")
+}
+
+struct ChirpView: View {
+    @ObservedObject var chirp: Chirp
+
+    var body: some View {
+        HStack {
+            AsyncImage(url: chirp.user!.profilePicture!)
+            VStack {
+                Text(chirp.user!.username)
+                Text(chirp.text)
+                if let media = chirp.media {
+                    AsyncImage(url: media)
+                }
+            }
+        }
+    }
+}
+
+struct ChirpUserView: View {
+    @ObservedResults(ChirpUser.self, where: { $0.in(AppState.shared.currentUser!.following) })
+    var subscribedUsers
+    @ObservedObject var user: ChirpUser
+
+    var body: some View {
+        VStack(alignment: .center) {
+            AsyncImage(url: user.profilePicture!)
+            Text(user.bio)
+            Button("unfollow") {
+                guard let currentUser = AppState.shared.currentUser,
+                      let realm = currentUser.realm else { fatalError() }
+                try! realm.write {
+                    currentUser.following.remove(user)
+                }
+                Task {
+                    try await subscribedUsers.update {
+                        $0.in(currentUser.following)
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct ChirpDeckView: View {
+    @ObservedResults(ChirpUser.self, where: { $0.in(AppState.shared.currentUser!.following) })
+    var subscribedUsers
+
+    var body: some View {
+        if case .subscribing = $subscribedUsers.state {
+            ProgressView()
+        } else if case let .error(error) = $subscribedUsers.state {
+            Text("Error: \(error.localizedDescription)")
+        } else {
+            List {
+                ForEach(subscribedUsers.flatMap(\.chirps).sorted(by: { $0.date > $1.date })) { chirp in
+                    ChirpView(chirp: chirp)
+                }
+            }
+        }
+    }
+}
+
+struct LoginView: View {
+    @State var username: String = ""
+    @State var password: String = ""
+
+    var body: some View {
+        VStack {
+            TextField("username", text: $username)
+            TextField("password", text: $password)
+            Button("login") {
+                Task {
+                    // login a mongodb realm user
+                    let user = try await AppState.shared.app.login(credentials: .emailPassword(email: username, password: password))
+                    let realm = try await Realm(configuration: user.flexibleSyncConfiguration())
+                    // subscribe to the user's id, and if they exist, set the app state property
+                    // else, create the new ChirpUser with the matching id
+                    if let chirpUser = try await realm.objects(ChirpUser.self).where({
+                        $0._id == user.id
+                    }).first {
+                        AppState.shared.currentUser = chirpUser
+                    } else {
+                        let chirpUser = ChirpUser()
+                        chirpUser._id = user.id
+                        realm.add(chirpUser)
+                        AppState.shared.currentUser = chirpUser
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct ContentView: View {
+    @State var state = AppState.shared
+
+    var body: some View {
+        if state.currentUser != nil, let user = AppState.shared.app.currentUser {
+            ChirpDeckView().environment(\.realmConfiguration, user.flexibleSyncConfiguration())
+        } else {
+            LoginView()
+        }
+    }
+}
+
+@main
+struct ChirpApp: SwiftUI.App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/examples/ios/swift/Chirp/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/examples/ios/swift/Chirp/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
This PR contains a complete new QBS API for Flexible Sync, intended to make flexible sync less confusing to the developer, this proposal use a query based subscription API, which makes use of `async await` to be able to add a subscription and bootstrap data from it.

```swift
let app = App(id: "my-app-id")
let user = try await app.login(credentials: .anonymous)
let realm = try await Realm(configuration: user.flexibleSyncConfiguration())

// You can subscribe and get a Result, using the async `function objects<>` API
let persons = try await realm.objects(SwiftPerson.self) // All documents for this object type
let dogs = try await realm.objects(SwiftDog.self, where: { $0.breed != "labradoodle" })
let birds = try await realm.objects(Bird.self, where: { $0.species.in(BirdSpecies.allCases) })

print(persons.count) //20

let newPerson = Person()
newPerson.age = 18
try realm.write {
    realm.add(newPerson)
}

// Updating a subscription is as easy as sub querying over the results
let newPerson = try await persons.where { $0.age > 18 }

// Unsubscribe will remove the values from the Realm and the Results collection and remove the subscription from the subscription set.
try await persons.unsubscribe()

// Reusing a Subscription is as easy as getting a `Results`  for the same query.
let persons = try await realm.objects(SwiftPerson.self, where: { $0.age > 12 })

// You can use unsubscribeAll to remove all subscriptions from the subscription set
try await realm.subscriptions.unsubscribeAll()

// Or you can remove them by type
try await realm.subscriptions.unsubscribeAll(ofType: Person.self)
```

SwiftUI
You can use `@ObservedResults` to add a subscription and retrieve data from it, ObservedResults will subscribe to the query provided on the initialiser if this is a flexible sync realm app.
We are adding a new property to `@ObservedResults`which includes a state value, this state will publish any subscription state changes to view.
```swift
public enum SubscriptionState {
    case pending //Subscription has been added and waiting for data to bootstrap.
    case error(Error) // An error has occurred while adding the subscription (client or server side)
    case completed // Data has been bootstrapped and query results updated.
}
```
```swift
@available(macOS 12.0, *)
struct ObservedQueryResultsStateView: View {
    @ObservedResults(Person.self, where: { $0.age > 18 && $0.firstName == ProcessInfo.processInfo.environment["firstName"]! })
    var persons

    var body: some View {
        VStack {
            switch $persons.state {
            case .pending:
                ProgressView()
            case .completed:
                List {
                    ForEach(persons) { person in
                        Text("\(person.firstName)")
                    }
                }
            case .error(let error):
                ErrorView(error: error)
                    .background(Color.red)
                    .transition(AnyTransition.move(edge: .trailing)).animation(.default)
            }
        }
    }
}

@available(macOS 12.0, *)
struct ObservedQueryResultsView: View {
    @ObservedResults(Person.self,  where: { $0.age >= 15 && $0.firstName == ProcessInfo.processInfo.environment["firstName"]! })
    var persons
    @State var searchFilter: String = ""

    var body: some View {
        VStack {
            if persons.isEmpty {
                ProgressView()
            } else {
                List {
                    ForEach(persons) { person in
                        HStack {
                            Text("\(person.firstName)")
                            Spacer()
                            Text("\(person.age)")
                        }
                    }
                }
            }
        }
        .onDisappear {
            Task {
                do {
                    try await $persons.unsubscribe()
                }
            }
        }
    }
}
```