### PR TITLE
Ensure sync sessions stay alive while there is a pending error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ x.y.z Release notes (yyyy-MM-dd)
   when using a sync configuration.
 
 ### Fixed
-* Add missing `initialSubscription` and `rerunOnOpen` to copyWithZone method on `RLMRealmConfiguration`. This resulted in incorrect values when using `RLMRealmConfiguration.defaultConfiguration`.
+* Add missing `initialSubscription` and `rerunOnOpen` to copyWithZone method on
+  `RLMRealmConfiguration`. This resulted in incorrect values when using
+  `RLMRealmConfiguration.defaultConfiguration`.
+* The sync error handler did not hold a strong reference to the sync session
+  while dispatching the error from the worker thread to the main thread,
+  resulting in the session passed to the error handler being invalid if there
+  were no other remaining strong references elsewhere.
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -144,6 +144,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface RLMSyncManager ()
+- (void)waitForSessionTermination;
+@end
+
 NS_ASSUME_NONNULL_END
 
 #define WAIT_FOR_SEMAPHORE(macro_semaphore, macro_timeout) do {                                                        \

--- a/Realm/RLMSyncConfiguration.mm
+++ b/Realm/RLMSyncConfiguration.mm
@@ -290,6 +290,9 @@ static void setDefaults(SyncConfig& config, RLMUser *user) {
         }
         RLMSyncSession *session = [[RLMSyncSession alloc] initWithSyncSession:errored_session];
         dispatch_async(dispatch_get_main_queue(), ^{
+            // Keep the SyncSession alive until the callback completes as
+            // RLMSyncSession only holds a weak reference
+            static_cast<void>(errored_session);
             errorHandler(nsError, session);
         });
     };


### PR DESCRIPTION
If the last external reference to a sync session was dropped between when the error handler on the sync thread ran and when we delivered the error to the user on the main thread, the user would see a sync session in a weird invalid state in the error handler due to that RLMSyncSession only holds a weak reference.