### PR TITLE
Rename authenticationDidCompleteWithError:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,11 @@ x.y.z Release notes (yyyy-MM-dd)
 * Accented characters are now handled by case-insensitive but
   diacritic-sensitive queries. ([Core #5825](https://github.com/realm/realm-core/issues/5825), since v2.2.0)
 
-<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
+### Breaking Changes
+* `-[RLMASLoginDelegate authenticationDidCompleteWithError:]` has been renamed
+  to `-[RLMASLoginDelegate authenticationDidFailWithError:]` to comply with new
+  app store requirements. This only effects the obj-c API.
+  ([#7945](https://github.com/realm/realm-swift/issues/7945))
 
 ### Compatibility
 * Realm Studio: 11.0.0 or later.

--- a/Realm/RLMApp.h
+++ b/Realm/RLMApp.h
@@ -184,7 +184,7 @@ API_AVAILABLE(ios(13.0), macos(10.15), tvos(13.0), watchos(6.0))
 
 /// Callback that is invoked should the authentication fail.
 /// @param error An error describing the authentication failure.
-- (void)authenticationDidCompleteWithError:(NSError *)error NS_SWIFT_NAME(authenticationDidComplete(error:));
+- (void)authenticationDidFailWithError:(NSError *)error NS_SWIFT_NAME(authenticationDidComplete(error:));
 
 /// Callback that is invoked should the authentication succeed.
 /// @param user The newly authenticated user.

--- a/Realm/RLMApp.mm
+++ b/Realm/RLMApp.mm
@@ -397,14 +397,14 @@ static std::mutex& s_appMutex = *new std::mutex();
            if (user) {
                [self.authorizationDelegate authenticationDidCompleteWithUser:user];
            } else {
-               [self.authorizationDelegate authenticationDidCompleteWithError:error];
+               [self.authorizationDelegate authenticationDidFailWithError:error];
            }
        }];
 }
 
 - (void)authorizationController:(__unused ASAuthorizationController *)controller
            didCompleteWithError:(NSError *)error API_AVAILABLE(ios(13.0), macos(10.15), tvos(13.0), watchos(6.0)) {
-    [self.authorizationDelegate authenticationDidCompleteWithError:error];
+    [self.authorizationDelegate authenticationDidFailWithError:error];
 }
 
 - (RLMAppSubscriptionToken *)subscribe:(RLMAppNotificationBlock)block {


### PR DESCRIPTION
Apple has banned the use of that selector name, so we have to pick a new name.

Fixes https://github.com/realm/realm-swift/issues/7945.