### PR TITLE
Recovery mode for partition realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,18 @@ x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
 * Add `.recover` and `.recoverOrDiscardLocal` behaviors to `ClientResetMode`. See below for detail.
-* Add `RLMClientResetModeRecover` and `RLMClientResetModeRecoverOrDiscard` behaviors to `RLMClientResetMode` enums.  See below for detail.
+* Add `RLMClientResetModeRecover` and `RLMClientResetModeRecoverOrDiscard` behaviors to `RLMClientResetMode`.  See below for detail.
 * The new recover modes function by downloading a realm with objects which reflect 
   the latest version of the server after a client reset. The recovery process is run 
   locally in an attempt to integrate the server version with any local changes from 
   before the client reset occurred.
   The changes are integrated with the following rules:
-  1. Objects created locally that were not integrated before client reset will be integrated.
-  2. If an object has been deleted on the server, but was modified on the recovering client, the delete takes precedence and the update is discarded
-  3. If an object was deleted on the recovering client, but not the server, then the client delete instruction is applied.
+  1. Objects created locally that were not synced before client reset will be integrated.
+  2. If an object has been deleted on the server, but was modified on the client, the delete takes precedence and the update is discarded
+  3. If an object was deleted on the client, but not the server, then the client delete instruction is applied.
   4. In the case of conflicting updates to the same field, the most recent update is applied.
-  - The two new swift recovery also support client reset callbacks: `.recover(((Realm) -> Void)? = nil, ((Realm, Realm) -> Void)? = nil)`.
-  - The two new Obj-C recovery modes support client reset callback via the `notifyBeforeReset` and `notifyAfterReset` parameters in `[RLMUser configurationWithPartitionValue]`
+  - The two new swift recovery modes support client reset callbacks: `.recover(((Realm) -> Void)? = nil, ((Realm, Realm) -> Void)? = nil)`.
+  - The two new Obj-C recovery modes support client reset callbacks via the `notifyBeforeReset` and `notifyAfterReset` parameters in `[RLMUser configurationWithPartitionValue]`
   - For more detail on client reset callbacks, see `ClientResetMode`, `RLMClientResetBeforeBlock`, `RLMClientResetAfterBlock`, and the 10.25.0 changelog entry.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,20 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Add `.recover` and `.recoverOrDiscardLocal` behaviors to `ClientResetMode`. See below for detail.
