### PR TITLE
Allow  `RLMSupport.swift`to be used from RealmSwift's Cocoapods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * The `intialSubscriptions` callback was invoked every time a Realm was opened
   regardless of the value of `rerunOnOpen` and if the Realm was already open on
   another thread (since v10.28.0).
+* Allow `RLMSupport.Swift` to be used from RealmSwift's Cocoapods ([#6886](https://github.com/realm/realm-swift/pull/6886)).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/RealmSwift.podspec
+++ b/RealmSwift.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.weak_frameworks = 'SwiftUI'
 
   s.dependency 'Realm', "= #{s.version}"
-  s.source_files = 'RealmSwift/*.swift', 'RealmSwift/Impl/*.swift'
+  s.source_files = 'RealmSwift/*.swift', 'RealmSwift/Impl/*.swift', 'Realm/Swift/*.swift'
   s.exclude_files = 'RealmSwift/Nonsync.swift'
 
   s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }


### PR DESCRIPTION
Allow  `RLMSupport.swift`to be used from RealmSwift's Cocoapods