### PR TITLE
(work in progress) Add Ownable<T> and OwnableResults<T>

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -44,6 +44,7 @@ Pod::Spec.new do |s|
                               'include/RLMSwiftValueStorage.h',
                               'include/RLMThreadSafeReference.h',
                               'include/RLMValue.h',
+                              'include/RLMOwnableCollection.h',
 
                               # Sync
                               'include/NSError+RLMSync.h',

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -464,6 +464,17 @@
 		ACC6BEE62796EA78006C1728 /* RLMSyncSubscription.h in Headers */ = {isa = PBXBuildFile; fileRef = 53E308CA27905794002A8D91 /* RLMSyncSubscription.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ACC6BEE72796ED6C006C1728 /* RLMSyncSubscription.mm in Sources */ = {isa = PBXBuildFile; fileRef = 531F956B27906F7600E497F1 /* RLMSyncSubscription.mm */; };
 		ACF08B6726DD936200686CBC /* Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF08B6626DD936200686CBC /* Query.swift */; };
+		BA79815D9647D01921938C5A /* RLMOwnableCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = BA798B95AA33448D6A7008A0 /* RLMOwnableCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BA7983CB4661565356800EDA /* Ownable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA798EF69698FEF55B403301 /* Ownable.swift */; };
+		BA79851F3F507B88B52A8BE7 /* BusyTown.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7989238B03E75B5A8A483F /* BusyTown.swift */; };
+		BA79859EEE05196EEFB5331B /* BusyTownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7988D3D3663B21BC36581B /* BusyTownTests.swift */; };
+		BA79893551C6DA98CDC294B6 /* RealmProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA798DF10142DDB73AFE15D9 /* RealmProvider.swift */; };
+		BA7989E011BBEE5E788F07BE /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA798E7F2A7899A2719C3954 /* Message.swift */; };
+		BA798A18F33D842D8E8EFD72 /* RLMOwnableCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = BA798C70EDE6781C01F32606 /* RLMOwnableCollection.m */; };
+		BA798B204BEA767074BF3F6D /* OwnableResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7980FE54040A4B84689038 /* OwnableResults.swift */; };
+		BA798EE7176C80CAD69D63CD /* RealmError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7986D5AD8A9B811252A459 /* RealmError.swift */; };
+		BA798F8FC9E7554DBD28A423 /* Realm+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7982B21912163B3CE0F00E /* Realm+Extensions.swift */; };
+		BA798FA37D65BAE3382B2885 /* RLMOwnableCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = BA798C70EDE6781C01F32606 /* RLMOwnableCollection.m */; };
 		C042A48D1B7522A900771ED2 /* RealmConfigurationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C042A48C1B7522A900771ED2 /* RealmConfigurationTests.mm */; };
 		C042A48E1B7522A900771ED2 /* RealmConfigurationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C042A48C1B7522A900771ED2 /* RealmConfigurationTests.mm */; };
 		C0CDC0821B38DABA00C5716D /* UtilTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 021A88311AAFB5BE00EEAC84 /* UtilTests.mm */; };
