### PR TITLE
Lower minimum version for more concurrency extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
+* Lower minimum version async login and functions
 * Add Swift API for asynchronous transactions
 ```
     try? realm.writeAsync {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* Lower minimum version async login and functions
 * Add Swift API for asynchronous transactions
 ```
     try? realm.writeAsync {
@@ -40,6 +39,7 @@ x.y.z Release notes (yyyy-MM-dd)
 ```
 
 ### Fixed
+* Lower minimum OS version for `async` login and FunctionCallables. ([#7791]https://github.com/realm/realm-swift/issues/7791)
 * Consuming a RealmSwift XCFramework with library evolution enabled would give the error
   `'Failed to build module 'RealmSwift'; this SDK is not supported by the compiler'` when the XCFramework was built
   with an older XCode version and is then consumed with a later version. ([#7313](https://github.com/realm/realm-swift/issues/7313), since v3.18.0)

--- a/RealmSwift/App.swift
+++ b/RealmSwift/App.swift
@@ -587,7 +587,7 @@ extension EmailPasswordAuth {
     }
 }
 
-@available(macOS 12.0, tvOS 15.0, iOS 15.0, watchOS 8.0, *)
+@available(macOS 10.15, tvOS 13.0, iOS 13.0, watchOS 6.0, *)
 extension App {
     /// Login to a user for the Realm app.
     /// @param credentials The credentials identifying the user.

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -895,7 +895,7 @@ public extension User {
     }
 }
 
-@available(macOS 12.0, tvOS 15.0, iOS 15.0, watchOS 8.0, *)
+@available(macOS 10.15, tvOS 13.0, iOS 13.0, watchOS 6.0, *)
 extension FunctionCallable {
     /// The implementation of @dynamicMemberLookup that allows  for `async await` callable return.
     ///


### PR DESCRIPTION
It would appear that we missed two more places where we didn't reduce the minimum version of the concurrency module.