### PR TITLE
Fix moving `List` items to a higher index in SwiftUI results in wrong  destination index.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ x.y.z Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* Fix moving `List` items to a higher index in SwiftUI results in wrong destination index ([#7956](https://github.com/realm/realm-swift/issues/7956), since v10.6.0).
+* Fix moving `List` items to a higher index in SwiftUI results in wrong destination index
+  ([#7956](https://github.com/realm/realm-swift/issues/7956), since v10.6.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
-* None.
+* Fix moving `List` items to a higher index in SwiftUI results in wrong destination index ([#7956](https://github.com/realm/realm-swift/issues/7956), since v10.6.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/Tests/SwiftUITestHostUITests/SwiftUITestHostUITests.swift
+++ b/Realm/Tests/SwiftUITestHostUITests/SwiftUITestHostUITests.swift
@@ -16,7 +16,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-
 import XCTest
 import RealmSwift
 
@@ -88,15 +87,13 @@ class SwiftUITests: XCTestCase {
         addButton.tap()
         app.buttons["New List"].tap()
         XCTAssertTrue(app.navigationBars.staticTexts["New List"].waitForExistence(timeout: 1.0))
-        func addReminder(_ title: String) {
-            app.buttons["addReminder"].tap()
-            app.textFields["title"].tap()
-            app.textFields["title"].tap()
-            app.textFields["title"].typeText(title)
-            XCTAssertTrue(app.navigationBars.staticTexts[title].waitForExistence(timeout: 1.0))
-        }
-
-        addReminder("My Reminder")
+        app.buttons["addReminder"].tap()
+        // type in a name
+        app.textFields["title"].tap()
+        app.textFields["title"].tap()
+        app.textFields["title"].typeText("My Reminder")
+        // check to see if it is reflected live in the title view
+        XCTAssertTrue(app.navigationBars.staticTexts["My Reminder"].waitForExistence(timeout: 1.0))
         let myReminder = realm.objects(ReminderList.self).first!.reminders.first!
         XCTAssertEqual(myReminder.priority, .low)
         if #available(iOS 16, *) {
@@ -110,32 +107,16 @@ class SwiftUITests: XCTestCase {
         app.navigationBars.buttons.element(boundBy: 0).tap()
 
         // MARK: Test Move
-        addReminder("My Reminder 2")
-        app.navigationBars.buttons.element(boundBy: 0).tap()
-        addReminder("My Reminder 3")
-        app.navigationBars.buttons.element(boundBy: 0).tap()
-        addReminder("My Reminder 4")
-        app.navigationBars.buttons.element(boundBy: 0).tap()
-
+        app.buttons["addReminder"].tap()
         XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders.first!.title, "My Reminder")
-        XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders[1].title, "My Reminder 2")
-        XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders[2].title, "My Reminder 3")
-        XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders[3].title, "My Reminder 4")
+        XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders[1].title, "")
+        app.navigationBars.buttons.element(boundBy: 0).tap()
 
         app.buttons["Edit"].tap()
-        app.buttons.matching(identifier: "Reorder").firstMatch.press(forDuration: 0.5, thenDragTo: tables.cells.element(boundBy: 2))
+        app.buttons.matching(identifier: "Reorder").firstMatch.press(forDuration: 0.5, thenDragTo: tables.cells.element(boundBy: 1))
 
-        XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders.first!.title, "My Reminder 2")
-        XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders[1].title, "My Reminder 3")
-        XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders[2].title, "My Reminder")
-        XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders[3].title, "My Reminder 4")
-
-        app.buttons.matching(identifier: "Reorder").element(boundBy: 2).press(forDuration: 0.5, thenDragTo: tables.cells.element(boundBy: 0))
-
-        XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders.first!.title, "My Reminder")
-        XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders[1].title, "My Reminder 2")
-        XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders[2].title, "My Reminder 3")
-        XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders[3].title, "My Reminder 4")
+        XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders.first!.title, "")
+        XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders[1].title, "My Reminder")
 
         // MARK: Test Delete
         // potentially brittle, but these are the hooks swiftUI gives us. when editing a list,