@@ -1039,6 +1050,16 @@
 		ACB6FD31273C60920009712F /* SwiftFlexibleSyncServerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftFlexibleSyncServerTests.swift; path = Realm/ObjectServerTests/SwiftFlexibleSyncServerTests.swift; sourceTree = "<group>"; };
 		ACB6FD34273C60CC0009712F /* SyncSubscription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncSubscription.swift; sourceTree = "<group>"; };
 		ACF08B6626DD936200686CBC /* Query.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Query.swift; sourceTree = "<group>"; };
+		BA7980FE54040A4B84689038 /* OwnableResults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OwnableResults.swift; sourceTree = "<group>"; };
+		BA7982B21912163B3CE0F00E /* Realm+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Realm+Extensions.swift"; sourceTree = "<group>"; };
+		BA7986D5AD8A9B811252A459 /* RealmError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmError.swift; sourceTree = "<group>"; };
+		BA7988D3D3663B21BC36581B /* BusyTownTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BusyTownTests.swift; sourceTree = "<group>"; };
+		BA7989238B03E75B5A8A483F /* BusyTown.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BusyTown.swift; sourceTree = "<group>"; };
+		BA798B95AA33448D6A7008A0 /* RLMOwnableCollection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMOwnableCollection.h; sourceTree = "<group>"; };
+		BA798C70EDE6781C01F32606 /* RLMOwnableCollection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMOwnableCollection.m; sourceTree = "<group>"; };
+		BA798DF10142DDB73AFE15D9 /* RealmProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmProvider.swift; sourceTree = "<group>"; };
+		BA798E7F2A7899A2719C3954 /* Message.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
+		BA798EF69698FEF55B403301 /* Ownable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Ownable.swift; sourceTree = "<group>"; };
 		C042A48C1B7522A900771ED2 /* RealmConfigurationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RealmConfigurationTests.mm; sourceTree = "<group>"; };
 		C073E1201AE9B705002C0A30 /* RLMObject_Private.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = RLMObject_Private.hpp; sourceTree = "<group>"; };
 		C0D2DD051B6BDEA1004E8919 /* RLMRealmConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMRealmConfiguration.h; sourceTree = "<group>"; };
@@ -1515,6 +1536,11 @@
 				ACB6FD34273C60CC0009712F /* SyncSubscription.swift */,
 				3F222C4D1E26F51300CA0713 /* ThreadSafeReference.swift */,
 				5D660FF01BE98D670021E04F /* Util.swift */,
+				BA798EF69698FEF55B403301 /* Ownable.swift */,
+				BA7986D5AD8A9B811252A459 /* RealmError.swift */,
+				BA7982B21912163B3CE0F00E /* Realm+Extensions.swift */,
+				BA798DF10142DDB73AFE15D9 /* RealmProvider.swift */,
+				BA7980FE54040A4B84689038 /* OwnableResults.swift */,
 			);
 			path = RealmSwift;
 			sourceTree = "<group>";
@@ -1571,6 +1597,9 @@
 				5D6610121BE98D880021E04F /* TestCase.swift */,
 				3F90C1B12716169C0029000E /* TestValueFactory.swift */,
 				3F73BC841E3A870F00FE80B6 /* ThreadSafeReferenceTests.swift */,
+				BA7989238B03E75B5A8A483F /* BusyTown.swift */,
+				BA7988D3D3663B21BC36581B /* BusyTownTests.swift */,
+				BA798E7F2A7899A2719C3954 /* Message.swift */,
 			);
 			name = "RealmSwift Tests";
 			path = RealmSwift/Tests;
@@ -1903,6 +1932,8 @@
 				3F1D8D32265B071000593ABA /* RLMUUID_Private.hpp */,
 				3F1D8D30265B071000593ABA /* RLMValue.h */,
 				3F1D8D31265B071000593ABA /* RLMValue.mm */,
+				BA798C70EDE6781C01F32606 /* RLMOwnableCollection.m */,
+				BA798B95AA33448D6A7008A0 /* RLMOwnableCollection.h */,
 			);
 			path = Realm;
 			sourceTree = "<group>";
