### PR TITLE
Change JWT expiration

### DIFF
--- a/Realm/ObjectServerTests/RLMSyncTestCase.mm
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.mm
@@ -287,7 +287,7 @@ static NSURL *syncDirectoryForChildProcess() {
     NSDictionary *payload = @{
         @"aud": appId,
         @"sub": @"someUserId",
-        @"exp": @1661896476,
+        @"exp": @1961896476,
         @"user_data": @{
             @"name": @"Foo Bar",
             @"occupation": @"firefighter"


### PR DESCRIPTION
Old expiration was 8/30/2022.
New expiration is 2032.
Helps `testCustomTokenAuthentication` pass.
Similar to https://github.com/realm/realm-core/pull/5797/