+* Add `RLMClientResetModeRecover` and `RLMClientResetModeRecoverOrDiscard` behaviors to `RLMClientResetMode` enums.  See below for detail.
+* The new recover modes function by downloading a realm with objects which reflect 
+  the latest version of the server after a client reset. The recovery process is run 
+  locally in an attempt to integrate the server version with any local changes from 
+  before the client reset occurred.
+  The changes are integrated with the following rules:
+  1. Objects created locally that were not integrated before client reset will be integrated.
+  2. If an object has been deleted on the server, but was modified on the recovering client, the delete takes precedence and the update is discarded
+  3. If an object was deleted on the recovering client, but not the server, then the client delete instruction is applied.
+  4. In the case of conflicting updates to the same field, the most recent update is applied.
+  - The two new swift recovery also support client reset callbacks: `.recover(((Realm) -> Void)? = nil, ((Realm, Realm) -> Void)? = nil)`.
+  - The two new Obj-C recovery modes support client reset callback via the `notifyBeforeReset` and `notifyAfterReset` parameters in `[RLMUser configurationWithPartitionValue]`
+  - For more detail on client reset callbacks, see `ClientResetMode`, `RLMClientResetBeforeBlock`, `RLMClientResetAfterBlock`, and the 10.25.0 changelog entry.
 
 ### Fixed
 * Add missing `initialSubscription` and `rerunOnOpen` to copyWithZone method on `RLMRealmConfiguration`. This resulted in incorrect values when using `RLMRealmConfiguration.defaultConfiguration`.

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -1470,9 +1470,13 @@ static NSString *randomEmail() {
 - (void)testSetClientResetMode {
     RLMUser *user = [self userForTest:_cmd];
     NSString *partitionValue = NSStringFromSelector(_cmd);
+
     RLMRealmConfiguration *config = [user configurationWithPartitionValue:partitionValue clientResetMode:RLMClientResetModeDiscardLocal];
     XCTAssertEqual(config.syncConfiguration.clientResetMode, RLMClientResetModeDiscardLocal);
-
+    config = [user configurationWithPartitionValue:partitionValue clientResetMode:RLMClientResetModeRecover];
+    XCTAssertEqual(config.syncConfiguration.clientResetMode, RLMClientResetModeRecover);
+    config = [user configurationWithPartitionValue:partitionValue clientResetMode:RLMClientResetModeRecoverOrDiscard];
+    XCTAssertEqual(config.syncConfiguration.clientResetMode, RLMClientResetModeRecoverOrDiscard);
     // Default is manual
     config = [user configurationWithPartitionValue:partitionValue];
     XCTAssertEqual(config.syncConfiguration.clientResetMode, RLMClientResetModeManual);

--- a/Realm/ObjectServerTests/RealmServer.swift
+++ b/Realm/ObjectServerTests/RealmServer.swift
@@ -433,7 +433,7 @@ public class RealmServer: NSObject {
     @objc public static var shared = RealmServer()
 
     /// Log level for the server and mongo processes.
-    public var logLevel = LogLevel.none
+    public var logLevel = LogLevel.info
 
     /// Process that runs the local mongo server. Should be terminated on exit.
     private let mongoProcess = Process()
@@ -1038,6 +1038,57 @@ public class RealmServer: NSObject {
         syncConfig["sync"] = syncInfo
         app.services[syncServiceId].config.patch(syncConfig, completion)
     }
+
+    // ???: think about collapsing this into devmodeenabled?
+    public func recoveryModeDisabled(appServerId: String, syncServiceId: String) throws -> Bool {
+        guard let session = session else {
+            fatalError()
+        }
+        let app = session.apps[appServerId]
+        let response = try app.services[syncServiceId].config.get().get() as? [String: Any]
+        guard let syncInfo = response?["sync"] as? [String: Any] else {
+            return false
+        }
+        return (syncInfo["is_recovery_mode_disabled"] as? Bool == true)
+    }
+
+    public func patchRecoveryMode(disable: Bool, appServerId: String, syncServiceId: String, syncServiceConfiguration: [String: Any], completion: @escaping (Result<Any?, Error>) -> Void) throws {
+        // If desired edit is already the case, return
+        if (try recoveryModeDisabled(appServerId: appServerId, syncServiceId: syncServiceId) == disable) {
+            return
+        }
+
+        var syncConfig = syncServiceConfiguration
+        guard let session = session else {
+            completion(.failure(URLError.unknown as! Error))
+            return
+        }
+        let app = session.apps[appServerId]
+        guard var syncInfo = syncConfig["sync"] as? [String: Any] else {
+            completion(.failure(URLError.unknown as! Error))
+            return
+        }
+
+        syncInfo["is_recovery_mode_disabled"] = disable
+        syncConfig["sync"] = syncInfo
+        app.services[syncServiceId].config.patch(syncConfig, completion)
+    }
+    
+//    public func disableRecoveryMode(appServerId: String, syncServiceId: String, syncServiceConfiguration: [String: Any], completion: @escaping (Result<Any?, Error>) -> Void) {
+//        var syncConfig = syncServiceConfiguration
+//        guard let session = session else {
+//            completion(.failure(URLError.unknown as! Error))
+//            return
+//        }
+//        let app = session.apps[appServerId]
+//        guard var syncInfo = syncConfig["sync"] as? [String: Any] else {
+//            completion(.failure(URLError.unknown as! Error))
+//            return
+//        }
+//        syncInfo["is_recovery_mode_disabled"] = true
+//        syncConfig["sync"] = syncInfo
+//        app.services[syncServiceId].config.patch(syncConfig, completion)
+//    }
 
     public func retrieveUser(_ appId: String, userId: String, _ completion: @escaping (Result<Any?, Error>) -> Void) {
         guard let appServerId = try? RealmServer.shared.retrieveAppServerId(appId),

--- a/Realm/ObjectServerTests/RealmServer.swift
+++ b/Realm/ObjectServerTests/RealmServer.swift
@@ -433,7 +433,7 @@ public class RealmServer: NSObject {
     @objc public static var shared = RealmServer()
 
     /// Log level for the server and mongo processes.
-    public var logLevel = LogLevel.info
+    public var logLevel = LogLevel.none
 
     /// Process that runs the local mongo server. Should be terminated on exit.
     private let mongoProcess = Process()
@@ -1039,7 +1039,6 @@ public class RealmServer: NSObject {
         app.services[syncServiceId].config.patch(syncConfig, completion)
     }
 
-    // ???: think about collapsing this into devmodeenabled?
     public func recoveryModeDisabled(appServerId: String, syncServiceId: String) throws -> Bool {
         guard let session = session else {
             fatalError()
@@ -1073,22 +1072,6 @@ public class RealmServer: NSObject {
         syncConfig["sync"] = syncInfo
         app.services[syncServiceId].config.patch(syncConfig, completion)
     }
-    
-//    public func disableRecoveryMode(appServerId: String, syncServiceId: String, syncServiceConfiguration: [String: Any], completion: @escaping (Result<Any?, Error>) -> Void) {
-//        var syncConfig = syncServiceConfiguration
-//        guard let session = session else {
-//            completion(.failure(URLError.unknown as! Error))
-//            return
-//        }
-//        let app = session.apps[appServerId]
-//        guard var syncInfo = syncConfig["sync"] as? [String: Any] else {
-//            completion(.failure(URLError.unknown as! Error))
-//            return
-//        }
-//        syncInfo["is_recovery_mode_disabled"] = true
-//        syncConfig["sync"] = syncInfo
-//        app.services[syncServiceId].config.patch(syncConfig, completion)
-//    }
 
     public func retrieveUser(_ appId: String, userId: String, _ completion: @escaping (Result<Any?, Error>) -> Void) {
         guard let appServerId = try? RealmServer.shared.retrieveAppServerId(appId),

--- a/Realm/ObjectServerTests/RealmServer.swift
+++ b/Realm/ObjectServerTests/RealmServer.swift
@@ -1053,7 +1053,7 @@ public class RealmServer: NSObject {
 
     public func patchRecoveryMode(disable: Bool, appServerId: String, syncServiceId: String, syncServiceConfiguration: [String: Any], completion: @escaping (Result<Any?, Error>) -> Void) throws {
         // If desired edit is already the case, return
-        if (try recoveryModeDisabled(appServerId: appServerId, syncServiceId: syncServiceId) == disable) {
+        if try recoveryModeDisabled(appServerId: appServerId, syncServiceId: syncServiceId) == disable {
             return
         }
 

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -524,7 +524,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         case .discardLocal(let before, let after):
             XCTAssertNotNil(before)
             XCTAssertNotNil(after)
-        case default:
+        default:
             XCTFail("Should be set to discardLocal")
         }
 
@@ -572,7 +572,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         case .recover(let before, let after):
             XCTAssertNotNil(before)
             XCTAssertNotNil(after)
-        case default:
+        default:
             XCTFail("Should be set to recover")
         }
 
@@ -625,7 +625,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         case .recoverOrDiscard(let before, let after):
             XCTAssertNotNil(before)
             XCTAssertNotNil(after)
-        case default:
+        default:
             XCTFail("Should be set to recoverOrDiscard")
         }
 

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -311,7 +311,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
                 XCTFail("Error: \(error.localizedDescription)")
             }
         }
-        waitForExpectations(timeout: 6, handler: nil)
+        waitForExpectations(timeout: 20, handler: nil)
         XCTAssertFalse(try RealmServer.shared.syncEnabled(appServerId: appServerId, syncServiceId: syncServiceId))
     }
 
@@ -345,6 +345,39 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         waitForExpectations(timeout: 6, handler: nil)
         XCTAssertTrue(try RealmServer.shared.devModeEnabled(appServerId: appServerId, syncServiceId: syncServiceId))
     }
+
+    func waitForEditRecoveryMode(disable: Bool) throws {
+        // Retrieve server IDs
+        let appServerId = try RealmServer.shared.retrieveAppServerId(appId)
+        let syncServiceId = try RealmServer.shared.retrieveSyncServiceId(appServerId: appServerId)
+        guard let syncServiceConfig = try RealmServer.shared.getSyncServiceConfiguration(appServerId: appServerId, syncServiceId: syncServiceId) else { fatalError("precondition failure: no sync service configuration found") }
+
+        let exp = expectation(description: "edit recovery mode")
+        try RealmServer.shared.patchRecoveryMode(disable: disable, appServerId: appServerId, syncServiceId: syncServiceId, syncServiceConfiguration: syncServiceConfig) { result in
+            switch result {
+            case .success(_):
+                exp.fulfill()
+            case .failure(let error):
+                XCTFail("Error: \(error.localizedDescription)")
+            }
+        }
+        waitForExpectations(timeout: 20, handler: nil)
+    }
+
+//    func waitForRecoveryModeDisabled(appServerId: String, syncServiceId: String,  syncServiceConfig: [String: Any]) {
+//        XCTAssertFalse(try RealmServer.shared.recoveryModeDisabled(appServerId: appServerId, syncServiceId: syncServiceId))
+//        let exp = expectation(description: "disable recovery")
+//        RealmServer.shared.disableRecoveryMode(appServerId: appServerId, syncServiceId: syncServiceId, syncServiceConfiguration: syncServiceConfig) { results in
+//            switch results {
+//            case .success(_):
+//                exp.fulfill()
+//            case .failure(let error):
+//                XCTFail("Error: \(error.localizedDescription)")
+//            }
+//        }
+//        waitForExpectations(timeout: 6, handler: nil)
+//        XCTAssertTrue(try RealmServer.shared.recoveryModeDisabled(appServerId: appServerId, syncServiceId: syncServiceId))
+//    }
 
     // This function disables sync, executes a block while the sync service is disabled, then re-enables the sync service and dev mode.
     func executeBlockOffline(block: () throws -> Void) throws {
@@ -522,11 +555,19 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         }
     }
 
+//    func testClientResetFailbackToDiscardLocal() throws {
+//        let user = try logInUser(for: basicCredentials())
+//        try prepareClientReset(#function, user)
+//
+//        try assertDiscardLocal(user)
+
+//        try waitForEditRecoveryMode(disable: false)
+//    }
+
     func testClientResetRecover() throws {
         let user = try logInUser(for: basicCredentials())
         try prepareClientReset(#function, user)
 
-        // ???: How to not repeat this from test to test? Couldn't pull this out into helper fn because of the expectations?
         // Define the blocks that will be passed into the sync configuration initializer.
         let beforeCallbackEx = expectation(description: "before reset callback")
         let beforeClientResetBlock: (Realm) -> Void = { local in
@@ -609,6 +650,60 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
             asyncOpenEx.fulfill()
         }
         wait(for: [beforeCallbackEx, afterCallbackEx, asyncOpenEx], timeout: 60.0)
+    }
+    
+    func testClientResetFailbackToDiscardLocal() throws {
+        try waitForEditRecoveryMode(disable: true)
+
+        let user = try logInUser(for: basicCredentials())
+        try prepareClientReset(#function, user)
+
+        // Define the blocks that will be passed into the sync configuration initializer.
+        let beforeCallbackEx = expectation(description: "before reset callback")
+        let beforeClientResetBlock: (Realm) -> Void = { local in
+            let results = local.objects(SwiftPerson.self)
+            XCTAssertEqual(results.count, 1)
+            XCTAssertEqual(results.filter("firstName == 'John'").count, 1)
+            beforeCallbackEx.fulfill()
+        }
+        let afterCallbackEx = expectation(description: "after reset callback")
+        let afterClientResetBlock: (Realm, Realm) -> Void = { before, after in
+            let results = before.objects(SwiftPerson.self)
+            XCTAssertEqual(results.count, 1)
+            XCTAssertEqual(results.filter("firstName == 'John'").count, 1)
+
+            let results2 = after.objects(SwiftPerson.self)
+            XCTAssertEqual(results2.count, 1)
+            XCTAssertEqual(results2.filter("firstName == 'Paul'").count, 1)
+
+            afterCallbackEx.fulfill()
+        }
+
+        var configuration = user.configuration(partitionValue: #function, clientResetMode: .recoverOrDiscard(beforeClientResetBlock, afterClientResetBlock))
+        configuration.objectTypes = [SwiftPerson.self]
+
+        guard let syncConfig = configuration.syncConfiguration else { fatalError("Test condition failure. SyncConfiguration not set.") }
+        switch syncConfig.clientResetMode {
+        case .manual:
+            XCTFail("Should be set to recoverOrDiscard")
+        case .discardLocal(_, _):
+            XCTFail("Should be set to recoverOrDiscard")
+        case .recover(_, _):
+            XCTFail("Should be set to recoverOrDiscard")
+        case .recoverOrDiscard(let before, let after):
+            XCTAssertNotNil(before)
+            XCTAssertNotNil(after)
+        }
+
+        // Expect the recovery to fail back to discardLocal logic
+        try autoreleasepool {
+            let realm = try Realm(configuration: configuration)
+            wait(for: [beforeCallbackEx, afterCallbackEx], timeout: 60.0)
+            XCTAssertEqual(realm.objects(SwiftPerson.self).count, 1) // Expect the server realm (one object) to have overwritten the local realm (2 objects)
+            XCTAssertEqual(realm.objects(SwiftPerson.self)[0].firstName, "Paul")
+        }
+
+        try waitForEditRecoveryMode(disable: false)
     }
 
     // MARK: - Progress notifiers

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -355,7 +355,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         let exp = expectation(description: "edit recovery mode")
         try RealmServer.shared.patchRecoveryMode(disable: disable, appServerId: appServerId, syncServiceId: syncServiceId, syncServiceConfiguration: syncServiceConfig) { result in
             switch result {
-            case .success(_):
+            case .success:
                 exp.fulfill()
             case .failure(let error):
                 XCTFail("Error: \(error.localizedDescription)")
@@ -526,7 +526,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         case .discardLocal(let before, let after):
             XCTAssertNotNil(before)
             XCTAssertNotNil(after)
-        case .recover(_, _):
+        case .recover:
             XCTFail("Should be set to discardLocal")
         case .recoverOrDiscard:
             XCTFail("Should be set to discardLocal")
@@ -573,12 +573,12 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         switch syncConfig.clientResetMode {
         case .manual:
             XCTFail("Should be set to recover")
-        case .discardLocal(_, _):
+        case .discardLocal:
             XCTFail("Should be set to recover")
         case .recover(let before, let after):
             XCTAssertNotNil(before)
             XCTAssertNotNil(after)
-        case .recoverOrDiscard(_, _):
+        case .recoverOrDiscard:
             XCTFail("Should be set to recover")
         }
 
@@ -628,9 +628,9 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         switch syncConfig.clientResetMode {
         case .manual:
             XCTFail("Should be set to recoverOrDiscard")
-        case .discardLocal(_, _):
+        case .discardLocal:
             XCTFail("Should be set to recoverOrDiscard")
-        case .recover(_, _):
+        case .recover:
             XCTFail("Should be set to recoverOrDiscard")
         case .recoverOrDiscard(let before, let after):
             XCTAssertNotNil(before)

--- a/Realm/RLMSyncConfiguration.h
+++ b/Realm/RLMSyncConfiguration.h
@@ -50,7 +50,11 @@ typedef NS_ENUM(NSUInteger, RLMClientResetMode) {
     /// If RLMClientResetModeDiscardLocal is enabled but the client reset operation is unable to complete
     /// then the client reset process reverts to manual mode. Example) During a destructive schema change this
     /// mode will fail and invoke the manual client reset handler.
-    RLMClientResetModeDiscardLocal
+    RLMClientResetModeDiscardLocal,
+    // TODO: docs
+    RLMClientResetModeRecover,
+    // TODO: docs
+    RLMClientResetModeRecoverOrDiscard
 };
 
 /**

--- a/Realm/RLMSyncConfiguration.h
+++ b/Realm/RLMSyncConfiguration.h
@@ -51,7 +51,11 @@ typedef NS_ENUM(NSUInteger, RLMClientResetMode) {
     /// then the client reset process reverts to manual mode. Example) During a destructive schema change this
     /// mode will fail and invoke the manual client reset handler.
     RLMClientResetModeDiscardLocal,
-    // TODO: docs
+    /// The client device will download a realm with objects reflecting the latest version of the server. A recovery
+    /// process is run locally in an attempt to integrate the server version with any local changes from before the
+    /// client reset occurred.
+    /// The changes are integrated with the following rules:
+    /// TODO: finish docstring
     RLMClientResetModeRecover,
     // TODO: docs
     RLMClientResetModeRecoverOrDiscard

--- a/Realm/RLMSyncConfiguration.h
+++ b/Realm/RLMSyncConfiguration.h
@@ -50,17 +50,39 @@ typedef NS_ENUM(NSUInteger, RLMClientResetMode) {
     /// If RLMClientResetModeDiscardLocal is enabled but the client reset operation is unable to complete
     /// then the client reset process reverts to manual mode. Example) During a destructive schema change this
     /// mode will fail and invoke the manual client reset handler.
+    ///
+    /// The RLMClientResetModeDiscardLocal mode supports two client reset callbacks -- `RLMClientResetBeforeBlock`, `RLMClientResetAfterBlock` -- which can be passed as arguments when creating the `RLMSyncConfiguration`.
+    ///- see: `RLMClientResetAfterBlock` and `RLMClientResetBeforeBlock`
     RLMClientResetModeDiscardLocal,
     /// The client device will download a realm with objects reflecting the latest version of the server. A recovery
     /// process is run locally in an attempt to integrate the server version with any local changes from before the
     /// client reset occurred.
+    ///
     /// The changes are integrated with the following rules:
-    /// 1. Objects created locally that were not integrated before client reset will be integrated.
-    /// 2. If an object has been deleted on the server, but was modified on the recovering client, the delete takes precedence and the update is discarded
-    /// 3. If an object was deleted on the recovering client, but not the server, then the client delete instruction is applied.
+    /// 1. Objects created locally that were not synced before client reset will be integrated.
+    /// 2. If an object has been deleted on the server, but was modified on the client, the delete takes precedence and the update is discarded
+    /// 3. If an object was deleted on the client, but not the server, then the client delete instruction is applied.
     /// 4. In the case of conflicting updates to the same field, the most recent update is applied.
+    ///
+    /// If the recovery process fails, the client reset process falls back to RLMClientResetModeManual.
+    ///
+    /// The RLMClientResetModeRecover mode supports two client reset callbacks -- `RLMClientResetBeforeBlock`, `RLMClientResetAfterBlock` -- which can be passed as arguments when creating the `RLMSyncConfiguration`.
+    ///- see: `RLMClientResetAfterBlock` and `RLMClientResetBeforeBlock`
     RLMClientResetModeRecover,
-    // TODO: docs
+    /// The client device will download a realm with objects reflecting the latest version of the server. A recovery
+    /// process is run locally in an attempt to integrate the server version with any local changes from before the
+    /// client reset occurred.
+    ///
+    /// The changes are integrated with the following rules:
+    /// 1. Objects created locally that were not synced before client reset will be integrated.
+    /// 2. If an object has been deleted on the server, but was modified on the client, the delete takes precedence and the update is discarded
+    /// 3. If an object was deleted on the client, but not the server, then the client delete instruction is applied.
+    /// 4. In the case of conflicting updates to the same field, the most recent update is applied.
+    ///
+    /// If the recovery process fails, the client reset process falls back to RLMClientResetModeDiscardLocal.
+    ///
+    /// The RLMClientResetModeRecoverOrDiscard mode supports two client reset callbacks -- `RLMClientResetBeforeBlock`, `RLMClientResetAfterBlock` -- which can be passed as arguments when creating the `RLMSyncConfiguration`.
+    ///- see: `RLMClientResetAfterBlock` and `RLMClientResetBeforeBlock`
     RLMClientResetModeRecoverOrDiscard
 };
 

--- a/Realm/RLMSyncConfiguration.h
+++ b/Realm/RLMSyncConfiguration.h
@@ -64,7 +64,9 @@ typedef NS_ENUM(NSUInteger, RLMClientResetMode) {
     /// 3. If an object was deleted on the client, but not the server, then the client delete instruction is applied.
     /// 4. In the case of conflicting updates to the same field, the most recent update is applied.
     ///
-    /// If the recovery process fails, the client reset process falls back to RLMClientResetModeManual.
+    /// If the recovery integration fails, the client reset process falls back to RLMClientResetModeManual.
+    /// The recovery integration will fail if the "Client Recovery" setting is not enabled on the server.
+    /// Integration may also fail in the event of an incompatible schema change.
     ///
     /// The RLMClientResetModeRecover mode supports two client reset callbacks -- `RLMClientResetBeforeBlock`, `RLMClientResetAfterBlock` -- which can be passed as arguments when creating the `RLMSyncConfiguration`.
     ///- see: `RLMClientResetAfterBlock` and `RLMClientResetBeforeBlock`
@@ -79,7 +81,9 @@ typedef NS_ENUM(NSUInteger, RLMClientResetMode) {
     /// 3. If an object was deleted on the client, but not the server, then the client delete instruction is applied.
     /// 4. In the case of conflicting updates to the same field, the most recent update is applied.
     ///
-    /// If the recovery process fails, the client reset process falls back to RLMClientResetModeDiscardLocal.
+    /// If the recovery integration fails, the client reset process falls back to RLMClientResetModeDiscardLocal.
+    /// The recovery integration will fail if the "Client Recovery" setting is not enabled on the server.
+    /// Integration may also fail in the event of an incompatible schema change.
     ///
     /// The RLMClientResetModeRecoverOrDiscard mode supports two client reset callbacks -- `RLMClientResetBeforeBlock`, `RLMClientResetAfterBlock` -- which can be passed as arguments when creating the `RLMSyncConfiguration`.
     ///- see: `RLMClientResetAfterBlock` and `RLMClientResetBeforeBlock`

--- a/Realm/RLMSyncConfiguration.h
+++ b/Realm/RLMSyncConfiguration.h
@@ -55,7 +55,10 @@ typedef NS_ENUM(NSUInteger, RLMClientResetMode) {
     /// process is run locally in an attempt to integrate the server version with any local changes from before the
     /// client reset occurred.
     /// The changes are integrated with the following rules:
-    /// TODO: finish docstring
+    /// 1. Objects created locally that were not integrated before client reset will be integrated.
+    /// 2. If an object has been deleted on the server, but was modified on the recovering client, the delete takes precedence and the update is discarded
+    /// 3. If an object was deleted on the recovering client, but not the server, then the client delete instruction is applied.
+    /// 4. In the case of conflicting updates to the same field, the most recent update is applied.
     RLMClientResetModeRecover,
     // TODO: docs
     RLMClientResetModeRecoverOrDiscard

--- a/Realm/RLMSyncUtil.mm
+++ b/Realm/RLMSyncUtil.mm
@@ -50,8 +50,6 @@ static_assert((int)RLMClientResetModeDiscardLocal == (int)realm::ClientResyncMod
 static_assert((int)RLMClientResetModeRecover == (int)realm::ClientResyncMode::Recover);
 static_assert((int)RLMClientResetModeRecoverOrDiscard == (int)realm::ClientResyncMode::RecoverOrDiscard);
 
-
-
 SyncSessionStopPolicy translateStopPolicy(RLMSyncStopPolicy stopPolicy) {
     switch (stopPolicy) {
         case RLMSyncStopPolicyImmediately:              return SyncSessionStopPolicy::Immediately;

--- a/Realm/RLMSyncUtil.mm
+++ b/Realm/RLMSyncUtil.mm
@@ -47,6 +47,10 @@ using namespace realm;
 
 static_assert((int)RLMClientResetModeManual == (int)realm::ClientResyncMode::Manual);
 static_assert((int)RLMClientResetModeDiscardLocal == (int)realm::ClientResyncMode::DiscardLocal);
+static_assert((int)RLMClientResetModeRecover == (int)realm::ClientResyncMode::Recover);
+static_assert((int)RLMClientResetModeRecoverOrDiscard == (int)realm::ClientResyncMode::RecoverOrDiscard);
+
+
 
 SyncSessionStopPolicy translateStopPolicy(RLMSyncStopPolicy stopPolicy) {
     switch (stopPolicy) {

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -218,7 +218,7 @@ public enum ClientResetMode {
     case manual
     /// - see: `RLMClientResetModeDiscardLocal` for more details on `.discardLocal` behavior
     ///
-    /// The first `.discardLocal` function argument notifies prior to a client reset occurring.
+    /// The first `.discardLocal` function argument, `((Realm) -> Void)? = nil`, is executed prior to a client reset occurring.
     /// The `Realm` argument contains a frozen copy of the Realm state prior to client reset.
     /// ```
     /// user.configuration(partitionValue: "myPartition", clientResetMode: .discardLocal({ beforeRealm in
@@ -235,14 +235,14 @@ public enum ClientResetMode {
     ///  For more details on ((Realm) -> Void)? = nil,
     /// - see: `RLMClientResetBeforeBlock`
     ///
-    /// The second `.discardLocal` function argument notifies after a client reset has occurred.
+    /// The second `.discardLocal` function argument, `((Realm, Realm) -> Void)? = nil`, is executed after a client reset has occurred.
     /// - Within this function, the first `Realm` argument contains a frozen copy of the local Realm state prior to client reset.
     /// - Within this function, the second `Realm` argument contains the Realm state after client reset.
     /// ```
     /// user.configuration(partitionValue: "myPartition", clientResetMode: .discardLocal( nil, { beforeRealm, afterRealm in
     /// // This block could be used to add custom recovery logic, back-up a realm file, send reporting, etc.
-    /// for object in before.objects(myClass.self) {
-    ///     let res = after.objects(myClass.self)
+    /// for object in beforeRealm.objects(myClass.self) {
+    ///     let res = afterRealm.objects(myClass.self)
     ///     if (res.filter("primaryKey == %@", object.primaryKey).first != nil) {
     ///         // ...custom recovery logic...
     ///     } else {
@@ -254,9 +254,15 @@ public enum ClientResetMode {
     ///  For more details on the second block: ((Realm, Realm) -> Void)? = nil,
     /// - see: `RLMClientResetAfterBlock`
     case discardLocal(((Realm) -> Void)? = nil, ((Realm, Realm) -> Void)? = nil)
-    // TODO: docs
+    /// - see: `RLMClientResetModeRecover` for more details on `.recover` behavior
+    ///
+    /// - see `ClientResetMode.discardLocal` for a detailed explanation of the
+    ///   two callback arguments: `((Realm) -> Void)? = nil, ((Realm, Realm) -> Void)? = nil`
     case recover(((Realm) -> Void)? = nil, ((Realm, Realm) -> Void)? = nil)
-    // TODO: docs
+    /// - see: `RLMClientResetModeRecoverOrDiscard` for more details on `.recoverOrDiscard` behavior
+    ///
+    /// - see `ClientResetMode.discardLocal` for a detailed explanation of the
+    ///   two callback arguments: `((Realm) -> Void)? = nil, ((Realm, Realm) -> Void)? = nil`
     case recoverOrDiscard(((Realm) -> Void)? = nil, ((Realm, Realm) -> Void)? = nil)
 }
 

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -218,7 +218,7 @@ public enum ClientResetMode {
     case manual
     /// - see: `RLMClientResetModeDiscardLocal` for more details on `.discardLocal` behavior
     ///
-    /// The first `.discardLocal` function argument, `((Realm) -> Void)? = nil`, is executed prior to a client reset occurring.
+    /// The first `.discardLocal` function argument is executed prior to a client reset occurring.
     /// The `Realm` argument contains a frozen copy of the Realm state prior to client reset.
     /// ```
     /// user.configuration(partitionValue: "myPartition", clientResetMode: .discardLocal({ beforeRealm in
@@ -235,7 +235,7 @@ public enum ClientResetMode {
     ///  For more details on ((Realm) -> Void)? = nil,
     /// - see: `RLMClientResetBeforeBlock`
     ///
-    /// The second `.discardLocal` function argument, `((Realm, Realm) -> Void)? = nil`, is executed after a client reset has occurred.
+    /// The second `.discardLocal` function argument is executed after a client reset has occurred.
     /// - Within this function, the first `Realm` argument contains a frozen copy of the local Realm state prior to client reset.
     /// - Within this function, the second `Realm` argument contains the Realm state after client reset.
     /// ```

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -254,6 +254,8 @@ public enum ClientResetMode {
     ///  For more details on the second block: ((Realm, Realm) -> Void)? = nil,
     /// - see: `RLMClientResetAfterBlock`
     case discardLocal(((Realm) -> Void)? = nil, ((Realm, Realm) -> Void)? = nil)
+    case recover(((Realm) -> Void)? = nil, ((Realm, Realm) -> Void)? = nil)
+    case recoverOrDiscard(((Realm) -> Void)? = nil, ((Realm, Realm) -> Void)? = nil)
 }
 
 /**
@@ -310,6 +312,10 @@ public enum ClientResetMode {
             self.clientResetMode = .manual
         case .discardLocal:
             self.clientResetMode = .discardLocal(ObjectiveCSupport.convert(object: config.beforeClientReset), ObjectiveCSupport.convert(object: config.afterClientReset))
+        case .recover:
+            self.clientResetMode = .recover(ObjectiveCSupport.convert(object: config.beforeClientReset), ObjectiveCSupport.convert(object: config.afterClientReset))
+        case .recoverOrDiscard:
+            self.clientResetMode = .recoverOrDiscard(ObjectiveCSupport.convert(object: config.beforeClientReset), ObjectiveCSupport.convert(object: config.afterClientReset))
         @unknown default:
             fatalError("what's best in this case?")
         }
@@ -333,6 +339,20 @@ public enum ClientResetMode {
                                                          partitionValue: partitionValue.map(ObjectiveCSupport.convertBson),
                                                          stopPolicy: stopPolicy,
                                                          clientResetMode: .discardLocal,
+                                                         notifyBeforeReset: ObjectiveCSupport.convert(object: before),
+                                                         notifyAfterReset: ObjectiveCSupport.convert(object: after))
+            case .recover(let before, let after):
+                syncConfiguration = RLMSyncConfiguration(user: user,
+                                                         partitionValue: partitionValue.map(ObjectiveCSupport.convertBson),
+                                                         stopPolicy: stopPolicy,
+                                                         clientResetMode: .recover,
+                                                         notifyBeforeReset: ObjectiveCSupport.convert(object: before),
+                                                         notifyAfterReset: ObjectiveCSupport.convert(object: after))
+            case .recoverOrDiscard(let before, let after):
+                syncConfiguration = RLMSyncConfiguration(user: user,
+                                                         partitionValue: partitionValue.map(ObjectiveCSupport.convertBson),
+                                                         stopPolicy: stopPolicy,
+                                                         clientResetMode: .recoverOrDiscard,
                                                          notifyBeforeReset: ObjectiveCSupport.convert(object: before),
                                                          notifyAfterReset: ObjectiveCSupport.convert(object: after))
             }
@@ -486,6 +506,16 @@ public extension User {
         case .discardLocal(let beforeClientReset, let afterClientReset):
             config = self.__configuration(withPartitionValue: ObjectiveCSupport.convert(object: AnyBSON(partitionValue)),
                                               clientResetMode: .discardLocal,
+                                              notifyBeforeReset: ObjectiveCSupport.convert(object: beforeClientReset),
+                                              notifyAfterReset: ObjectiveCSupport.convert(object: afterClientReset))
+        case .recover(let beforeClientReset, let afterClientReset):
+            config = self.__configuration(withPartitionValue: ObjectiveCSupport.convert(object: AnyBSON(partitionValue)),
+                                              clientResetMode: .recover,
+                                              notifyBeforeReset: ObjectiveCSupport.convert(object: beforeClientReset),
+                                              notifyAfterReset: ObjectiveCSupport.convert(object: afterClientReset))
+        case .recoverOrDiscard(let beforeClientReset, let afterClientReset):
+            config = self.__configuration(withPartitionValue: ObjectiveCSupport.convert(object: AnyBSON(partitionValue)),
+                                              clientResetMode: .recoverOrDiscard,
                                               notifyBeforeReset: ObjectiveCSupport.convert(object: beforeClientReset),
                                               notifyAfterReset: ObjectiveCSupport.convert(object: afterClientReset))
         }

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -254,7 +254,9 @@ public enum ClientResetMode {
     ///  For more details on the second block: ((Realm, Realm) -> Void)? = nil,
     /// - see: `RLMClientResetAfterBlock`
     case discardLocal(((Realm) -> Void)? = nil, ((Realm, Realm) -> Void)? = nil)
+    // TODO: docs
     case recover(((Realm) -> Void)? = nil, ((Realm, Realm) -> Void)? = nil)
+    // TODO: docs
     case recoverOrDiscard(((Realm) -> Void)? = nil, ((Realm, Realm) -> Void)? = nil)
 }
 


### PR DESCRIPTION
Adds the `.recover`, `.recoverOrDiscard`, `RLMClientResetModeRecover`, and `RLMClientResetModeRecoverOrDiscard` to `ClientResetMode` and `RLMClientResetMode` respectively.

The new recover modes function by downloading a realm with objects which reflect the latest version of the server after a client reset. The recovery process is run locally in an attempt to integrate the server version with any changes from 
the local realm before the client reset occurred.
1. Objects created locally that were not synced before client reset will be integrated.
2. If an object has been deleted on the server, but was modified on the client, the delete takes precedence and the update is discarded
3. If an object was deleted on the client, but not the server, then the client delete instruction is applied.
4. In the case of conflicting updates to the same field, the most recent update is applied.