@@ -1951,6 +1982,7 @@
 			files = (
 				3F73BC951E3A878500FE80B6 /* NSError+RLMSync.h in Headers */,
 				5D659EA51BE04556006515A0 /* Realm.h in Headers */,
+				BA79815D9647D01921938C5A /* RLMOwnableCollection.h in Headers */,
 				5D659EA71BE04556006515A0 /* RLMAccessor.h in Headers */,
 				CFAEF761242B5F9A00EAF721 /* RLMAPIKeyAuth.h in Headers */,
 				4993221224129DCE00A0EC8E /* RLMApp.h in Headers */,
@@ -2787,6 +2819,7 @@
 				5D659E9B1BE04556006515A0 /* RLMUtil.mm in Sources */,
 				0C5796A225643D7500744CAE /* RLMUUID.mm in Sources */,
 				3F1D8D35265B071000593ABA /* RLMValue.mm in Sources */,
+				BA798FA37D65BAE3382B2885 /* RLMOwnableCollection.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2844,6 +2877,13 @@
 				ACB6FD35273C60CC0009712F /* SyncSubscription.swift in Sources */,
 				3F222C4E1E26F51300CA0713 /* ThreadSafeReference.swift in Sources */,
 				5D660FFE1BE98D670021E04F /* Util.swift in Sources */,
+				BA7983CB4661565356800EDA /* Ownable.swift in Sources */,
+				BA798EE7176C80CAD69D63CD /* RealmError.swift in Sources */,
+				BA798F8FC9E7554DBD28A423 /* Realm+Extensions.swift in Sources */,
+				BA79893551C6DA98CDC294B6 /* RealmProvider.swift in Sources */,
+				BA79851F3F507B88B52A8BE7 /* BusyTown.swift in Sources */,
+				BA7989E011BBEE5E788F07BE /* Message.swift in Sources */,
+				BA798B204BEA767074BF3F6D /* OwnableResults.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2904,6 +2944,7 @@
 				3F90C1B22716169C0029000E /* TestValueFactory.swift in Sources */,
 				3F88250D1E5E335000586B35 /* ThreadSafeReferenceTests.swift in Sources */,
 				5DBEC9B11F719A9D001233EC /* Util.swift in Sources */,
+				BA79859EEE05196EEFB5331B /* BusyTownTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2970,6 +3011,7 @@
 				5DD755991BE056DE002800DA /* RLMUtil.mm in Sources */,
 				0C5796A325643D7500744CAE /* RLMUUID.mm in Sources */,
 				3F1D8D36265B071000593ABA /* RLMValue.mm in Sources */,
+				BA798A18F33D842D8E8EFD72 /* RLMOwnableCollection.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3358,6 +3400,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D660FBD1BE98BEF0021E04F /* RealmSwift.xcconfig */;
 			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 			};
 			name = Debug;
 		};
@@ -3365,6 +3408,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D660FBD1BE98BEF0021E04F /* RealmSwift.xcconfig */;
 			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 			};
 			name = Release;
 		};
