### PR TITLE
Do not show an error message in cases where  session is already deallocated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,8 +340,6 @@ The prebuilt binary for Carthage is now build with Xcode 14.0.1.
   removing the destination link object.
   ([Core #5574](https://github.com/realm/realm-core/pull/5573), since the introduction of AnyRealmValue in v10.8.0)
 
-<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
-
 ### Compatibility
 
 * Realm Studio: 12.0.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The prebuilt binary for Carthage is now build with Xcode 14.0.1.
 
 ### Fixed
 * Setting a `List` property with `Results` no longer throws an unrecognized selector exception (since 10.8.0-beta.2)
+* Do not show an error message in cases where `RLMProgressNotificationToken` session is already deallocated ([#7831](https://github.com/realm/realm-swift/issues/7831),
+  since v2.3.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 
@@ -337,8 +339,6 @@ The prebuilt binary for Carthage is now build with Xcode 14.0.1.
   such as `mixed.hpp:165: [realm-core-12.1.0] Assertion failed: m_type` when
   removing the destination link object.
   ([Core #5574](https://github.com/realm/realm-core/pull/5573), since the introduction of AnyRealmValue in v10.8.0)
-* Do not show an error message in cases where `RLMProgressNotificationToken` session is already deallocated ([#7831](https://github.com/realm/realm-swift/issues/7831),
-  since v2.3.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ The prebuilt binary for Carthage is now build with Xcode 14.0.1.
 
 ### Fixed
 * Setting a `List` property with `Results` no longer throws an unrecognized selector exception (since 10.8.0-beta.2)
-* Do not show an error message in cases where `RLMProgressNotificationToken` session is already deallocated ([#7831](https://github.com/realm/realm-swift/issues/7831),
-  since v2.3.0).
-
-<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
+* Do not show an error message in cases where `RLMProgressNotificationToken` session is already deallocated. 
+  Now `RLMProgressNotificationToken` and `ProgressNotificationToken` hold a strong reference to the sync session,
+  keeping it alive until the token is deallocated or invalidated. 
+  ([#7831](https://github.com/realm/realm-swift/issues/7831), since v2.3.0).
 
 ### Compatibility
 * Realm Studio: 11.0.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,6 +337,10 @@ The prebuilt binary for Carthage is now build with Xcode 14.0.1.
   such as `mixed.hpp:165: [realm-core-12.1.0] Assertion failed: m_type` when
   removing the destination link object.
   ([Core #5574](https://github.com/realm/realm-core/pull/5573), since the introduction of AnyRealmValue in v10.8.0)
+* Do not show an error message in cases where `RLMProgressNotificationToken` session is already deallocated ([#7831](https://github.com/realm/realm-swift/issues/7831),
+  since v2.3.0).
+
+<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 
 ### Compatibility
 

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -741,11 +741,11 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         XCTAssert(downloadCount > 1)
         XCTAssert(uploadCount > 1)
 
-        downloadCount = 0
-        uploadCount = 0
-
         tokenDownload!.invalidate()
         tokenUpload!.invalidate()
+
+        downloadCount = 0
+        uploadCount = 0
 
         executeChild()
         waitForDownloads(for: realm)

--- a/Realm/RLMSyncSession.mm
+++ b/Realm/RLMSyncSession.mm
@@ -52,9 +52,11 @@ using namespace realm;
 }
 
 - (void)invalidate {
-    _session->unregister_progress_notifier(_token);
-    _session.reset();
-    _token = 0;
+    if (_session) {
+        _session->unregister_progress_notifier(_token);
+        _session.reset();
+        _token = 0;
+    }
 }
 
 - (nullable instancetype)initWithTokenValue:(uint64_t)token

--- a/Realm/RLMSyncSession.mm
+++ b/Realm/RLMSyncSession.mm
@@ -60,7 +60,8 @@ using namespace realm;
 }
 
 - (void)dealloc {
-    if (_token != 0) {
+    auto session = _session.lock();
+    if (session && _token != 0) {
         NSLog(@"RLMProgressNotificationToken released without unregistering a notification. "
               @"You must hold on to the RLMProgressNotificationToken and call "
               @"-[RLMProgressNotificationToken invalidate] when you no longer wish to receive "

--- a/Realm/RLMSyncSession.mm
+++ b/Realm/RLMSyncSession.mm
@@ -40,7 +40,7 @@ using namespace realm;
 
 @interface RLMProgressNotificationToken() {
     uint64_t _token;
-    std::weak_ptr<SyncSession> _session;
+    std::shared_ptr<SyncSession> _session;
 }
 @end
 
@@ -52,21 +52,9 @@ using namespace realm;
 }
 
 - (void)invalidate {
-    if (auto session = _session.lock()) {
-        session->unregister_progress_notifier(_token);
-        _session.reset();
-        _token = 0;
-    }
-}
-
-- (void)dealloc {
-    auto session = _session.lock();
-    if (session && _token != 0) {
-        NSLog(@"RLMProgressNotificationToken released without unregistering a notification. "
-              @"You must hold on to the RLMProgressNotificationToken and call "
-              @"-[RLMProgressNotificationToken invalidate] when you no longer wish to receive "
-              @"progress update notifications.");
-    }
+    _session->unregister_progress_notifier(_token);
+    _session.reset();
+    _token = 0;
 }
 
 - (nullable instancetype)initWithTokenValue:(uint64_t)token
@@ -214,7 +202,7 @@ static RLMSyncConnectionState convertConnectionState(SyncSession::ConnectionStat
                 block((NSUInteger)transferred, (NSUInteger)transferrable);
             });
         }, notifier_direction, is_streaming);
-        return [[RLMProgressNotificationToken alloc] initWithTokenValue:token session:std::move(session)];
+        return [[RLMProgressNotificationToken alloc] initWithTokenValue:token session:session];
     }
     return nil;
 }


### PR DESCRIPTION
Do not show an error message in cases where `RLMProgressNotificationToken` session is already deallocated ([#7831](https://github.com/realm/realm-swift/issues/7831), since v2.3.0).