### PR TITLE
Defer `@AsyncOpen` and `@AutoOpen` async operation after all environment values are setted.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ x.y.z Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
-* None.
+* Defer `Realm.asyncOpen` execution on `@AsyncOpen` and `@AutoOpen` property wrappers, 
+  until all the environment values are set. This will guarantee the configuration and partition value
+  are set set before opening the realm.
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 
@@ -159,6 +160,8 @@ x.y.z Release notes (yyyy-MM-dd)
   such as `mixed.hpp:165: [realm-core-12.1.0] Assertion failed: m_type` when
   removing the destination link object.
   ([Core #5574](https://github.com/realm/realm-core/pull/5573), since the introduction of AnyRealmValue in v10.8.0)
+
+<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 
 ### Compatibility
 

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -1082,6 +1082,8 @@ private class ObservableAsyncOpenStorage: ObservableObject {
     var configuration: Realm.Configuration?
     var partitionValue: AnyBSON?
 
+    var setupHasRun = false
+
     // Tracks User State for App for Multi-User Support
     enum AppState {
         case loggedIn(User)
@@ -1182,7 +1184,6 @@ private class ObservableAsyncOpenStorage: ObservableObject {
 
         if let user = app.currentUser {
             appState = .loggedIn(user)
-            asyncOpenForUser(user)
         } else {
             appState = .loggedOut
             asyncOpenState = .waitingForUser
@@ -1287,7 +1288,12 @@ private class ObservableAsyncOpenStorage: ObservableObject {
 
     /// :nodoc:
     public var wrappedValue: AsyncOpenState {
-        storage.asyncOpenState
+        if !storage.setupHasRun {
+            storage.asyncOpen()
+            storage.setupHasRun = true
+        }
+        return storage.asyncOpenState
+
     }
 
     /**
@@ -1306,6 +1312,18 @@ private class ObservableAsyncOpenStorage: ObservableObject {
                  if empty the user configuration will be used.
      - parameter timeout: The maximum number of milliseconds to allow for a connection to
      become fully established., if empty or `nil` no connection timeout is set.
+
+     - Note: It is recommend to use the configuration obtained from the user, using  `user.configuration(partitionValue:)` or `user.flexibleSyncConfiguration()`
+             when adding a configuration to this property wrapper, and modify any configuration option from it if needed.
+
+             AsyncOpenView()
+                 .environment(\.realmConfiguration, getConfiguration())
+
+             func getConfiguration() -> Realm.Configuration {
+                 var configuration = user.configuration(partitionValue: "partitionValue")
+                 configuration.encryptionKey =  <ENCRYPYION_KEY>
+                 return configuration
+             }
      */
     public init<Partition>(appId: String? = nil,
                            partitionValue: Partition,
@@ -1324,6 +1342,18 @@ private class ObservableAsyncOpenStorage: ObservableObject {
                  if empty the user configuration will be used.
      - parameter timeout: The maximum number of milliseconds to allow for a connection to
                  become fully established., if empty or `nil` no connection timeout is set.
+
+     - Note: It is recommend to use the configuration obtained from the user, using  `user.configuration(partitionValue:)` or `user.flexibleSyncConfiguration()`
+             when adding a configuration to this property wrapper, and modify any configuration option from it if needed.
+
+             AsyncOpenView()
+                 .environment(\.realmConfiguration, getConfiguration())
+
+             func getConfiguration() -> Realm.Configuration {
+                 var configuration = user.configuration(partitionValue: "partitionValue")
+                 configuration.encryptionKey =  <ENCRYPYION_KEY>
+                 return configuration
+             }
      */
     public init(appId: String? = nil,
                 configuration: Realm.Configuration? = nil,
@@ -1338,7 +1368,6 @@ private class ObservableAsyncOpenStorage: ObservableObject {
             let bsonValue = AnyBSON(partitionValue: partitionValue)
             if storage.partitionValue != bsonValue {
                 storage.partitionValue = bsonValue
-                storage.asyncOpen()
             }
         }
 
@@ -1349,7 +1378,6 @@ private class ObservableAsyncOpenStorage: ObservableObject {
                 storage.partitionValue = partitionValue
             }
             storage.configuration = configuration
-            storage.asyncOpen()
         }
     }
 }
@@ -1412,7 +1440,11 @@ private class ObservableAsyncOpenStorage: ObservableObject {
 
     /// :nodoc:
     public var wrappedValue: AsyncOpenState {
-        storage.asyncOpenState
+        if !storage.setupHasRun {
+            storage.asyncOpen()
+            storage.setupHasRun = true
+        }
+        return storage.asyncOpenState
     }
 
     /**
@@ -1431,6 +1463,18 @@ private class ObservableAsyncOpenStorage: ObservableObject {
                  if empty the user configuration will be used.
      - parameter timeout: The maximum number of milliseconds to allow for a connection to
                  become fully established, if empty or `nil` no connection timeout is set.
+
+     - Note: It is recommend to use the configuration obtained from the user, using  `user.configuration(partitionValue:)` or `user.flexibleSyncConfiguration()`
+             when adding a configuration to this property wrapper, and modify any configuration option from it if needed.
+
+             AsyncOpenView()
+                 .environment(\.realmConfiguration, getConfiguration())
+
+             func getConfiguration() -> Realm.Configuration {
+                 var configuration = user.configuration(partitionValue: "partitionValue")
+                 configuration.encryptionKey =  <ENCRYPYION_KEY>
+                 return configuration
+             }
      */
     public init<Partition>(appId: String? = nil,
                            partitionValue: Partition,
@@ -1449,6 +1493,18 @@ private class ObservableAsyncOpenStorage: ObservableObject {
                  if empty the user configuration will be used.
      - parameter timeout: The maximum number of milliseconds to allow for a connection to
                  become fully established., if empty or `nil` no connection timeout is set.
+
+     - Note: It is recommend to use the configuration obtained from the user, using  `user.configuration(partitionValue:)` or `user.flexibleSyncConfiguration()`
+             when adding a configuration to this property wrapper, and modify any configuration option from it if needed.
+
+             AsyncOpenView()
+                 .environment(\.realmConfiguration, getConfiguration())
+
+             func getConfiguration() -> Realm.Configuration {
+                 var configuration = user.configuration(partitionValue: "partitionValue")
+                 configuration.encryptionKey =  <ENCRYPYION_KEY>
+                 return configuration
+             }
      */
     public init(appId: String? = nil,
                 configuration: Realm.Configuration? = nil,
@@ -1463,7 +1519,6 @@ private class ObservableAsyncOpenStorage: ObservableObject {
             let bsonValue = AnyBSON(partitionValue: partitionValue)
             if storage.partitionValue != bsonValue {
                 storage.partitionValue = bsonValue
-                storage.asyncOpen()
             }
         }
 
@@ -1474,7 +1529,6 @@ private class ObservableAsyncOpenStorage: ObservableObject {
                 storage.partitionValue = partitionValue
             }
             storage.configuration = configuration
-            storage.asyncOpen()
         }
     }
 }

--- a/examples/ios/swift/AsyncOpenSwiftUI/ContentView.swift
+++ b/examples/ios/swift/AsyncOpenSwiftUI/ContentView.swift
@@ -132,7 +132,7 @@ struct AsyncOpenView: View {
                 ProgressView("Waiting for user to logged in...")
             case .open(let realm):
                 ContactsListView()
-                    .environment(\.realm, realm)
+                    .environment(\.realmConfiguration, realm.configuration)
             case .error(let error):
                 ErrorView(error: error)
             case .progress(let progress):
@@ -157,7 +157,7 @@ struct AutoOpenView: View {
                 ProgressView("Waiting for user to logged in...")
             case .open(let realm):
                 ContactsListView()
-                    .environment(\.realm, realm)
+                    .environment(\.realmConfiguration, realm.configuration)
             case .error(let error):
                 ErrorView(error: error)
             case .progress(let progress):


### PR DESCRIPTION
Defer @AsyncOpen and @AutoOpen async operation after all environment values are set. Opening the realm after the property wrappers initialisation and before environment values were injected is causing the realm to be open twice.