### PR TITLE
Only call the `initialSubscriptions` callback when it should be called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ x.y.z Release notes (yyyy-MM-dd)
 * Using `seedFilePath` threw an exception if the Realm file being opened
   already existed ([#7840](https://github.com/realm/realm-swift/issues/7840),
   since v10.26.0).
+* The `intialSubscriptions` callback was invoked every time a Realm was opened
+  regardless of the value of `rerunOnOpen` and if the Realm was already open on
+  another thread (since v10.28.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 
@@ -49,10 +52,10 @@ x.y.z Release notes (yyyy-MM-dd)
    }
 ```
 * Add Combine API support for flexible sync beta.
-* Add an `initialSubscriptions` parameter when retrieving the flexible sync configuration from a user, 
-  which allows to specify a subscription update block, to bootstrap a set of flexible sync subscriptions 
+* Add an `initialSubscriptions` parameter when retrieving the flexible sync configuration from a user,
+  which allows to specify a subscription update block, to bootstrap a set of flexible sync subscriptions
   when the Realm is first opened.
-  There is an additional optional parameter flag `rerunOnOpen`, which allows to run this initial 
+  There is an additional optional parameter flag `rerunOnOpen`, which allows to run this initial
   subscriptions on every app startup.
 
 ```swift

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -131,13 +131,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)resetAppCache;
 
-- (void)clearCachedRealms;
-
 #pragma mark Flexible Sync App
 
 @property (nonatomic, readonly) NSString *flexibleSyncAppId;
 @property (nonatomic, readonly) RLMApp *flexibleSyncApp;
 
+- (RLMUser *)flexibleSyncUser:(SEL)testSel;
 - (RLMRealm *)openFlexibleSyncRealm:(SEL)testSel;
 - (RLMRealm *)getFlexibleSyncRealm:(SEL)testSel;
 - (bool)populateData:(void (^)(RLMRealm *))block;

--- a/Realm/ObjectServerTests/RLMSyncTestCase.mm
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.mm
@@ -660,21 +660,21 @@ static NSURL *syncDirectoryForChildProcess() {
     return realm;
 }
 
+- (RLMUser *)flexibleSyncUser:(SEL)testSel {
+    return [self logInUserForCredentials:[self basicCredentialsWithName:NSStringFromSelector(testSel)
+                                                               register:YES
+                                                                    app:self.flexibleSyncApp]
+                                     app:self.flexibleSyncApp];
+}
+
 - (RLMRealm *)getFlexibleSyncRealm:(SEL)testSel {
-    RLMUser *user = [self logInUserForCredentials:[self basicCredentialsWithName:NSStringFromSelector(testSel)
-                                                                        register:YES
-                                                                             app:self.flexibleSyncApp]
-                                              app:self.flexibleSyncApp];
-    RLMRealm *realm = [self flexibleSyncRealmForUser:user];
+    RLMRealm *realm = [self flexibleSyncRealmForUser:[self flexibleSyncUser:testSel]];
     XCTAssertNotNil(realm);
     return realm;
 }
 
 - (RLMRealm *)openFlexibleSyncRealm:(SEL)testSel {
-    RLMUser *user = [self logInUserForCredentials:[self basicCredentialsWithName:NSStringFromSelector(testSel)
-                                                                        register:YES
-                                                                             app:self.flexibleSyncApp]
-                                              app:self.flexibleSyncApp];
+    RLMUser *user = [self flexibleSyncUser:testSel];
     RLMRealmConfiguration *config = [user flexibleSyncConfiguration];
     config.objectClasses = @[Dog.self,
                              Person.self];
@@ -699,8 +699,7 @@ static NSURL *syncDirectoryForChildProcess() {
                                                                              app:self.flexibleSyncApp]
                                               app:self.flexibleSyncApp];
     RLMRealmConfiguration *config = [user flexibleSyncConfiguration];
-    config.objectClasses = @[Dog.self,
-                             Person.self];
+    config.objectClasses = @[Dog.self, Person.self];
     RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
 
     RLMSyncSubscriptionSet *subs = realm.subscriptions;
@@ -745,10 +744,6 @@ static NSURL *syncDirectoryForChildProcess() {
     XCTAssertNotNil(subs);
     [self waitForExpectationsWithTimeout:20.0 handler:nil];
     [self waitForDownloadsForRealm:realm];
-}
-
-- (void)clearCachedRealms {
-    RLMClearRealmCache();
 }
 
 @end