@@ -3373,6 +3417,7 @@
 			baseConfigurationReference = 5D660FC01BE98BEF0021E04F /* Tests.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3387,6 +3432,7 @@
 			baseConfigurationReference = 5D660FC01BE98BEF0021E04F /* Tests.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Realm.xcodeproj/xcshareddata/xcschemes/RealmSwift.xcscheme
+++ b/Realm.xcodeproj/xcshareddata/xcschemes/RealmSwift.xcscheme
@@ -86,6 +86,10 @@
             ReferencedContainer = "container:Realm.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <LocationScenarioReference
+         identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
+         referenceType = "1">
+      </LocationScenarioReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Realm/RLMOwnableCollection.h
+++ b/Realm/RLMOwnableCollection.h
@@ -1,0 +1,38 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2014 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import <Foundation/Foundation.h>
+
+@class RLMRealm;
+@class RLMThreadSafeReference;
+@protocol RLMThreadConfined;
+@protocol RLMCollection;
+
+@interface RLMOwnableCollection<__covariant Confined : id <RLMThreadConfined>> : NSObject
+
+@property(nonatomic, strong, readonly) RLMThreadSafeReference *__nonnull threadConfined;
+@property(nonatomic, strong, readonly) RLMRealm *__nonnull realm;
+
+- (__nonnull instancetype)initWithItems:(id<RLMCollection> __nonnull)items;
+
+- (__nonnull instancetype)initWithThreadConfined:(RLMThreadSafeReference *__nonnull)threadConfined
+                                           realm:(RLMRealm *__nonnull)realm;
+
+- (__nonnull Confined)take;
+
+@end

--- a/Realm/RLMOwnableCollection.m
+++ b/Realm/RLMOwnableCollection.m
@@ -1,0 +1,57 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2014 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+#import "RLMRealm.h"
+#import "RLMThreadSafeReference.h"
+#import "RLMCollection.h"
+#import "RLMOwnableCollection.h"
+#import "RLMThreadSafeReference.h"
+
+
+@implementation RLMOwnableCollection
+
+- (instancetype)initWithItems:(id<RLMCollection>)items {
+    if (items.realm != nil) {
+        id reference = [RLMThreadSafeReference referenceWithThreadConfined:items];
+        return [self initWithThreadConfined:reference realm:items.realm];
+    } else {
+        [NSException raise:NSInternalInconsistencyException format:@"Item realm can't be nil"];
+        return nil;
+    }
+}
+
+- (instancetype)initWithThreadConfined:(RLMThreadSafeReference *)threadConfined realm:(RLMRealm *)realm {
+    self = [super init];
+    if (self) {
+        _threadConfined = threadConfined;
+        _realm = realm;
+    }
+    return self;
+}
+
+- (id)take {
+    id result = [_realm resolveThreadSafeReference:_threadConfined];
+    if (result) {
+        return result;
+    } else {
+        [NSException raise:NSInternalInconsistencyException format:@"Object was deleted in another thread"];
+        return nil;
+    }
+}
+
+
+@end

--- a/Realm/Realm.h
+++ b/Realm/Realm.h
@@ -61,3 +61,4 @@
 #import <Realm/RLMFindOptions.h>
 #import <Realm/RLMFindOneAndModifyOptions.h>
 #import <Realm/RLMSyncSubscription.h>
+#import <Realm/RLMOwnableCollection.h>

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -90,7 +90,7 @@ import Realm
         self.handle = RLMLinkingObjectsHandle(linkingObjects: collection as! RLMResults<AnyObject>)
     }
 
-    internal var collection: RLMCollection {
+    public var collection: RLMCollection {
         return handle?.results ?? RLMResults<AnyObject>.emptyDetached()
     }
 

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -40,7 +40,7 @@ public final class List<Element: RealmCollectionValue>: RLMSwiftCollectionBase, 
     internal var rlmArray: RLMArray<AnyObject> {
         unsafeDowncast(collection, to: RLMArray<AnyObject>.self)
     }
-    internal var collection: RLMCollection {
+    public var collection: RLMCollection {
         _rlmCollection
     }
 

--- a/RealmSwift/MutableSet.swift
+++ b/RealmSwift/MutableSet.swift
@@ -40,7 +40,7 @@ public final class MutableSet<Element: RealmCollectionValue>: RLMSwiftCollection
     internal var rlmSet: RLMSet<AnyObject> {
         unsafeDowncast(_rlmCollection, to: RLMSet.self)
     }
-    internal var collection: RLMCollection {
+    public var collection: RLMCollection {
         _rlmCollection
     }
 

--- a/RealmSwift/Ownable.swift
+++ b/RealmSwift/Ownable.swift
@@ -1,0 +1,55 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2014 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import Foundation
+
+public class Ownable<T: ThreadConfined> {
+
+    private(set) var realm: Realm?
+    private(set) var threadConfined: ThreadSafeReference<T>?
+    private(set) var unmanaged: T?
+
+    public convenience init(item: T) {
+        if let realm = item.realm {
+            let wrappedObj = ThreadSafeReference(to: item)
+            self.init(threadConfined: wrappedObj, unmanaged: nil, realm: realm)
+        } else {
+            self.init(threadConfined: nil, unmanaged: item, realm: nil)
+        }
+    }
+
+    public init(threadConfined: ThreadSafeReference<T>?, unmanaged: T?, realm: Realm?) {
+        self.threadConfined = threadConfined
+        self.unmanaged = unmanaged
+        self.realm = realm
+    }
+
+    public func take() throws -> T {
+        if let threadConfined = threadConfined, let realm = realm {
+            if let result = realm.resolve(threadConfined) {
+                return result
+            } else {
+                throw RealmError("Object was deleted in another thread!!")
+            }
+        } else if let unmanaged = unmanaged {
+            return unmanaged
+        } else {
+            throw RealmError("Require either a realm bound or managed object")
+        }
+    }
+}

--- a/RealmSwift/OwnableResults.swift
+++ b/RealmSwift/OwnableResults.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Realm
+
+public class OwnableResults<T: RealmCollectionValue> {
+
+    private(set) var ownableCollection: RLMOwnableCollection<RLMCollection>
+
+    public init(_ results: Results<T>) {
+        ownableCollection = RLMOwnableCollection(items: results.collection)
+    }
+
+    public func take() throws -> Results<T> {
+        Results<T>(collection: ownableCollection.take())
+    }
+}

--- a/RealmSwift/Realm+Extensions.swift
+++ b/RealmSwift/Realm+Extensions.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+public extension Realm {
+
+    static let queue = DispatchQueue(label: "RealmQueue", qos: .background)
+
+    static var defaultConfig: Configuration {
+        Realm.Configuration(schemaVersion: 100, deleteRealmIfMigrationNeeded: true)
+    }
+
+    static var defaultRealm: Realm {
+        get throws {
+            try provider.defaultRealm
+        }
+    }
+
+    static var provider: RealmProvider {
+        RealmProvider.shared
+    }
+
+    /**
+     Participate in the current transaction, if it exists, or create one.
+     - Parameter block:
+     - Throws:
+     */
+    func inTransactionDo(_ block: (() throws -> Void)) throws {
+        if isInWriteTransaction {
+            try block()
+        } else {
+            try write(block)
+        }
+    }
+
+}
+
+extension Realm {
+    public func writeAsync<T : ThreadConfined>(_ obj: T,
+                                               errorHandler: @escaping ((_ error : Swift.Error) -> Void) = { _ in return },
+                                               block: @escaping ((Realm, T?) -> Void)) {
+
+        let wrappedObj = ThreadSafeReference(to: obj)
+        DispatchQueue(label: "background").async {
+            autoreleasepool {
+                do {
+                    let config = Realm.Configuration(schemaVersion: 100, deleteRealmIfMigrationNeeded: true)
+                    let realm = try Realm(configuration: config)
+                    let obj = realm.resolve(wrappedObj)
+
+                    try realm.write {
+                        block(realm, obj)
+                    }
+                }
+                catch {
+                    errorHandler(error)
+                }
+            }
+        }
+    }
+}

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -234,6 +234,8 @@ public protocol RealmCollectionBase: RandomAccessCollection, LazyCollectionProto
 public protocol RealmCollection: RealmCollectionBase, Equatable {
     // MARK: Properties
 
+    var collection: RLMCollection { get }
+
     /// The Realm which manages the collection, or `nil` for unmanaged collections.
     var realm: Realm? { get }
 
@@ -1070,7 +1072,7 @@ public extension RealmCollection {
  collection directly.
  */
 @frozen public struct AnyRealmCollection<Element: RealmCollectionValue>: RealmCollectionImpl {
-    internal let collection: RLMCollection
+    public let collection: RLMCollection
     internal var lastAccessedNames: NSMutableArray?
     internal init(collection: RLMCollection) {
         self.collection = collection

--- a/RealmSwift/RealmError.swift
+++ b/RealmSwift/RealmError.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public class RealmError : NSError {
+
+    public convenience init(_ message: String = "Realm Error") {
+        self.init(domain: "com.symbiose.realm", code: 0, userInfo: [
+            NSLocalizedDescriptionKey : message
+        ])
+    }
+
+}

--- a/RealmSwift/RealmProvider.swift
+++ b/RealmSwift/RealmProvider.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/**
+ Provides a configured instance or Realm. Realm configuration is modularized and de-duplicated here.
+ */
+public class RealmProvider {
+
+    static let shared = RealmProvider()
+
+    static let bgQueue = DispatchQueue(label: "RealmQueue")
+
+    var defaultRealm: Realm {
+        get throws {
+            try realm(queue: nil)
+        }
+    }
+
+    var bgRealm: Realm {
+        get throws {
+            try realm(queue: RealmProvider.bgQueue)
+        }
+    }
+
+    public init() {}
+
+    func realm(queue: DispatchQueue? = nil) throws -> Realm {
+        do {
+            let config = Realm.Configuration(schemaVersion: 100, deleteRealmIfMigrationNeeded: true)
+            let realm = try Realm(configuration: config, queue: queue)
+            return realm
+        } catch {
+            throw error
+        }
+    }
+
+}

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -144,7 +144,7 @@ extension Projection: KeypathSortable {}
  Results instances cannot be directly instantiated.
  */
 @frozen public struct Results<Element: RealmCollectionValue>: Equatable, RealmCollectionImpl {
-    internal let collection: RLMCollection
+    public let collection: RLMCollection
 
     /// A human-readable description of the objects represented by the results.
     public var description: String {

--- a/RealmSwift/Tests/BusyTown.swift
+++ b/RealmSwift/Tests/BusyTown.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Realm
+
+class BusyTown {
+
+    var busyCount = 0;
+
+    static var chance: Int {
+        Int.random(in: 1..<100)
+    }
+
+    func getBusyAsync() async throws {
+        busyCount += 1
+        await delay(seconds: Double.random(in: 0.0..<1.0))
+        let message = try await loadMessagesAsync().take()
+        if message.realm == nil {
+            Message.saveToRealm(message: message)
+        }
+//        let toUpdate = try await loadSeveral().take()
+        if let realm = message.realm {
+            try realm.inTransactionDo {
+                message.contentTxt = "updated: \(Date().timeIntervalSince1970)"
+                let newChild = try! unsavedChildMessage(parentId: message.uid)
+                message.childMessages.append(newChild)
+                realm.add(message, update: .modified)
+            }
+        }
+        let ownableResults = try await loadSeveral()
+        let results = try ownableResults.take()
+        print("Got results: \(results)")
+        results.forEach {
+            print("Message: \($0)")
+        }
+    }
+
+
+    func delay(seconds: TimeInterval) async {
+        Thread.sleep(forTimeInterval: seconds)
+    }
+
+    func loadMessagesAsync() async throws -> Ownable<Message> {
+        print("$$$ IN THREAD")
+        Thread.sleep(forTimeInterval: 0.348)
+        let createNew = Message.count == 0 || BusyTown.chance <= 50
+        print("Create new? \(createNew)")
+        if createNew {
+            let parent = try unsavedChildMessage(parentId: nil)
+            let newChild = try unsavedChildMessage(parentId: parent.uid)
+            parent.childMessages.append(newChild)
+            return Ownable(item: parent)
+        } else {
+            let parent = try Message.anyMessage()
+            return Ownable(item: parent)
+        }
+    }
+
+    func loadSeveral() async throws -> OwnableResults<Message> {
+        let messages = try Realm.defaultRealm.objects(Message.self)
+            .filter("color = %@", "Orange")
+        return OwnableResults(messages)
+    }
+
+    func unsavedChildMessage(parentId: String?) throws -> Message {
+        let uuid = UUID().uuidString
+        let contentTxt = "message: \(Date().timeIntervalSinceNow)"
+        let color = randomColor()
+        return Message(uid: uuid, contentTxt: contentTxt, color: color, createdAt: Date(),
+            parentMessageID: parentId)
+    }
+
+    func randomColor() -> String {
+        switch Int.random(in: 0...2) {
+        case 0: return "Orange"
+        case 1: return "Green"
+        default: return "Blue"
+        }
+    }
+
+}
+

--- a/RealmSwift/Tests/BusyTownTests.swift
+++ b/RealmSwift/Tests/BusyTownTests.swift
@@ -1,0 +1,20 @@
+import Foundation
+import XCTest
+@testable import RealmSwift
+
+class BusyTownTests : XCTestCase {
+    
+    func testFoobar() {
+        let expectation = XCTestExpectation(description: "Handle 10 thread hand-offs")
+        let busyTown = BusyTown()
+
+        Task {
+            while (busyTown.busyCount < 10) {
+                try await busyTown.getBusyAsync()
+            }
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 10.0)
+    }
+}

--- a/RealmSwift/Tests/Message.swift
+++ b/RealmSwift/Tests/Message.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+extension Message {
+
+    static var count: Int {
+        try! Realm.defaultRealm.objects(Message.self).count
+    }
+
+    static func saveToRealm(messages: [Message]) {
+        let realm = try! Realm.defaultRealm
+        try? realm.write {
+            realm.add(messages, update: .modified)
+        }
+    }
+
+    static func saveToRealm(message: Message) {
+        let realm = try! Realm.defaultRealm
+        try? realm.write {
+            realm.add(message, update: .modified)
+        }
+    }
+
+    static func anyMessage(realm: Realm = try! Realm.defaultRealm) throws -> Message {
+        let messages = try realm.objects(Message.self)
+        let index = Int.random(in: 0..<Message.count)
+        return messages[index]
+    }
+
+}
+
+class Message: Object, Identifiable {
+
+    override func isEqual(_ object: Any?) -> Bool {
+        if let other = object as? Message {
+            return other.uid == uid
+        }
+        return false
+    }
+
+    var id: String { uid }
+    @Persisted(primaryKey: true) var uid: String
+
+    @Persisted var contentTxt: String
+    @Persisted var color: String? = nil
+    @Persisted var createdAt: Date
+//    @Persisted(originProperty: "parentMessage") var parentOf: LinkingObjects<MessageModel>
+
+
+    @Persisted var childMessages: List<Message>
+    @Persisted(originProperty: "childMessages") var childOf: LinkingObjects<Message>
+
+    var replyCount: Int {
+        childMessages.count
+    }
+
+
+//    var descendantCount: Int {
+//        if parentOf.count == 0 {
+//            return 0
+//        } else {
+//            var inc = 0
+//            parentOf.forEach { inc = inc + $0.descendantCount }
+//            return inc
+//        }
+//    }
+
+    override init() {
+        super.init()
+    }
+
+
+    init(uid: String, contentTxt: String, color: String, createdAt: Date, parentMessageID: String?) {
+
+        super.init()
+
+        self.uid = uid
+        self.contentTxt = contentTxt
+        self.color = color
+        self.createdAt = createdAt
+
+    }
+
+
+}
+


### PR DESCRIPTION
PR is too messy to merge as-is (added some of our utility classes for testing) however using it to serve as an executable discussion: 

# The Problem 

Modern iOS and Mac apps depend on very high levels of concurrency. Realm provides utilities for passing objects between threads, however the current (lack of) documentation and approaches mean that it takes a lot of research and then boiler-plate code to get it done. The upshot is that most apps using Realm objects to update the UI end up using Realm on the main thread. Often the performance is pretty good, but for large datasets, it can be an issue. 

## Proposal: Simple Way to Pass Between Threads. 

I introduce an `Ownable<T>` and `OwnableResults<T>` that can be returned from concurrent code, like: 

* Promises
* Async Functions
* Rx____ and Combine, etc 

Use it like so: 

```swift 
    func loadSeveral() async throws -> OwnableResults<Message> {
        let messages = try Realm.defaultRealm.objects(Message.self)
            .filter("color = %@", "Orange")
        return OwnableResults(messages)
    }
```

Above function will run in its own (unknown) thread. We can then pass ownership of the returned Realm objects to another (including the main thread, when calling it) like this: 

```
let results = try await loadSeveral().take() // Now use the results on a new thread
```

Similarly we have an `Ownable<T>` type for a single item. (We could probably combine the one class to support anything that's Realm-backed) if we wanted. 


## Implementation Details

The `Ownable<T>` is just a pure swift class: 

```
public class Ownable<T: ThreadConfined> {

    private(set) var realm: Realm?
    private(set) var threadConfined: ThreadSafeReference<T>?
    private(set) var unmanaged: T?

    public convenience init(item: T) {
        if let realm = item.realm {
            let wrappedObj = ThreadSafeReference(to: item)
            self.init(threadConfined: wrappedObj, unmanaged: nil, realm: realm)
        } else {
            self.init(threadConfined: nil, unmanaged: item, realm: nil)
        }
    }

    public init(threadConfined: ThreadSafeReference<T>?, unmanaged: T?, realm: Realm?) {
        self.threadConfined = threadConfined
        self.unmanaged = unmanaged
        self.realm = realm
    }

    public func take() throws -> T {
        if let threadConfined = threadConfined, let realm = realm {
            if let result = realm.resolve(threadConfined) {
                return result
            } else {
                // TODO: Throw errors the Realm way
                throw RealmError("Object was deleted in another thread!!")
            }
        } else if let unmanaged = unmanaged {
            return unmanaged
        } else {
            throw RealmError("Require either a realm bound or managed object")
        }
    }
}
```

### RLMOwnableCollection 

For Results<T> it seems that the Swift API didn't expose the internals needed, so I created an Objective-C class: 


```objc
@class RLMRealm;
@class RLMThreadSafeReference;
@protocol RLMThreadConfined;
@protocol RLMCollection;

@interface RLMOwnableCollection<__covariant Confined : id <RLMThreadConfined>> : NSObject

@property(nonatomic, strong, readonly) RLMThreadSafeReference *__nonnull threadConfined;
@property(nonatomic, strong, readonly) RLMRealm *__nonnull realm;

- (__nonnull instancetype)initWithItems:(id<RLMCollection> __nonnull)items;

- (__nonnull instancetype)initWithThreadConfined:(RLMThreadSafeReference *__nonnull)threadConfined
                                           realm:(RLMRealm *__nonnull)realm;

- (__nonnull Confined)take;

@end
```

With implementation . . . 

```objc
@implementation RLMOwnableCollection

- (instancetype)initWithItems:(id<RLMCollection>)items {
    if (items.realm != nil) {
        id reference = [RLMThreadSafeReference referenceWithThreadConfined:items];
        return [self initWithThreadConfined:reference realm:items.realm];
    } else {
        [NSException raise:NSInternalInconsistencyException format:@"Item realm can't be nil"];
        return nil;
    }
}

- (instancetype)initWithThreadConfined:(RLMThreadSafeReference *)threadConfined realm:(RLMRealm *)realm {
    self = [super init];
    if (self) {
        _threadConfined = threadConfined;
        _realm = realm;
    }
    return self;
}

- (id)take {
    id result = [_realm resolveThreadSafeReference:_threadConfined];
    if (result) {
        return result;
    } else {
        [NSException raise:NSInternalInconsistencyException format:@"Object was deleted in another thread"];
        return nil;
    }
}


@end
```

And it has a little Swift wrapper around it: 


```swift
public class OwnableResults<T: RealmCollectionValue> {

    private(set) var ownableCollection: RLMOwnableCollection<RLMCollection>

    public init(_ results: Results<T>) {
        ownableCollection = RLMOwnableCollection(items: results.collection)
    }

    public func take() throws -> Results<T> {
        Results<T>(collection: ownableCollection.take())
    }
}
```

Again we could probably have a single `Ownable<T>` class that works for anything that's bound to a realm, but this is a proof of concept. 

### Notes

Note that docs state you can pass an object to between threads, but they don't address what to do if the object is not yet in a realm, so users get confused, like in this StackOverflow issue: 

* https://stackoverflow.com/questions/57617719/how-to-save-normal-array-into-realm-in-background-thread-swift

^-- We can see how its useful to address whether the object is already in a Realm or not. However doing this every time is a lot of boiler-plate, so its useful to have a wrapper to handle it. 

Here are some other issues where folks are struggling with threading: 

* https://stackoverflow.com/questions/67336606/reaching-realm-results-object-from-different-thread-gives-crash
* https://stackoverflow.com/questions/37525964/how-to-deal-with-thread-and-realm-ios