### PR TITLE
Revert documentation change to object(ofType:forPrimaryKey:)

### DIFF
--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -785,7 +785,7 @@ public typealias AsyncTransactionId = RLMAsyncTransactionId
 
      - see: `Object.primaryKey()`
 
-     - parameter type: The type of the object to be returned. Your primary key must be one of the following data types: String, Int, ObjectId, or UUID.
+     - parameter type: The type of the object to be returned.
      - parameter key:  The primary key of the desired object.
 
      - returns: An object of type `type`, or `nil` if no instance with the given primary key exists.


### PR DESCRIPTION
I originally approved #7735 because it was consistent with documentation for Object.primaryKey() at Object.swift:146.

This was incorrect because the method itself Realm.object(ofType:forPrimaryKey:) doesn't place such restrictions. Through type projections it's also possible to have a primary key outside those four types.