@@ -152,19 +133,20 @@ class SwiftUITests: XCTestCase {
                 app.buttons.matching(identifier: "Delete").firstMatch.tap()
             }
         }
-        XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders.count, 4)
-        delete()
-        XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders.count, 3)
-        delete()
         XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders.count, 2)
         delete()
         XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders.count, 1)
+        if #available(iOS 16.0, *) {
+            app.buttons["Edit"].tap()
+        }
+        delete()
+        XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders.count, 0)
+
+        app.navigationBars.buttons.firstMatch.tap()
 
         if #available(iOS 16.0, *) {
             app.buttons["Done"].tap()
         }
-
-        app.navigationBars.buttons.firstMatch.tap()
         tables.cells.firstMatch.swipeLeft()
         app.buttons.matching(identifier: "Delete").firstMatch.tap()
         XCTAssertEqual(realm.objects(ReminderList.self).count, 0)
@@ -200,7 +182,7 @@ class SwiftUITests: XCTestCase {
         searchBar.tap()
 
         searchBar.typeText("reminder list 1\n") // \n to dismiss keyboard
-        XCTAssertEqual(table.cells.count, 9)
+        XCTAssertEqual(table.cells.count, 11)
     }
 
     func testMultipleEnvironmentRealms() {
@@ -314,7 +296,7 @@ class SwiftUITests: XCTestCase {
         let table = tables.firstMatch
 
         // Observed Results filter, should filter reminders without name.
-        XCTAssertEqual(table.cells.count, 12)
+        XCTAssertEqual(table.cells.count, 13)
 
         let searchBar = app.searchFields.firstMatch
         searchBar.tap()
@@ -333,7 +315,7 @@ class SwiftUITests: XCTestCase {
 
         clearSearchBar()
         app.navigationBars["Reminders"].buttons["Cancel"].tap()
-        XCTAssertEqual(table.cells.count, 12)
+        XCTAssertEqual(table.cells.count, 13)
 
         searchBar.tap()
         searchBar.typeText("2")
@@ -394,14 +376,13 @@ class SwiftUITests: XCTestCase {
         // Expect the ui to still show two cells labelled New List.
         // The view should've not updated because the name change was
         // outside keypath input.
-        XCTAssert(app.collectionViews.firstMatch.otherElements.staticTexts["N"].exists)
-        let cell0 = app.collectionViews.firstMatch.cells.element(boundBy: 1)
-        let cell1 = app.collectionViews.firstMatch.cells.element(boundBy: 2)
+        XCTAssert(app.tables.firstMatch.otherElements.staticTexts["N"].exists)
+        let cell0 = app.tables.firstMatch.cells.element(boundBy: 0)
+        let cell1 = app.tables.firstMatch.cells.element(boundBy: 1)
         XCTAssert(cell0.staticTexts["New List"].exists)
         XCTAssert(cell1.staticTexts["New List"].exists)
         XCTAssertEqual(realm.objects(ReminderList.self).count, 2)
-        // The section title is now a cell within the collection view
-        XCTAssertEqual(app.collectionViews.firstMatch.cells.count, 3)
+        XCTAssertEqual(app.tables.firstMatch.cells.count, 2)
 
         // Change isFlagged status of a linked reminder.
         try! realm.write {
@@ -417,15 +398,15 @@ class SwiftUITests: XCTestCase {
         // Expect 2 cells now displaying "changed".
         // Expect two sections as another `ReminderList` has
         // been inserted into the Realm.
-        XCTAssert(app.collectionViews.otherElements.staticTexts["A"].exists)
-        XCTAssert(app.collectionViews.otherElements.staticTexts["c"].exists)
+        XCTAssert(app.tables.otherElements.staticTexts["A"].exists)
+        XCTAssert(app.tables.otherElements.staticTexts["c"].exists)
         XCTAssert(cell0.staticTexts["Another List"].exists)
-        let cell2 = app.collectionViews.cells.element(boundBy: 3)
-        let cell3 = app.collectionViews.cells.element(boundBy: 4)
+        let cell2 = app.tables.cells.element(boundBy: 1)
+        let cell3 = app.tables.cells.element(boundBy: 2)
         XCTAssert(cell2.staticTexts["changed"].exists)
         XCTAssert(cell3.staticTexts["changed"].exists)
         XCTAssertEqual(realm.objects(ReminderList.self).count, 3)
-        XCTAssertEqual(app.collectionViews.firstMatch.cells.count, 5)
+        XCTAssertEqual(app.tables.firstMatch.cells.count, 3)
     }
 
     func testKeyPathObservedSectionedResults2() {
@@ -455,13 +436,13 @@ class SwiftUITests: XCTestCase {
         // Expect the ui to still show two cells labelled New List.
         // The view should've not updated because the name change was
         // outside keypath input.
-        XCTAssert(app.collectionViews.firstMatch.otherElements.staticTexts["N"].exists)
-        let cell0 = app.collectionViews.firstMatch.cells.element(boundBy: 1)
-        let cell1 = app.collectionViews.firstMatch.cells.element(boundBy: 2)
+        XCTAssert(app.tables.firstMatch.otherElements.staticTexts["N"].exists)
+        let cell0 = app.tables.firstMatch.cells.element(boundBy: 0)
+        let cell1 = app.tables.firstMatch.cells.element(boundBy: 1)
         XCTAssert(cell0.staticTexts["New List"].exists)
         XCTAssert(cell1.staticTexts["New List"].exists)
         XCTAssertEqual(realm.objects(ReminderList.self).count, 2)
-        XCTAssertEqual(app.collectionViews.firstMatch.cells.count, 3)
+        XCTAssertEqual(app.tables.firstMatch.cells.count, 2)
 
         // Change isFlagged status of a linked reminder.
         try! realm.write {
@@ -477,15 +458,15 @@ class SwiftUITests: XCTestCase {
         // Expect 2 cells now displaying "changed".
         // Expect two sections as another `ReminderList` has
         // been inserted into the Realm.
-        XCTAssert(app.collectionViews.otherElements.staticTexts["A"].exists)
-        XCTAssert(app.collectionViews.otherElements.staticTexts["c"].exists)
+        XCTAssert(app.tables.otherElements.staticTexts["A"].exists)
+        XCTAssert(app.tables.otherElements.staticTexts["c"].exists)
         XCTAssert(cell0.staticTexts["Another List"].exists)
-        let cell2 = app.collectionViews.cells.element(boundBy: 3)
-        let cell3 = app.collectionViews.cells.element(boundBy: 4)
+        let cell2 = app.tables.cells.element(boundBy: 1)
+        let cell3 = app.tables.cells.element(boundBy: 2)
         XCTAssert(cell2.staticTexts["changed"].exists)
         XCTAssert(cell3.staticTexts["changed"].exists)
         XCTAssertEqual(realm.objects(ReminderList.self).count, 3)
-        XCTAssertEqual(app.collectionViews.firstMatch.cells.count, 5)
+        XCTAssertEqual(app.tables.firstMatch.cells.count, 3)
     }
 
     func testUpdateObservedSectionedResultsWithSearchable() {
@@ -514,38 +495,36 @@ class SwiftUITests: XCTestCase {
             searchBar.typeText(deleteString)
         }
 
-        let table = app.collectionViews.firstMatch
+        let table = app.tables.firstMatch
 
         // Observed Results filter, should filter reminders without name.
-        XCTAssertEqual(table.cells.count, 12)
+        XCTAssertEqual(table.cells.count, 20)
 
         let searchBar = app.searchFields.firstMatch
         searchBar.tap()
 
         searchBar.typeText("reminder")
-        XCTAssertEqual(table.cells.count, 14)
-        XCTAssert(app.collectionViews.otherElements.staticTexts["r"].exists)
+        XCTAssertEqual(table.cells.count, 20)
+        XCTAssert(app.tables.otherElements.staticTexts["r"].exists)
 
         searchBar.typeText(" list 1")
-        XCTAssertEqual(table.cells.count, 12)
+        XCTAssertEqual(table.cells.count, 11)
 
         searchBar.typeText("8")
-        XCTAssertEqual(table.cells.count, 2)
+        XCTAssertEqual(table.cells.count, 1)
 
         searchBar.typeText("9")
         XCTAssertEqual(table.cells.count, 0)
 
         clearSearchBar()
-        app.buttons["Cancel"].tap()
-        XCTAssertEqual(table.cells.count, 12)
+        XCTAssertEqual(table.cells.count, 20)
 
-        searchBar.tap()
         searchBar.typeText("5")
-        XCTAssertEqual(table.cells.count, 3)
+        XCTAssertEqual(table.cells.count, 2)
 
         clearSearchBar()
         searchBar.typeText("12")
-        XCTAssertEqual(table.cells.count, 2)
+        XCTAssertEqual(table.cells.count, 1)
     }
 
     func testObservedSectionedResultsConfiguration() {
@@ -565,12 +544,12 @@ class SwiftUITests: XCTestCase {
             addButtonB.tap()
         }
 
-        let tableA = app.collectionViews["ListA"]
+        let tableA = app.tables["ListA"]
         XCTAssert(tableA.otherElements.staticTexts["N"].exists)
-        XCTAssertEqual(tableA.cells.count, 6)
+        XCTAssertEqual(tableA.cells.count, 5)
 
-        let tableB = app.collectionViews["ListB"]
+        let tableB = app.tables["ListB"]
         XCTAssert(tableB.otherElements.staticTexts["N"].exists)
-        XCTAssertEqual(tableB.cells.count, 6)
+        XCTAssertEqual(tableB.cells.count, 5)
     }
 }

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -350,7 +350,7 @@ extension List: MutableCollection {
     public func move(fromOffsets offsets: IndexSet, toOffset destination: Int) {
         for offset in offsets {
             var d = destination
-            if destination >= count {
+            if destination > offset {
                 d = destination - 1
             }
             move(from: offset, to: d)

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -346,7 +346,7 @@ class ListTests: TestCase {
         XCTAssertEqual(array[1].stringCol, "3")
         XCTAssertEqual(array[2].stringCol, "2")
 
-        array.move(fromOffsets: IndexSet([0]), toOffset: 0)
+        array.move(fromOffsets: IndexSet([0]), toOffset: 1)
         // [1, 3, 2]
         XCTAssertEqual(array[0].stringCol, "1")
         XCTAssertEqual(array[1].stringCol, "3")
@@ -368,10 +368,10 @@ class ListTests: TestCase {
         XCTAssertEqual(array[2].stringCol, "3")
 
         array.move(fromOffsets: IndexSet([0, 2]), toOffset: 1)
-        // [2, 3, 1]
-        XCTAssertEqual(array[0].stringCol, "2")
+        // [1, 3, 2]
+        XCTAssertEqual(array[0].stringCol, "1")
         XCTAssertEqual(array[1].stringCol, "3")
-        XCTAssertEqual(array[2].stringCol, "1")
+        XCTAssertEqual(array[2].stringCol, "2")
     }
 
     func testReplaceRange() {

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -22,6 +22,11 @@ import Realm
 
 final class SwiftStringObject: Object {
     @objc dynamic var stringCol = ""
+
+    convenience init(stringCol: String) {
+        self.init()
+        self.stringCol = stringCol
+    }
 }
 
 class ModernSwiftStringObject: Object {

--- a/RealmSwift/Tests/SwiftUITests.swift
+++ b/RealmSwift/Tests/SwiftUITests.swift
@@ -453,18 +453,31 @@ class SwiftUITests: TestCase {
         object.stringList.append(SwiftStringObject(stringCol: "Tom"))
         object.stringList.append(SwiftStringObject(stringCol: "Sam"))
         object.stringList.append(SwiftStringObject(stringCol: "Dan"))
+        object.stringList.append(SwiftStringObject(stringCol: "Paul"))
 
         let binding = object.bind(\.stringList)
         XCTAssertEqual(object.stringList.first!.stringCol, "Tom")
-        XCTAssertEqual(object.stringList.last!.stringCol, "Dan")
+        XCTAssertEqual(object.stringList[1].stringCol, "Sam")
+        XCTAssertEqual(object.stringList[2].stringCol, "Dan")
+        XCTAssertEqual(object.stringList.last!.stringCol, "Paul")
 
         binding.move(fromOffsets: IndexSet([0]), toOffset: 3)
         XCTAssertEqual(object.stringList.first!.stringCol, "Sam")
+        XCTAssertEqual(object.stringList[1].stringCol, "Dan")
+        XCTAssertEqual(object.stringList[2].stringCol, "Tom")
+        XCTAssertEqual(object.stringList.last!.stringCol, "Paul")
+
+        binding.move(fromOffsets: IndexSet([2]), toOffset: 4)
+        XCTAssertEqual(object.stringList.first!.stringCol, "Sam")
+        XCTAssertEqual(object.stringList[1].stringCol, "Dan")
+        XCTAssertEqual(object.stringList[2].stringCol, "Paul")
         XCTAssertEqual(object.stringList.last!.stringCol, "Tom")
 
-        binding.move(fromOffsets: IndexSet([2]), toOffset: 0)
+        binding.move(fromOffsets: IndexSet([3]), toOffset: 0)
         XCTAssertEqual(object.stringList.first!.stringCol, "Tom")
-        XCTAssertEqual(object.stringList.last!.stringCol, "Dan")
+        XCTAssertEqual(object.stringList[1].stringCol, "Sam")
+        XCTAssertEqual(object.stringList[2].stringCol, "Dan")
+        XCTAssertEqual(object.stringList.last!.stringCol, "Paul")
 
         XCTAssertEqual(state.wrappedValue.count, 0)
     }
@@ -477,20 +490,33 @@ class SwiftUITests: TestCase {
         object.stringList.append(SwiftStringObject(stringCol: "Tom"))
         object.stringList.append(SwiftStringObject(stringCol: "Sam"))
         object.stringList.append(SwiftStringObject(stringCol: "Dan"))
+        object.stringList.append(SwiftStringObject(stringCol: "Paul"))
 
         state.projectedValue.append(object)
 
         let binding = object.bind(\.stringList)
         XCTAssertEqual(object.stringList.first!.stringCol, "Tom")
-        XCTAssertEqual(object.stringList.last!.stringCol, "Dan")
+        XCTAssertEqual(object.stringList[1].stringCol, "Sam")
+        XCTAssertEqual(object.stringList[2].stringCol, "Dan")
+        XCTAssertEqual(object.stringList.last!.stringCol, "Paul")
 
         binding.move(fromOffsets: IndexSet([0]), toOffset: 3)
         XCTAssertEqual(object.stringList.first!.stringCol, "Sam")
+        XCTAssertEqual(object.stringList[1].stringCol, "Dan")
+        XCTAssertEqual(object.stringList[2].stringCol, "Tom")
+        XCTAssertEqual(object.stringList.last!.stringCol, "Paul")
+
+        binding.move(fromOffsets: IndexSet([2]), toOffset: 4)
+        XCTAssertEqual(object.stringList.first!.stringCol, "Sam")
+        XCTAssertEqual(object.stringList[1].stringCol, "Dan")
+        XCTAssertEqual(object.stringList[2].stringCol, "Paul")
         XCTAssertEqual(object.stringList.last!.stringCol, "Tom")
 
-        binding.move(fromOffsets: IndexSet([2]), toOffset: 0)
+        binding.move(fromOffsets: IndexSet([3]), toOffset: 0)
         XCTAssertEqual(object.stringList.first!.stringCol, "Tom")
-        XCTAssertEqual(object.stringList.last!.stringCol, "Dan")
+        XCTAssertEqual(object.stringList[1].stringCol, "Sam")
+        XCTAssertEqual(object.stringList[2].stringCol, "Dan")
+        XCTAssertEqual(object.stringList.last!.stringCol, "Paul")
 
         XCTAssertEqual(state.wrappedValue.count, 1)
     }


### PR DESCRIPTION
Fix moving `List` items to a higher index in SwiftUI results in wrong  destination index.
https://github.com/realm/realm-swift/issues/7956
Fixed some of the SwiftUI test, the other two are failing because the hardware keyboard is  enabled and is causing issues when typing on a staticText field.