### PR TITLE
Fix using the dynamic API on unmanaged objects before shared schema init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ x.y.z Release notes (yyyy-MM-dd)
     }];
     [realm cancelAsyncTransaction:asyncTransactionId];
 ```
+* Improve performance of opening a Realm with `objectClasses`/`objectTypes` set
+  in the configuration.
 
 ### Fixed
 * Consuming a RealmSwift XCFramework with library evolution enabled would give the error
@@ -51,6 +53,9 @@ x.y.z Release notes (yyyy-MM-dd)
   The timing for this was probably not possible to hit in practice (since 10.25.0).
 * Calling `[RLMRealm freeze]`/`Realm.freeze` on a Realm which had been created from `writeCopy`
   would not produce a frozen Realm. ([#7697](https://github.com/realm/realm-swift/issues/7697), since v5.0.0)
+* Using the dynamic subscript API on unmanaged objects before first opening a
+  Realm or if `objectTypes` was set when opening a Realm would throw an
+  exception ([#7786](https://github.com/realm/realm-swift/issues/7786)).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -286,11 +286,9 @@ using namespace realm;
     schema->_unmanagedClass = _unmanagedClass;
     schema->_isSwiftClass = _isSwiftClass;
     schema->_isEmbedded = _isEmbedded;
-
-    // call property setter to reset map and primary key
-    schema.properties = [[NSArray allocWithZone:zone] initWithArray:_properties copyItems:YES];
-    schema.computedProperties = [[NSArray allocWithZone:zone] initWithArray:_computedProperties copyItems:YES];
-
+    schema->_properties = [[NSArray allocWithZone:zone] initWithArray:_properties copyItems:YES];
+    schema->_computedProperties = [[NSArray allocWithZone:zone] initWithArray:_computedProperties copyItems:YES];
+    [schema _propertiesDidChange];
     return schema;
 }
 

--- a/Realm/RLMObjectStore.h
+++ b/Realm/RLMObjectStore.h
@@ -37,14 +37,6 @@ void RLMVerifyHasPrimaryKey(Class cls);
 void RLMVerifyInWriteTransaction(RLMRealm *const realm);
 
 //
-// Accessor Creation
-//
-
-// create or get cached accessors for the given schema
-void RLMRealmCreateAccessors(RLMSchema *schema);
-
-
-//
 // Adding, Removing, Getting Objects
 //
 

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -42,25 +42,6 @@
 
 using namespace realm;
 
-void RLMRealmCreateAccessors(RLMSchema *schema) {
-    const size_t bufferSize = sizeof("RLM:Managed  ") // includes null terminator
-                            + std::numeric_limits<unsigned long long>::digits10
-                            + realm::Group::max_table_name_length;
-
-    char className[bufferSize] = "RLM:Managed ";
-    char *const start = className + strlen(className);
-
-    for (RLMObjectSchema *objectSchema in schema.objectSchema) {
-        if (objectSchema.accessorClass != objectSchema.objectClass) {
-            continue;
-        }
-
-        static unsigned long long count = 0;
-        sprintf(start, "%llu %s", count++, objectSchema.className.UTF8String);
-        objectSchema.accessorClass = RLMManagedAccessorClassForObjectClass(objectSchema.objectClass, objectSchema, className);
-    }
-}
-
 static inline void RLMVerifyRealmRead(__unsafe_unretained RLMRealm *const realm) {
     if (!realm) {
         @throw RLMException(@"Realm must not be nil");

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -564,7 +564,7 @@ static RLMRealm *getCachedRealm(RLMRealmConfiguration *configuration, void *cach
 
         realm->_schema = schema;
         realm->_info = RLMSchemaInfo(realm);
-        RLMRealmCreateAccessors(realm.schema);
+        RLMSchemaEnsureAccessorsCreated(realm.schema);
 
         if (!configuration.readOnly) {
             REALM_ASSERT(!realm->_realm->is_in_read_transaction());

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -276,7 +276,7 @@ static bool isSync(realm::Realm::Config const& config) {
 }
 
 - (void)setObjectClasses:(NSArray *)objectClasses {
-    self.customSchema = objectClasses ? [RLMSchema schemaWithObjectClasses:objectClasses] : nil;
+    _customSchema = objectClasses ? [RLMSchema schemaWithObjectClasses:objectClasses] : nil;
     [self updateSchemaMode];
 }
 

--- a/Realm/RLMSchema_Private.hpp
+++ b/Realm/RLMSchema_Private.hpp
@@ -29,3 +29,8 @@ namespace realm {
 + (instancetype)dynamicSchemaFromObjectStoreSchema:(realm::Schema const&)objectStoreSchema;
 - (realm::Schema)objectStoreCopy;
 @end
+
+// Ensure that all objectSchema in the given schema have managed accessors created.
+// This is normally done during schema discovery but may not be when using
+// dynamically created schemas.
+void RLMSchemaEnsureAccessorsCreated(RLMSchema *schema);

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -1237,6 +1237,17 @@ RLM_COLLECTION_TYPE(NotARealClass)
     RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
     XCTAssertNotNil([realm.schema schemaForClassName:@"OrphanObject"]);
 }
+
+- (void)testDynamicUnmanagedAccessorsBeforeSharedSchemaInit {
+    if (self.isParent) {
+        RLMRunChildAndWait();
+        return;
+    }
+
+    IntObject *io = [IntObject new];
+    io[@"intCol"] = @10;
+    XCTAssertEqualObjects(io[@"intCol"], @10);
+}
 #endif
 
 @end


### PR DESCRIPTION
If the shared schema was never used to open a Realm, the object schema instances in it wouldn't have `accessorClass` set, resulting in `RLMObjectBaseSetObjectForKeyedSubscript()`'s check of `object.class == object->_objectSchema.accessorClass` incorrectly concluding that unmanaged objects were managed. A localized fix for this was possible, but I instead cleaned up some long-standing tech debt and shifted where `accessorClass` is populated to a more appropriate location.

We originally captured the *column index* in the blocks used to create the getters and setters for managed accessor classes. Because column order doesn't have to match the declared property order, this meant that we had to create accessor classes after opening a Realm to be able to capture the appropriate column indices. Early versions of sync broke this: sync originally required that the column order be the same on all clients, which meant that the sync algorithm would reorder columns at runtime and we had to deal with that. To make this work, we switched to capturing the *property index* in the accessor blocks, and then looked up the column index (and in more recent versions, the column key) on each property access. This eliminated the need to create per-Realm accessor classes, but at the time we left the working code alone.

Sync later removed the need for column orders on all clients to match, but the extra indirection of looking up things by property index turned out to be a trivial amount of overhead.

This changes it so that we create the accessor classes at schema discovery time rather than Realm opening time. This fixes the initially reported bug, and should generally improve performance. When using `objectTypes` it was possible to create multiple redundant sets of accessor classes, which should no longer happen. In addition it eliminates some unnecessary copying when using `objectTypes`.

There is still a follow-up check to ensure that accessor classes are set when opening a Realm as it can be unset when dynamically creating RLMObjectSchema instances. This is mostly only applicable to our tests.

Fixes #7786.