### PR TITLE
Check conformance to NSFastEnumeration before iterating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
-* None.
+* Setting a `List` property with `Results` no longer throws an unrecognized selector exception (since 10.8.0-beta.2)
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -112,9 +112,10 @@ static id validatedObjectForProperty(__unsafe_unretained id const obj,
     }
     if (prop.type == RLMPropertyTypeObject) {
         Class objectClass = schema[prop.objectClassName].objectClass;
+        id enumerable = RLMAsFastEnumeration(obj);
         if (prop.dictionary) {
             NSMutableDictionary *ret = [[NSMutableDictionary alloc] init];
-            for (id key in obj) {
+            for (id key in enumerable) {
                 id val = RLMCoerceToNil(obj[key]);
                 if (val) {
                     val = coerceToObjectType(obj[key], objectClass, schema);
@@ -125,7 +126,6 @@ static id validatedObjectForProperty(__unsafe_unretained id const obj,
         }
         else if (prop.collection) {
             NSMutableArray *ret = [[NSMutableArray alloc] init];
-            id enumerable = RLMAsFastEnumeration(obj);
             for (id el in enumerable) {
                 [ret addObject:coerceToObjectType(el, objectClass, schema)];
             }

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -125,7 +125,8 @@ static id validatedObjectForProperty(__unsafe_unretained id const obj,
         }
         else if (prop.collection) {
             NSMutableArray *ret = [[NSMutableArray alloc] init];
-            for (id el in obj) {
+            id enumerable = RLMAsFastEnumeration(obj);
+            for (id el in enumerable) {
                 [ret addObject:coerceToObjectType(el, objectClass, schema)];
             }
             return ret;

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -565,7 +565,7 @@ class ObjectTests: TestCase {
         setter(object, NSNull(), "arrayCol")
         XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).count, 0)
 
-        if (object.realm != nil) {
+        if object.realm != nil {
             let listRes = object.realm!.objects(SwiftBoolObject.self).filter("boolCol == true")
             setter(object, listRes, "arrayCol")
             XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).count, listRes.count)

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -565,6 +565,13 @@ class ObjectTests: TestCase {
         setter(object, NSNull(), "arrayCol")
         XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).count, 0)
 
+        if (object.realm != nil) {
+            let listRes = object.realm!.objects(SwiftBoolObject.self).filter("boolCol == true")
+            setter(object, listRes, "arrayCol")
+            XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).count, listRes.count)
+            assertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).first!, boolObject)
+        }
+
         let set = MutableSet<SwiftBoolObject>()
         set.insert(boolObject)
         setter(object, set, "setCol")


### PR DESCRIPTION
This will now check that a collection conforms to NSFastEnumeration before iterating in RLMObjectBase.
Previously a __SwiftValue could run into an unrecognized selector exception. RLMAsFastEnumeration checks that the collection conforms to NSFastEnumeration. If it does, it returns. If it doesn't, it bridges the value.

This should allow something like:
<img width="816" alt="Screen Shot 2022-09-20 at 1 17 12 PM" src="https://user-images.githubusercontent.com/25092858/191519566-946ae9a9-3a1b-4c2f-bf72-99120ec69449.png">
