### PR TITLE
Flexible Sync: Additive Changes V1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,11 @@ allows submitting to the app store with Xcode 12.
   Realm or if `objectTypes` was set when opening a Realm would throw an
   exception ([#7786](https://github.com/realm/realm-swift/issues/7786)).
 
-<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
+### Breaking Changes
+
+* Rename `SyncSubscriptionSet.write` to `SyncSubscriptionSet.update` to avoid confusion with `Realm.write`.
+* Rename `SyncSubscription.update` to `SyncSubscription.updateQuery` to avoid confusion with `SyncSubscriptionSet.update`.
+* Rename `RLMSyncSubscriptionSet.write` to `RLMSyncSubscriptionSet.update` to align it with swift API.
 
 ### Compatibility
 * Realm Studio: 11.0.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,13 +44,13 @@ allows submitting to the app store with Xcode 12.
 ```
 * Improve performance of opening a Realm with `objectClasses`/`objectTypes` set
   in the configuration.
-* Replace Xcode 13.3 binaries with 13.3.1 binaries.
 * Allow adding a subscription querying for all documents of a type in swift for flexible sync.
 ```
    try await subscriptions.update {
       subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_15"))
    }
 ```
+* Add Combine API support for flexible sync beta.
 
 ### Fixed
 * Consuming a RealmSwift XCFramework with library evolution enabled would give the error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@ allows submitting to the app store with Xcode 12.
 ```
 * Improve performance of opening a Realm with `objectClasses`/`objectTypes` set
   in the configuration.
+* Replace Xcode 13.3 binaries with 13.3.1 binaries.
+* Allow adding a subscription querying for all documents of a type in swift for flexible sync.
+```
+   try await subscriptions.update {
+      subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_15"))
+   }
+```
 
 ### Fixed
 * Consuming a RealmSwift XCFramework with library evolution enabled would give the error

--- a/Realm/ObjectServerTests/RLMFlexibleSyncServerTests.mm
+++ b/Realm/ObjectServerTests/RLMFlexibleSyncServerTests.mm
@@ -87,7 +87,7 @@
     XCTAssertEqual(subs.version, 0UL);
     XCTAssertEqual(subs.count, 0UL);
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                                      where:@"age > 15"];
     }];
@@ -103,7 +103,7 @@
     XCTAssertEqual(subs.version, 0UL);
     XCTAssertEqual(subs.count, 0UL);
 
-    [subs write:^{
+    [subs update:^{
     }];
 
     XCTAssertEqual(subs.version, 1UL);
@@ -114,7 +114,7 @@
     RLMRealm *realm = [self openFlexibleSyncRealm:_cmd];
     RLMSyncSubscriptionSet *subs = realm.subscriptions;
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                                      where:@"age > 15"];
     }];
@@ -133,7 +133,7 @@
     XCTAssertEqual(subs.version, 0UL);
     XCTAssertEqual(subs.count, 0UL);
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                                      where:@"firstName == %@ and lastName == %@", @"John", @"Doe"];
     }];
@@ -155,7 +155,7 @@
     XCTAssertEqual(subs.version, 0UL);
     XCTAssertEqual(subs.count, 0UL);
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                                  predicate:[NSPredicate predicateWithFormat:@"age == %d", 20]];
     }];
@@ -184,7 +184,7 @@
     XCTAssertEqual(realm.subscriptions.version, 0UL);
     XCTAssertEqual(realm.subscriptions.count, 0UL);
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                           subscriptionName:@"person_older_15"
                                      where:@"age > 15"];
@@ -200,7 +200,7 @@
     RLMRealm *realm = [self openFlexibleSyncRealm:_cmd];
     RLMSyncSubscriptionSet *subs = realm.subscriptions;
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                                      where:@"age > 15"];
         [subs addSubscriptionWithClassName:Person.className
@@ -215,7 +215,7 @@
     RLMRealm *realm = [self openFlexibleSyncRealm:_cmd];
     RLMSyncSubscriptionSet *subs = realm.subscriptions;
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                           subscriptionName:@"person_age"
                                      where:@"age > 15"];
@@ -240,7 +240,7 @@
     RLMRealm *realm = [self openFlexibleSyncRealm:_cmd];
     RLMSyncSubscriptionSet *subs = realm.subscriptions;
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                                      where:@"age > 15"];
         [subs addSubscriptionWithClassName:Person.className
@@ -255,7 +255,7 @@
     RLMRealm *realm = [self openFlexibleSyncRealm:_cmd];
     RLMSyncSubscriptionSet *subs = realm.subscriptions;
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                           subscriptionName:@"person_age_1"
                                      where:@"age > 15"];
@@ -282,7 +282,7 @@
     RLMRealm *realm = [self openFlexibleSyncRealm:_cmd];
     RLMSyncSubscriptionSet *subs = realm.subscriptions;
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                           subscriptionName:@"person_age_1"
                                      where:@"age > 15"];
@@ -298,7 +298,7 @@
     RLMRealm *realm = [self openFlexibleSyncRealm:_cmd];
     RLMSyncSubscriptionSet *subs = realm.subscriptions;
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                                  predicate:[NSPredicate predicateWithFormat:@"age > %d", 15]];
         [subs addSubscriptionWithClassName:Person.className
@@ -314,13 +314,13 @@
     RLMRealm *realm = [self openFlexibleSyncRealm:_cmd];
     RLMSyncSubscriptionSet *subs = realm.subscriptions;
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                           subscriptionName:@"person_age_1"
                                      where:@"age > 15"];
     }];
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                           subscriptionName:@"person_age_2"
                                  predicate:[NSPredicate predicateWithFormat:@"age > %d", 20]];
@@ -340,7 +340,7 @@
     RLMRealm *realm = [self openFlexibleSyncRealm:_cmd];
     RLMSyncSubscriptionSet *subs = realm.subscriptions;
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                           subscriptionName:@"person_age_1"
                                      where:@"age > 15"];