--- a/Realm/ObjectServerTests/SwiftFlexibleSyncServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftFlexibleSyncServerTests.swift
@@ -1242,18 +1242,20 @@ extension SwiftFlexibleSyncServerTests {
         if config.objectTypes == nil {
             config.objectTypes = [SwiftTypesSyncObject.self, SwiftPerson.self]
         }
-        let realm = try await Realm(configuration: config, downloadBeforeOpen: .always)
-        XCTAssertNotNil(realm)
-        XCTAssertEqual(realm.subscriptions.count, 1)
-        checkCount(expected: 9, realm, SwiftTypesSyncObject.self)
+        let c = config
+        _ = try await Task { @MainActor in
+            let realm = try await Realm(configuration: c, downloadBeforeOpen: .always)
+            XCTAssertNotNil(realm)
+            XCTAssertEqual(realm.subscriptions.count, 1)
+            checkCount(expected: 9, realm, SwiftTypesSyncObject.self)
+        }.value
 
-        clearCachedRealms()
-
-        let realm2 = try await Realm(configuration: config, downloadBeforeOpen: .always)
-        XCTAssertNotNil(realm2)
-        XCTAssertEqual(realm.subscriptions.count, 2)
-        XCTAssertEqual(realm2.subscriptions.count, 2)
-        checkCount(expected: 19, realm2, SwiftTypesSyncObject.self)
+        _ = try await Task { @MainActor in
+            let realm = try await Realm(configuration: c, downloadBeforeOpen: .always)
+            XCTAssertNotNil(realm)
+            XCTAssertEqual(realm.subscriptions.count, 2)
+            checkCount(expected: 19, realm, SwiftTypesSyncObject.self)
+        }.value
     }
 
     @MainActor

--- a/Realm/RLMRealmUtil.hpp
+++ b/Realm/RLMRealmUtil.hpp
@@ -31,8 +31,6 @@ void RLMCacheRealm(std::string const& path, void *key, RLMRealm *realm);
 RLMRealm *RLMGetThreadLocalCachedRealmForPath(std::string const& path, void *key);
 // Get a Realm for the given path
 RLMRealm *RLMGetAnyCachedRealmForPath(std::string const& path);
-// return `true` if any cached realm exist for the given path.
-bool RLMAnyCachedRealmExistsForPath(std::string const& path);
 // Clear the weak cache of Realms
 void RLMClearRealmCache();
 

--- a/Realm/RLMRealmUtil.mm
+++ b/Realm/RLMRealmUtil.mm
@@ -54,11 +54,6 @@ RLMRealm *RLMGetAnyCachedRealmForPath(std::string const& path) {
     return [s_realmsPerPath[path] objectEnumerator].nextObject;
 }
 
-bool RLMAnyCachedRealmExistsForPath(std::string const& path) {
-    std::lock_guard<std::mutex> lock(s_realmCacheMutex);
-    return s_realmsPerPath[path].count > 0;
-}
-
 RLMRealm *RLMGetThreadLocalCachedRealmForPath(std::string const& path, void *key) {
     std::lock_guard<std::mutex> lock(s_realmCacheMutex);
     RLMRealm *realm = [s_realmsPerPath[path] objectForKey:(__bridge id)key];

--- a/Realm/RLMSyncConfiguration.h
+++ b/Realm/RLMSyncConfiguration.h
@@ -18,10 +18,10 @@
 
 #import <Foundation/Foundation.h>
 
+@class RLMApp;
 @class RLMRealm;
 @class RLMRealmConfiguration;
 @class RLMUser;
-@class RLMApp;
 @protocol RLMBSON;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Realm/RLMSyncSubscription.mm
+++ b/Realm/RLMSyncSubscription.mm
@@ -281,7 +281,7 @@ NSUInteger RLMFastEnumerate(NSFastEnumerationState *state,
         return [[RLMSyncSubscription alloc] initWithSubscription:*iterator
                                                  subscriptionSet:self];
     }
-    return NULL;
+    return nil;
 }
 
 - (nullable RLMSyncSubscription *)subscriptionWithClassName:(NSString *)objectClassName
@@ -380,14 +380,12 @@ NSUInteger RLMFastEnumerate(NSFastEnumerationState *state,
     RLMClassInfo& info = _realm->_info[objectClassName];
     auto query = RLMPredicateToQuery(predicate, info.rlmObjectSchema, _realm.schema, _realm.group);
     
-    if (name != nil) {
-        auto iterator = _mutableSubscriptionSet->find([name UTF8String]);
-        
-        if (updateExisting || iterator == _mutableSubscriptionSet->end()) {
-            _mutableSubscriptionSet->insert_or_assign([name UTF8String], query);
+    if (name) {
+        if (updateExisting || _mutableSubscriptionSet->find(name.UTF8String) == _mutableSubscriptionSet->end()) {
+            _mutableSubscriptionSet->insert_or_assign(name.UTF8String, query);
         }
         else {
-            @throw RLMException(@"Cannot duplicate a subscription. If you meant to update the subscription please use the `update` method.");
+            @throw RLMException(@"A subscription named '%@' already exists. If you meant to update the existing subscription please use the `update` method.", name);
         }
     }
     else {
@@ -411,8 +409,8 @@ NSUInteger RLMFastEnumerate(NSFastEnumerationState *state,
     va_list args;
     va_start(args, predicateFormat);
     [self removeSubscriptionWithClassName:objectClassName
-                                    where: predicateFormat
-                                     args: args];
+                                    where:predicateFormat
+                                     args:args];
     va_end(args);
 }
 


### PR DESCRIPTION
It was called on every Realm open because the `initializationFunction` which attempted to check if this was the first open was never actually used so `isFirstOpen` was always `false`, and then the code which checked that value inverted the condition and did the logic for first open if `isFirstOpen` was `false` rather than `true`.

The test which attempted to test this did not actually open the Realm a second time.