### PR TITLE
Fix issue with creating a Frozen Realm after writeCopy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ x.y.z Release notes (yyyy-MM-dd)
 * If an async open of a Realm triggered a client reset, the callbacks for
   `discardLocal` could theoretically fail to be called due to a race condition.
   The timing for this was probably not possible to hit in practice (since 10.25.0).
+* Calling `[RLMRealm freeze]`/`Realm.freeze` on a Realm which had been created from `writeCopy`
+  would not produce a frozen Realm. ([#7697](https://github.com/realm/realm-swift/issues/7697), since v5.0.0)
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -436,11 +436,11 @@ static RLMRealm *getCachedRealm(RLMRealmConfiguration *configuration, void *cach
 + (instancetype)realmWithConfiguration:(RLMRealmConfiguration *)configuration
                                  queue:(dispatch_queue_t)queue
                                  error:(NSError **)error {
-    // The main thread and main queue share a cache key of 1 so that they give
-    // the same instance. Other Realms are keyed on either the thread or the queue.
+    // The main thread and main queue share a cache key of `std::numeric_limits<uintptr_t>::max()`
+    // so that they give the same instance. Other Realms are keyed on either the thread or the queue.
     // Note that despite being a void* the cache key is not actually a pointer;
     // this is just an artifact of NSMapTable's strange API.
-    void *cacheKey = reinterpret_cast<void *>(1);
+    void *cacheKey = reinterpret_cast<void *>(std::numeric_limits<uintptr_t>::max());
     if (queue) {
         if (queue != dispatch_get_main_queue()) {
             cacheKey = (__bridge void *)queue;

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -2349,6 +2349,10 @@
     XCTAssertNil(writeError);
     RLMRealm *copy = [self realmWithTestPath];
     XCTAssertEqual(1U, [IntObject allObjectsInRealm:copy].count);
+
+    RLMRealm *frozenCopy = [copy freeze];
+    XCTAssertTrue(frozenCopy.isFrozen);
+    XCTAssertTrue([IntObject allObjectsInRealm:frozenCopy].isFrozen);
 }
 
 - (void)testCannotOverwriteWithWriteCopy
@@ -2486,6 +2490,10 @@
     XCTAssertNil(writeError);
     RLMRealm *copy = [RLMRealm realmWithConfiguration:configuration error:nil];
     XCTAssertEqual(1U, [IntObject allObjectsInRealm:copy].count);
+
+    RLMRealm *frozenCopy = [copy freeze];
+    XCTAssertTrue(frozenCopy.isFrozen);
+    XCTAssertTrue([IntObject allObjectsInRealm:frozenCopy].isFrozen);
 }
 
 - (void)testWritingCopyWithConfigurationUsesWriteTransactionInProgress


### PR DESCRIPTION
Fixes: https://github.com/realm/realm-swift/issues/7697

The issue is that a freshly created realm will not have a ‘metadata’ table. The importance of this is that this table holds the schema version number as m_schema_version will be ’NotVersioned’ a write will be committed and the schema will be cached.

The error occurring using a `writeCopy` Realm after trying to freeze it is that because this copied realm already has a metadata table there is no need to run a write transaction and cache the schema. The write transaction version from the original Realm also will not be copied to the new one.

The freeze method in cocoa relies on the transaction version to be bumped in order to track the new Realm to be frozen. Because the transaction number will always be the same (because it is never bumped) the Realm stored in the NSMapTable will be returned for that key and a new frozen Realm will never be created.

### Solution
Hash both the current transaction version number and a flag of `true` to create a unique key for the frozen Realm. (This is the same as just artificially advancing the version number by one which should be adequate)