@@ -352,7 +352,7 @@
     XCTAssertEqual(subs.version, 1UL);
     XCTAssertEqual(subs.count, 2UL);
 
-    [subs write:^{
+    [subs update:^{
         [subs removeSubscriptionWithName:@"person_age_1"];
     }];
 
@@ -370,7 +370,7 @@
     RLMRealm *realm = [self openFlexibleSyncRealm:_cmd];
     RLMSyncSubscriptionSet *subs = realm.subscriptions;
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                           subscriptionName:@"person_age_1"
                                      where:@"age > 15"];
@@ -385,7 +385,7 @@
     RLMRealm *realm = [self openFlexibleSyncRealm:_cmd];
     RLMSyncSubscriptionSet *subs = realm.subscriptions;
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                           subscriptionName:@"person_age"
                                      where:@"age > 15"];
@@ -400,7 +400,7 @@
     XCTAssertEqual(subs.version, 1UL);
     XCTAssertEqual(subs.count, 3UL);
 
-    [subs write:^{
+    [subs update:^{
         [subs removeSubscriptionWithClassName:Person.className where:@"firstName == %@", @"John"];
         [subs removeSubscriptionWithClassName:Person.className predicate:[NSPredicate predicateWithFormat:@"lastName == %@", @"Doe"]];
     }];
@@ -422,7 +422,7 @@
     RLMRealm *realm = [self openFlexibleSyncRealm:_cmd];
     RLMSyncSubscriptionSet *subs = realm.subscriptions;
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                           subscriptionName:@"person_age"
                                      where:@"age > 15"];
@@ -440,7 +440,7 @@
     RLMSyncSubscription *foundSubscription = [subs subscriptionWithName:@"person_age"];
     XCTAssertNotNil(foundSubscription);
 
-    [subs write:^{
+    [subs update:^{
         [subs removeSubscription:foundSubscription];
     }];
 
@@ -450,7 +450,7 @@
     RLMSyncSubscription *foundSubscription2 = [subs subscriptionWithName:@"person_firstname"];
     XCTAssertNotNil(foundSubscription2);
 
-    [subs write:^{
+    [subs update:^{
         [subs removeSubscription:foundSubscription2];
     }];
 
@@ -462,7 +462,7 @@
     RLMRealm *realm = [self openFlexibleSyncRealm:_cmd];
     RLMSyncSubscriptionSet *subs = realm.subscriptions;
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                           subscriptionName:@"person_age"
                                      where:@"age > 15"];
@@ -477,7 +477,7 @@
     XCTAssertEqual(subs.version, 1UL);
     XCTAssertEqual(subs.count, 3UL);
 
-    [subs write:^{
+    [subs update:^{
         [subs removeAllSubscriptions];
     }];
 
@@ -492,7 +492,7 @@
     RLMRealm *realm = [self openFlexibleSyncRealm:_cmd];
     RLMSyncSubscriptionSet *subs = realm.subscriptions;
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                           subscriptionName:@"person_age"
                                      where:@"age > 15"];
@@ -507,7 +507,7 @@
     XCTAssertEqual(subs.version, 1UL);
     XCTAssertEqual(subs.count, 3UL);
 
-    [subs write:^{
+    [subs update:^{
         [subs removeAllSubscriptionsWithClassName:Person.className];
     }];
 
@@ -517,7 +517,7 @@
     RLMSyncSubscription *foundSubscription = [subs subscriptionWithName:@"dog_name"];
     XCTAssertNotNil(foundSubscription);
 
-    [subs write:^{
+    [subs update:^{
         [subs removeAllSubscriptionsWithClassName:Dog.className];
     }];
 
@@ -529,7 +529,7 @@
     RLMRealm *realm = [self openFlexibleSyncRealm:_cmd];
     RLMSyncSubscriptionSet *subs = realm.subscriptions;
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                           subscriptionName:@"person_age"
                                      where:@"age > 15"];
@@ -541,7 +541,7 @@
     RLMSyncSubscription *foundSubscription = [subs subscriptionWithName:@"person_age"];
     XCTAssertNotNil(foundSubscription);
 
-    [subs write:^{
+    [subs update:^{
         [foundSubscription updateSubscriptionWhere:@"age > 20"];
     }];
 
@@ -558,7 +558,7 @@
     RLMRealm *realm = [self openFlexibleSyncRealm:_cmd];
     RLMSyncSubscriptionSet *subs = realm.subscriptions;
 
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                           subscriptionName:@"subscription_1"
                                      where:@"age > 15"];
@@ -578,7 +578,7 @@
     RLMSyncSubscriptionSet *subs = realm.subscriptions;
 
     double numberOfSubs = 100;
-    [subs write:^{
+    [subs update:^{
         for (int i = 0; i < numberOfSubs; ++i) {
             [subs addSubscriptionWithClassName:Person.className
                               subscriptionName:[NSString stringWithFormat:@"person_age_%d", i]
@@ -609,7 +609,7 @@
     XCTAssertNil(subs.lastObject);
 
     int numberOfSubs = 20;
-    [subs write:^{
+    [subs update:^{
         for (int i = 1; i <= numberOfSubs; ++i) {
             [subs addSubscriptionWithClassName:Person.className
                               subscriptionName:[NSString stringWithFormat:@"person_age_%d", i]
@@ -636,7 +636,7 @@
     XCTAssertEqual(subs.count, 0UL);
 
     int numberOfSubs = 20;
-    [subs write:^{
+    [subs update:^{
         for (int i = 1; i <= numberOfSubs; ++i) {
             [subs addSubscriptionWithClassName:Person.className
                               subscriptionName:[NSString stringWithFormat:@"person_age_%d", i]

--- a/Realm/ObjectServerTests/RLMSyncTestCase.mm
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.mm
@@ -706,7 +706,7 @@ static NSURL *syncDirectoryForChildProcess() {
     XCTAssertNotNil(subs);
 
     XCTestExpectation *ex = [self expectationWithDescription:@"state change complete"];
-    [subs write:^{
+    [subs update:^{
         [subs addSubscriptionWithClassName:Person.className
                           subscriptionName:@"person_all"
                                      where:@"TRUEPREDICATE"];
@@ -732,7 +732,7 @@ static NSURL *syncDirectoryForChildProcess() {
     XCTAssertNotNil(subs);
 
     XCTestExpectation *ex = [self expectationWithDescription:@"state changes"];
-    [subs write:^{
+    [subs update:^{
         block(subs);
     } onComplete:^(NSError* error) {
         if (error == nil) {

--- a/Realm/ObjectServerTests/RealmServer.swift
+++ b/Realm/ObjectServerTests/RealmServer.swift
@@ -119,6 +119,7 @@ private extension ObjectSchema {
                 "bsonType": "\(partitionKeyType)"
             ]
         ]
+
         var relationships: [String: Any] = [:]
         for property in properties {
             // First pass we only add the properties to the schema as we can't add

--- a/Realm/ObjectServerTests/SwiftFlexibleSyncServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftFlexibleSyncServerTests.swift
@@ -67,7 +67,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func testWriteEmptyBlock() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
         }
 
         XCTAssertEqual(subscriptions.count, 0)
@@ -76,7 +76,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func testAddOneSubscriptionWithoutName() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(QuerySubscription<SwiftPerson> {
                 $0.age > 15
             })
@@ -88,7 +88,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func testAddOneSubscriptionWithName() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age") {
                 $0.age > 15
             })
@@ -100,12 +100,12 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func testAddSubscriptionsInDifferentBlocks() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age") {
                 $0.age > 15
             })
         }
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(QuerySubscription<SwiftTypesSyncObject> {
                 $0.boolCol == true
             })
@@ -117,7 +117,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func testAddSeveralSubscriptionsWithoutName() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(
                 QuerySubscription<SwiftPerson> {
                     $0.age > 15
@@ -136,7 +136,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func testAddSeveralSubscriptionsWithName() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(
                 QuerySubscription<SwiftPerson>(name: "person_age_15") {
                     $0.age > 15
@@ -154,7 +154,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func testAddMixedSubscriptions() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_15") {
                 $0.age > 15
             })
@@ -172,7 +172,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func testAddDuplicateSubscriptions() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(
                 QuerySubscription<SwiftPerson> {
                     $0.age > 15
@@ -187,7 +187,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func testAddDuplicateSubscriptionWithDifferentName() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(
                 QuerySubscription<SwiftPerson>(name: "person_age_1") {
                     $0.age > 15
@@ -203,7 +203,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func skip_testSameNamedSubscriptionThrows() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_1") {
                 $0.age > 15
             })
@@ -226,7 +226,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func testFindSubscriptionByName() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(
                 QuerySubscription<SwiftPerson>(name: "person_age_15") {
                     $0.age > 15
@@ -249,7 +249,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func testFindSubscriptionByQuery() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_firstname_james") {
                 $0.firstName == "James"
             })
@@ -275,7 +275,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func testRemoveSubscriptionByName() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_firstname_james") {
                 $0.firstName == "James"
             })
@@ -289,7 +289,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         }
         XCTAssertEqual(subscriptions.count, 3)
 
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.remove(named: "person_firstname_james")
         }
         XCTAssertEqual(subscriptions.count, 2)
@@ -298,7 +298,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func testRemoveSubscriptionByQuery() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(
                 QuerySubscription<SwiftPerson> {
                     $0.firstName == "Alex"
@@ -315,7 +315,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         }
         XCTAssertEqual(subscriptions.count, 4)
 
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.remove(ofType: SwiftPerson.self, {
                 $0.firstName == "Alex"
             })
@@ -332,7 +332,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func testRemoveSubscription() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_names") {
                 $0.firstName != "Alex" && $0.lastName != "Roy"
             })
@@ -344,7 +344,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
 
         let foundSubscription1 = subscriptions.first(named: "person_names")
         XCTAssertNotNil(foundSubscription1)
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.remove(foundSubscription1!)
         }
 
@@ -354,7 +354,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
             $0.intCol > 0
         })
         XCTAssertNotNil(foundSubscription2)
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.remove(foundSubscription2!)
         }
 
@@ -364,7 +364,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func testRemoveSubscriptionsByType() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(
                 QuerySubscription<SwiftPerson> {
                     $0.firstName == "Alex"
@@ -381,12 +381,12 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         }
         XCTAssertEqual(subscriptions.count, 4)
 
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.removeAll(ofType: SwiftPerson.self)
         }
         XCTAssertEqual(subscriptions.count, 1)
 
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.removeAll(ofType: SwiftTypesSyncObject.self)
         }
         XCTAssertEqual(subscriptions.count, 0)
@@ -395,7 +395,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func testRemoveAllSubscriptions() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(
                 QuerySubscription<SwiftPerson> {
                     $0.firstName == "Alex"
@@ -412,7 +412,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         }
         XCTAssertEqual(subscriptions.count, 4)
 
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.removeAll()
         }
 
@@ -424,7 +424,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         let subscriptions = realm.subscriptions
 
         let numberOfSubs = 50
-        subscriptions.write {
+        subscriptions.update {
             for i in 1...numberOfSubs {
                 subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_\(i)") {
                     $0.age > i
@@ -448,7 +448,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         let subscriptions = realm.subscriptions
 
         let numberOfSubs = 20
-        subscriptions.write {
+        subscriptions.update {
             for i in 1...numberOfSubs {
                 subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_\(i)") {
                     $0.age > i
@@ -472,7 +472,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         let subscriptions = realm.subscriptions
 
         let numberOfSubs = 20
-        subscriptions.write {
+        subscriptions.update {
             for i in 1...numberOfSubs {
                 subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_\(i)") {
                     $0.age > i
@@ -494,7 +494,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func testUpdateQueries() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(
                 QuerySubscription<SwiftPerson>(name: "person_age_15") {
                     $0.age > 15
@@ -508,9 +508,9 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         let foundSubscription1 = subscriptions.first(named: "person_age_15")
         let foundSubscription2 = subscriptions.first(named: "person_age_20")
 
-        subscriptions.write {
-            foundSubscription1?.update(toType: SwiftPerson.self, where: { $0.age > 0 })
-            foundSubscription2?.update(toType: SwiftPerson.self, where: { $0.age > 0 })
+        subscriptions.update {
+            foundSubscription1?.updateQuery(toType: SwiftPerson.self, where: { $0.age > 0 })
+            foundSubscription2?.updateQuery(toType: SwiftPerson.self, where: { $0.age > 0 })
         }
 
         XCTAssertEqual(subscriptions.count, 2)
@@ -519,7 +519,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func testUpdateQueriesWithoutName() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(
                 QuerySubscription<SwiftPerson> {
                     $0.age > 15
@@ -537,9 +537,9 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
             $0.age > 20
         })
 
-        subscriptions.write {
-            foundSubscription1?.update(toType: SwiftPerson.self, where: { $0.age > 0 })
-            foundSubscription2?.update(toType: SwiftPerson.self, where: { $0.age > 5 })
+        subscriptions.update {
+            foundSubscription1?.updateQuery(toType: SwiftPerson.self, where: { $0.age > 0 })
+            foundSubscription2?.updateQuery(toType: SwiftPerson.self, where: { $0.age > 5 })
         }
 
         XCTAssertEqual(subscriptions.count, 2)
@@ -549,7 +549,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func skip_testFlexibleSyncAppUpdateQueryWithDifferentObjectTypeWillThrow() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(
                 QuerySubscription<SwiftPerson>(name: "person_age_15") {
                     $0.age > 15
@@ -559,8 +559,8 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
 
         let foundSubscription1 = subscriptions.first(named: "person_age_15")
 
-        subscriptions.write {
-            assertThrows(foundSubscription1?.update(toType: SwiftTypesSyncObject.self, where: { $0.intCol > 0 }))
+        subscriptions.update {
+            assertThrows(foundSubscription1?.updateQuery(toType: SwiftTypesSyncObject.self, where: { $0.intCol > 0 }))
         }
     }
 
@@ -568,7 +568,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     func testFlexibleSyncTransactionsWithPredicateFormatAndNSPredicate() throws {
         let realm = try openFlexibleSyncRealm()
         let subscriptions = realm.subscriptions
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.append(
                 QuerySubscription<SwiftPerson>(name: "name_alex", where: "firstName == %@", "Alex"),
                 QuerySubscription<SwiftPerson>(name: "name_charles", where: "firstName == %@", "Charles"),
@@ -582,12 +582,12 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         let foundSubscription2 = subscriptions.first(ofType: SwiftTypesSyncObject.self, where: NSPredicate(format: "intCol > 0"))
         XCTAssertNotNil(foundSubscription2)
 
-        subscriptions.write {
+        subscriptions.update {
             subscriptions.remove(ofType: SwiftPerson.self, where: NSPredicate(format: "firstName == 'Belle'"))
             subscriptions.remove(ofType: SwiftPerson.self, where: "firstName == %@", "Charles")
 
-            foundSubscription1?.update(to: NSPredicate(format: "lastName == 'Wightman'"))
-            foundSubscription2?.update(to: "stringCol == %@", "string")
+            foundSubscription1?.updateQuery(to: NSPredicate(format: "lastName == 'Wightman'"))
+            foundSubscription2?.updateQuery(to: "stringCol == %@", "string")
         }
 
         XCTAssertEqual(subscriptions.count, 2)
@@ -638,7 +638,7 @@ class SwiftFlexibleSyncServerTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 0)
 
         let ex = expectation(description: "state change complete")
-        subscriptions.write({
+        subscriptions.update({
             subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_15") {
                 $0.age > 15 && $0.firstName == "\(#function)"
             })
@@ -678,7 +678,7 @@ class SwiftFlexibleSyncServerTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 0)
 
         let ex = expectation(description: "state change complete")
-        subscriptions.write({
+        subscriptions.update({
             subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_10") {
                 $0.age > 10 && $0.firstName == "\(#function)"
             })
@@ -721,7 +721,7 @@ class SwiftFlexibleSyncServerTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 0)
 
         let ex = expectation(description: "state change complete")
-        subscriptions.write({
+        subscriptions.update({
             subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_5") {
                 $0.age > 5 && $0.firstName == "\(#function)"
             })
@@ -742,7 +742,7 @@ class SwiftFlexibleSyncServerTests: SwiftSyncTestCase {
         checkCount(expected: 1, realm, SwiftTypesSyncObject.self)
 
         let ex2 = expectation(description: "state change complete")
-        subscriptions.write({
+        subscriptions.update({
             subscriptions.remove(named: "person_age_5")
         }, onComplete: { error in
             if error == nil {
@@ -780,7 +780,7 @@ class SwiftFlexibleSyncServerTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 0)
 
         let ex = expectation(description: "state change complete")
-        subscriptions.write({
+        subscriptions.update({
             subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_5") {
                 $0.age > 5 && $0.firstName == "\(#function)"
             })
@@ -802,7 +802,7 @@ class SwiftFlexibleSyncServerTests: SwiftSyncTestCase {
         checkCount(expected: 1, realm, SwiftTypesSyncObject.self)
 
         let ex2 = expectation(description: "state change complete")
-        subscriptions.write({
+        subscriptions.update({
             subscriptions.removeAll()
             subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_20") {
                 $0.age > 20 && $0.firstName == "\(#function)"
@@ -843,7 +843,7 @@ class SwiftFlexibleSyncServerTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 0)
 
         let ex = expectation(description: "state change complete")
-        subscriptions.write({
+        subscriptions.update({
             subscriptions.append(
                 QuerySubscription<SwiftPerson>(name: "person_age_5") {
                     $0.age > 20 && $0.firstName == "\(#function)"
@@ -868,7 +868,7 @@ class SwiftFlexibleSyncServerTests: SwiftSyncTestCase {
         checkCount(expected: 1, realm, SwiftTypesSyncObject.self)
 
         let ex2 = expectation(description: "state change complete")
-        subscriptions.write({
+        subscriptions.update({
             subscriptions.removeAll(ofType: SwiftPerson.self)
         }, onComplete: { error in
             if error == nil {
@@ -903,7 +903,7 @@ class SwiftFlexibleSyncServerTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 0)
 
         let ex = expectation(description: "state change complete")
-        subscriptions.write({
+        subscriptions.update({
             subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age") {
                 $0.age > 20 && $0.firstName == "\(#function)"
             })
@@ -923,8 +923,8 @@ class SwiftFlexibleSyncServerTests: SwiftSyncTestCase {
         XCTAssertNotNil(foundSubscription)
 
         let ex2 = expectation(description: "state change complete")
-        subscriptions.write({
-            foundSubscription?.update(toType: SwiftPerson.self, where: {
+        subscriptions.update({
+            foundSubscription?.updateQuery(toType: SwiftPerson.self, where: {
                 $0.age > 5 && $0.firstName == "\(#function)"
             })
         }, onComplete: { error in
@@ -965,7 +965,7 @@ class SwiftAsyncFlexibleSyncTests: SwiftSyncTestCase {
         let realm = try await Realm(configuration: config)
 
         let subscriptions = realm.subscriptions
-        try await subscriptions.write {
+        try await subscriptions.update {
             subscriptions.append(QuerySubscription<SwiftPerson> {
                 $0.age >= 0
             })
@@ -1000,7 +1000,7 @@ class SwiftAsyncFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertNotNil(subscriptions)
         XCTAssertEqual(subscriptions.count, 0)
 
-        try await subscriptions.write {
+        try await subscriptions.update {
             subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_15") {
                 $0.age > 15 && $0.firstName == "\(#function)"
             })
@@ -1021,7 +1021,7 @@ class SwiftAsyncFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 0)
 
         // should complete
-        try await subscriptions.write {
+        try await subscriptions.update {
             subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_15") {
                 $0.age > 15 && $0.firstName == "\(#function)"
             })
@@ -1029,7 +1029,7 @@ class SwiftAsyncFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.state, .complete)
         // should error
         do {
-            try await subscriptions.write {
+            try await subscriptions.update {
                 subscriptions.append(QuerySubscription<SwiftTypesSyncObject>(name: "swiftObject_longCol") {
                     $0.longCol == Int64(1)
                 })

--- a/Realm/ObjectServerTests/SwiftFlexibleSyncServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftFlexibleSyncServerTests.swift
@@ -19,6 +19,7 @@
 #if os(macOS)
 import RealmSwift
 import XCTest
+import Combine
 
 #if canImport(RealmTestSupport)
 import RealmSwiftSyncTestSupport
@@ -596,6 +597,21 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
 
 // MARK: - Completion Block
 class SwiftFlexibleSyncServerTests: SwiftSyncTestCase {
+    private var cancellables: Set<AnyCancellable> = []
+
+    override class var defaultTestSuite: XCTestSuite {
+        if hasCombine() {
+            return super.defaultTestSuite
+        }
+        return XCTestSuite(name: "\(type(of: self))")
+    }
+
+    override func tearDown() {
+        cancellables.forEach { $0.cancel() }
+        cancellables = []
+        super.tearDown()
+    }
+
     func testFlexibleSyncAppWithoutQuery() throws {
         try populateFlexibleSyncData { realm in
             for i in 1...21 {
@@ -943,7 +959,7 @@ class SwiftFlexibleSyncServerTests: SwiftSyncTestCase {
 
 // MARK: - Async Await
 #if swift(>=5.6) && canImport(_Concurrency)
-@available(macOS 12.0.0, *)
+@available(macOS 12.0, *)
 class SwiftAsyncFlexibleSyncTests: SwiftSyncTestCase {
     override class var defaultTestSuite: XCTestSuite {
         // async/await is currently incompatible with thread sanitizer and will
@@ -954,7 +970,10 @@ class SwiftAsyncFlexibleSyncTests: SwiftSyncTestCase {
         }
         return super.defaultTestSuite
     }
+}
 
+@available(macOS 12.0, *)
+extension SwiftFlexibleSyncServerTests {
     @MainActor
     private func populateFlexibleSyncData(_ block: @escaping (Realm) -> Void) async throws {
         var config = (try await self.flexibleSyncApp.login(credentials: .anonymous)).flexibleSyncConfiguration()
@@ -1078,6 +1097,82 @@ class SwiftAsyncFlexibleSyncTests: SwiftSyncTestCase {
     }
 
 }
-
 #endif // canImport(_Concurrency)
+
+// MARK: - Combine
+#if !(os(iOS) && (arch(i386) || arch(arm)))
+@available(macOS 10.15, *)
+extension SwiftFlexibleSyncServerTests {
+    func testFlexibleSyncCombineWrite() throws {
+        try populateFlexibleSyncData { realm in
+            for i in 1...21 {
+                let person = SwiftPerson(firstName: "\(#function)",
+                                         lastName: "lastname_\(i)",
+                                         age: i)
+                realm.add(person)
+            }
+        }
+
+        let realm = try flexibleSyncRealm()
+        XCTAssertNotNil(realm)
+        checkCount(expected: 0, realm, SwiftPerson.self)
+
+        let subscriptions = realm.subscriptions
+        XCTAssertNotNil(subscriptions)
+        XCTAssertEqual(subscriptions.count, 0)
+
+        let ex = expectation(description: "state change complete")
+        subscriptions.updateSubscriptions {
+            subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_10") {
+                $0.age > 10 && $0.firstName == "\(#function)"
+            })
+        }
+        .sink(receiveCompletion: { _ in },
+              receiveValue: { _ in
+            ex.fulfill()
+        }).store(in: &cancellables)
+
+        waitForExpectations(timeout: 20.0, handler: nil)
+
+        waitForDownloads(for: realm)
+        checkCount(expected: 11, realm, SwiftPerson.self)
+    }
+
+    func testFlexibleSyncCombineWriteFails() throws {
+        let realm = try flexibleSyncRealm()
+        XCTAssertNotNil(realm)
+        checkCount(expected: 0, realm, SwiftPerson.self)
+
+        let subscriptions = realm.subscriptions
+        XCTAssertNotNil(subscriptions)
+        XCTAssertEqual(subscriptions.count, 0)
+
+        let ex = expectation(description: "state change error")
+        subscriptions.updateSubscriptions {
+            subscriptions.append(QuerySubscription<SwiftTypesSyncObject>(name: "swiftObject_longCol") {
+                $0.longCol == Int64(1)
+            })
+        }
+        .sink(receiveCompletion: { result in
+            if case .failure(let error) = result {
+                if let error = error as NSError? {
+                    XCTAssertTrue(error.domain == RLMFlexibleSyncErrorDomain)
+                    XCTAssertTrue(error.code == 2)
+                }
+
+                guard case .error = subscriptions.state else {
+                    return XCTFail("Adding a query for a not queryable field should change the subscription set state to error")
+                }
+                ex.fulfill()
+            }
+        }, receiveValue: { _ in })
+        .store(in: &cancellables)
+
+        waitForExpectations(timeout: 20.0, handler: nil)
+
+        waitForDownloads(for: realm)
+        checkCount(expected: 0, realm, SwiftPerson.self)
+    }
+}
+#endif // canImport(Combine)
 #endif // os(macOS)

--- a/Realm/ObjectServerTests/SwiftSyncTestCase.swift
+++ b/Realm/ObjectServerTests/SwiftSyncTestCase.swift
@@ -243,8 +243,8 @@ open class SwiftSyncTestCase: RLMSyncTestCase {
         XCTAssertNotNil(subscriptions)
         let ex = expectation(description: "state change complete")
         subscriptions.update({
-            subscriptions.append(QuerySubscription<SwiftPerson>(where: "TRUEPREDICATE"))
-            subscriptions.append(QuerySubscription<SwiftTypesSyncObject>(where: "TRUEPREDICATE"))
+            subscriptions.append(QuerySubscription<SwiftPerson>())
+            subscriptions.append(QuerySubscription<SwiftTypesSyncObject>())
         }, onComplete: { error in
             XCTAssertNil(error)
             ex.fulfill()

--- a/Realm/ObjectServerTests/SwiftSyncTestCase.swift
+++ b/Realm/ObjectServerTests/SwiftSyncTestCase.swift
@@ -242,7 +242,7 @@ open class SwiftSyncTestCase: RLMSyncTestCase {
         let subscriptions = realm.subscriptions
         XCTAssertNotNil(subscriptions)
         let ex = expectation(description: "state change complete")
-        subscriptions.write({
+        subscriptions.update({
             subscriptions.append(QuerySubscription<SwiftPerson>(where: "TRUEPREDICATE"))
             subscriptions.append(QuerySubscription<SwiftTypesSyncObject>(where: "TRUEPREDICATE"))
         }, onComplete: { error in

--- a/Realm/RLMSyncSubscription.h
+++ b/Realm/RLMSyncSubscription.h
@@ -112,7 +112,9 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param block The block containing actions to perform to the subscription set.
  */
-- (void)write:(__attribute__((noescape)) void(^)(void))block;
+- (void)update:(__attribute__((noescape)) void(^)(void))block;
+
+- (void)write:(__attribute__((noescape)) void(^)(void))block __attribute__((unavailable("Use update")));
 
 /**
  Synchronously performs any transactions (add/remove/update) to the subscription set within the block,
@@ -123,7 +125,9 @@ NS_ASSUME_NONNULL_BEGIN
  @param onComplete The block called upon synchronization of subscriptions to the server. Otherwise
                    an `Error`describing what went wrong will be returned by the block
  */
-- (void)write:(__attribute__((noescape)) void(^)(void))block onComplete:(void(^)(NSError * _Nullable))onComplete;
+- (void)update:(__attribute__((noescape)) void(^)(void))block onComplete:(void(^)(NSError * _Nullable))onComplete;
+
+- (void)write:(__attribute__((noescape)) void(^)(void))block onComplete:(void(^)(NSError * _Nullable))onComplete __attribute__((unavailable("Use update")));
 
 #pragma mark - Find subscription
 

--- a/Realm/RLMSyncSubscription.h
+++ b/Realm/RLMSyncSubscription.h
@@ -113,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param block The block containing actions to perform to the subscription set.
  */
 - (void)update:(__attribute__((noescape)) void(^)(void))block;
-
+/// :nodoc:
 - (void)write:(__attribute__((noescape)) void(^)(void))block __attribute__((unavailable("Use update")));
 
 /**
@@ -126,7 +126,7 @@ NS_ASSUME_NONNULL_BEGIN
                    an `Error`describing what went wrong will be returned by the block
  */
 - (void)update:(__attribute__((noescape)) void(^)(void))block onComplete:(void(^)(NSError * _Nullable))onComplete;
-
+/// :nodoc:
 - (void)write:(__attribute__((noescape)) void(^)(void))block onComplete:(void(^)(NSError * _Nullable))onComplete __attribute__((unavailable("Use update")));
 
 #pragma mark - Find subscription

--- a/Realm/RLMSyncSubscription.mm
+++ b/Realm/RLMSyncSubscription.mm
@@ -369,10 +369,7 @@ NSUInteger RLMFastEnumerate(NSFastEnumerationState *state,
     if (name != nil) {
         auto iterator = _mutableSubscriptionSet->find([name UTF8String]);
         
-        if (updateExisting) {
-            _mutableSubscriptionSet->insert_or_assign([name UTF8String], query);
-        }
-        else if (iterator == _mutableSubscriptionSet->end()) {
+        if (updateExisting || iterator == _mutableSubscriptionSet->end()) {
             _mutableSubscriptionSet->insert_or_assign([name UTF8String], query);
         }
         else {

--- a/Realm/RLMSyncSubscription.mm
+++ b/Realm/RLMSyncSubscription.mm
@@ -228,11 +228,11 @@ NSUInteger RLMFastEnumerate(NSFastEnumerationState *state,
 
 #pragma mark - Batch Update subscriptions
 
-- (void)write:(__attribute__((noescape)) void(^)(void))block {
+- (void)update:(__attribute__((noescape)) void(^)(void))block {
     return [self write:block onComplete:^(NSError*){}];
 }
 
-- (void)write:(__attribute__((noescape)) void(^)(void))block
+- (void)update:(__attribute__((noescape)) void(^)(void))block
    onComplete:(void(^)(NSError *))completionBlock {
     if (_mutableSubscriptionSet != nil) {
         @throw RLMException(@"Cannot initiate a write transaction on subscription set that is already been updated.");

--- a/RealmSwift/SyncSubscription.swift
+++ b/RealmSwift/SyncSubscription.swift
@@ -87,11 +87,16 @@ import Realm.Private
      - parameter type: The type of the object to be queried.
      - parameter query: A query which will be used to modify the query.
      */
-    public func update<T: Object>(toType type: T.Type, where query: @escaping (Query<T>) -> Query<Bool>) {
+    public func updateQuery<T: Object>(toType type: T.Type, where query: @escaping (Query<T>) -> Query<Bool>) {
         guard _rlmSyncSubscription.objectClassName == "\(T.self)" else {
             throwRealmException("Updating a subscription query of a different Object Type is not allowed.")
         }
         _rlmSyncSubscription.update(with: query(Query()).predicate)
+    }
+
+    @available(*, deprecated, renamed: "updateQuery", message: "SyncSubscription update is deprecated, please use `.updateQuery` instead.")
+    public func update<T: Object>(toType type: T.Type, where query: @escaping (Query<T>) -> Query<Bool>) {
+        fatalError()
     }
 
     /**
@@ -103,8 +108,13 @@ import Realm.Private
      - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments,
                                   which will be used to modify the query.
      */
-    public func update(to predicateFormat: String, _ args: Any...) {
+    public func updateQuery(to predicateFormat: String, _ args: Any...) {
         _rlmSyncSubscription.update(with: NSPredicate(format: predicateFormat, argumentArray: unwrapOptionals(in: args)))
+    }
+
+    @available(*, deprecated, renamed: "updateQuery", message: "SyncSubscription update is deprecated, please use `.updateQuery` instead.")
+    public func update(to predicateFormat: String, _ args: Any...) {
+        fatalError()
     }
 
     /**
@@ -116,8 +126,13 @@ import Realm.Private
      - parameter predicate: The predicate with which to filter the objects on the server, which
                             will be used to modify the query.
      */
-    public func update(to predicate: NSPredicate) {
+    public func updateQuery(to predicate: NSPredicate) {
         _rlmSyncSubscription.update(with: predicate)
+    }
+
+    @available(*, deprecated, renamed: "updateQuery", message: "SyncSubscription update is deprecated, please use `.updateQuery` instead.")
+    public func update(to predicate: NSPredicate) {
+        fatalError()
     }
 }
 
@@ -199,8 +214,13 @@ import Realm.Private
      - parameter onComplete: The block called upon synchronization of subscriptions to the server. Otherwise
                              an `Error`describing what went wrong will be returned by the block
      */
+    public func update(_ block: (() -> Void), onComplete: ((Error?) -> Void)? = nil) {
+        rlmSyncSubscriptionSet.update(block, onComplete: onComplete ?? { _ in })
+    }
+
+    @available(*, deprecated, renamed: "update", message: "SyncSubscriptionSet write is deprecated, please use `.update` instead.")
     public func write(_ block: (() -> Void), onComplete: ((Error?) -> Void)? = nil) {
-        rlmSyncSubscriptionSet.write(block, onComplete: onComplete ?? { _ in })
+       fatalError()
     }
 
     /// Returns the current state for the subscription set.
@@ -439,9 +459,9 @@ extension SyncSubscriptionSet {
                If `block` throws, the function throws the propagated `ErrorType` instead.
      */
     @MainActor
-    public func write(_ block: (() -> Void)) async throws {
+    public func update(_ block: (() -> Void)) async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            write(block) { error in
+            update(block) { error in
                 if let error = error {
                     continuation.resume(throwing: error)
                 } else {
@@ -449,6 +469,12 @@ extension SyncSubscriptionSet {
                 }
             }
         }
+    }
+
+    @available(*, deprecated, renamed: "update", message: "SyncSubscriptionSet write is deprecated, please use `.update` instead.")
+    @MainActor
+    public func write(_ block: (() -> Void)) async throws {
+        fatalError()
     }
 }
 #endif // swift(>=5.6)

--- a/RealmSwift/SyncSubscription.swift
+++ b/RealmSwift/SyncSubscription.swift
@@ -85,13 +85,13 @@ import Realm.Private
      - warning: This method may only be called during a write subscription block.
 
      - parameter type: The type of the object to be queried.
-     - parameter query: A query which will be used to modify the query.
+     - parameter query: A query which will be used to modify the query, if nil it will set the query to all documents for the collection.
      */
-    public func updateQuery<T: Object>(toType type: T.Type, where query: @escaping (Query<T>) -> Query<Bool>) {
+    public func updateQuery<T: Object>(toType type: T.Type, where query: ((Query<T>) -> Query<Bool>)? = nil) {
         guard _rlmSyncSubscription.objectClassName == "\(T.self)" else {
             throwRealmException("Updating a subscription query of a different Object Type is not allowed.")
         }
-        _rlmSyncSubscription.update(with: query(Query()).predicate)
+        _rlmSyncSubscription.update(with: query?(Query()).predicate ?? NSPredicate(format: "TRUEPREDICATE"))
     }
 
     @available(*, deprecated, renamed: "updateQuery", message: "SyncSubscription update is deprecated, please use `.updateQuery` instead.")
@@ -146,19 +146,16 @@ import Realm.Private
     fileprivate var className: String
     fileprivate var predicate: NSPredicate
 
-    /// :nodoc:
-    public typealias QueryFunction = (Query<T>) -> Query<Bool>
-
     /**
      Creates a `QuerySubscription` for the given type.
 
      - parameter name: Name of the subscription.
-     - parameter query: The query for the subscription.
+     - parameter query: The query for the subscription, if nil it will set the query to all documents for the collection.
      */
-    public init(name: String? = nil, query: @escaping QueryFunction) {
+    public init(name: String? = nil, query: ((Query<T>) -> Query<Bool>)? = nil) {
         self.name = name
         self.className = "\(T.self)"
-        self.predicate = query(Query()).predicate
+        self.predicate = query?(Query()).predicate ?? NSPredicate(format: "TRUEPREDICATE")
     }
 
     /**

--- a/RealmSwift/SyncSubscription.swift
+++ b/RealmSwift/SyncSubscription.swift
@@ -20,6 +20,10 @@ import Foundation
 import Realm
 import Realm.Private
 
+#if !(os(iOS) && (arch(i386) || arch(arm)))
+import Combine
+#endif
+
 /// An enum representing different states for the Subscription Set.
 @frozen public enum SyncSubscriptionState: Equatable {
     /// The subscription is complete and the server has sent all the data that matched the subscription
@@ -94,6 +98,7 @@ import Realm.Private
         _rlmSyncSubscription.update(with: query?(Query()).predicate ?? NSPredicate(format: "TRUEPREDICATE"))
     }
 
+    /// :nodoc:
     @available(*, deprecated, renamed: "updateQuery", message: "SyncSubscription update is deprecated, please use `.updateQuery` instead.")
     public func update<T: Object>(toType type: T.Type, where query: @escaping (Query<T>) -> Query<Bool>) {
         fatalError()
@@ -112,6 +117,7 @@ import Realm.Private
         _rlmSyncSubscription.update(with: NSPredicate(format: predicateFormat, argumentArray: unwrapOptionals(in: args)))
     }
 
+    /// :nodoc:
     @available(*, deprecated, renamed: "updateQuery", message: "SyncSubscription update is deprecated, please use `.updateQuery` instead.")
     public func update(to predicateFormat: String, _ args: Any...) {
         fatalError()
@@ -130,6 +136,7 @@ import Realm.Private
         _rlmSyncSubscription.update(with: predicate)
     }
 
+    /// :nodoc:
     @available(*, deprecated, renamed: "updateQuery", message: "SyncSubscription update is deprecated, please use `.updateQuery` instead.")
     public func update(to predicate: NSPredicate) {
         fatalError()
@@ -204,8 +211,6 @@ import Realm.Private
 
     /**
      Synchronously performs any transactions (add/remove/update) to the subscription set within the block.
-     This will not wait for the server to acknowledge and see all the data associated with this collection of subscriptions,
-     and will return after committing the subscription transactions.
 
      - parameter block:      The block containing the subscriptions transactions to perform.
      - parameter onComplete: The block called upon synchronization of subscriptions to the server. Otherwise
@@ -215,6 +220,7 @@ import Realm.Private
         rlmSyncSubscriptionSet.update(block, onComplete: onComplete ?? { _ in })
     }
 
+    /// :nodoc:
     @available(*, deprecated, renamed: "update", message: "SyncSubscriptionSet write is deprecated, please use `.update` instead.")
     public func write(_ block: (() -> Void), onComplete: ((Error?) -> Void)? = nil) {
        fatalError()
@@ -446,14 +452,13 @@ extension SyncSubscriptionSet: Sequence {
 @available(macOS 10.15, tvOS 13.0, iOS 13.0, watchOS 6.0, *)
 extension SyncSubscriptionSet {
     /**
-     Asynchronously creates and commit a write transaction and updates the subscription set,
-     this will not wait for the server to acknowledge and see all the data associated with this
-     collection of subscription.
+     Synchronously creates and commit a write transaction and updates the subscription set,
+     this will continue when the server acknowledge and all the data associated with this
+     collection of subscriptions is synced.
 
      - parameter block: The block containing the subscriptions transactions to perform.
 
-     - throws: An `NSError` if the transaction could not be completed successfully.
-               If `block` throws, the function throws the propagated `ErrorType` instead.
+     - throws: An `NSError` if the subscription set state changes to an error state or there is and error while                           committing any changes to the subscriptions.
      */
     @MainActor
     public func update(_ block: (() -> Void)) async throws {
@@ -468,10 +473,35 @@ extension SyncSubscriptionSet {
         }
     }
 
+    /// :nodoc:
     @available(*, deprecated, renamed: "update", message: "SyncSubscriptionSet write is deprecated, please use `.update` instead.")
-    @MainActor
     public func write(_ block: (() -> Void)) async throws {
         fatalError()
     }
 }
 #endif // swift(>=5.6)
+
+#if !(os(iOS) && (arch(i386) || arch(arm)))
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension SyncSubscriptionSet {
+    /**
+     Synchronously creates and commit a write transaction and updates the subscription set,
+     this will return success when the server acknowledge and all the data associated with this
+     collection of subscriptions is synced.
+
+     - parameter block: The block containing the subscriptions transactions to perform.
+     - returns: A publisher that eventually returns `Result.success` or `Error`.
+     */
+    public func updateSubscriptions(_ block: @escaping (() -> Void)) -> Future<Void, Error> {
+        return Future<Void, Error> { promise in
+            update(block) { error in
+                if let error = error {
+                    promise(.failure(error))
+                } else {
+                    promise(.success(()))
+                }
+            }
+        }
+    }
+}
+#endif // canImport(Combine)


### PR DESCRIPTION
This is the 1/2 PRs which will include flexible sync additive changes for MDBW.
This PR includes 2 main points on the flexible sync additive changes scope:
* Rename subscriptions `write` to something else, which will not generate confusion with realm `write` block.
* Allow the ability to run a query for all document in a collection easily in swift.

This PR also includes one extra changes:
* Added missing Combine API for flexible sync.
