### PR TITLE
Remove export compliance clause

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,3 @@
-TABLE OF CONTENTS
-
-1. Apache License version 2.0
-2. Export Compliance
-
-1. -------------------------------------------------------------------------------
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -180,25 +173,5 @@ TABLE OF CONTENTS
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
 
-2. -------------------------------------------------------------------------------
-
-EXPORT COMPLIANCE
-
-You understand that the Software may contain cryptographic functions that may be
-subject to export restrictions, and you represent and warrant that you are not
-(i) located in a jurisdiction that is subject to United States economic
-sanctions (“Prohibited Jurisdiction”), including Cuba, Iran, North Korea,
-Sudan, Syria or the Crimea region, (ii) a person listed on any U.S. government
-blacklist (to include the List of Specially Designated Nationals and Blocked
-Persons or the Consolidated Sanctions List administered by the U.S. Department
-of the Treasury’s Office of Foreign Assets Control, or the Denied Persons List
-or Entity List administered by the U.S. Department of Commerce)
-(“Sanctioned Person”), or (iii) controlled or 50% or more owned by a Sanctioned
-Person.
-
-You agree to comply with all export, re-export and import restrictions and
-regulations of the U.S. Department of Commerce or other agency or authority of
-the United States or other applicable countries. You also agree not to transfer,
-or authorize the transfer of, directly or indirectly, of the Software to any
-Prohibited Jurisdiction, or otherwise in violation of any such restrictions or
-regulations.
+   END OF TERMS AND CONDITIONS
+   

--- a/README.md
+++ b/README.md
@@ -161,10 +161,6 @@ Realm Objective-C & Realm Swift are published under the Apache 2.0 license.
 Realm Core is also published under the Apache 2.0 license and is available
 [here](https://github.com/realm/realm-core).
 
-**This product is not being made available to any person located in Cuba, Iran,
-North Korea, Sudan, Syria or the Crimea region, or to any other person that is
-not eligible to receive the product under U.S. law.**
-
 ## Feedback
 
 **_If you use Realm and are happy with it, please consider sending out a tweet mentioning [@realm](https://twitter.com/realm) to share your thoughts!_**


### PR DESCRIPTION
Legal has confirmed that the export compliance clause is not needed on an open source projects such as the Realm SDKs.

This PR replace the LICENSE file with a clean Apache 2 license, ie. no ToC and export compliance. This allows tools such as github to pick up the correct license.