### PR TITLE
Fix a pile of issues with sync/app error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* `Realm.Error` is now a typealias for `RLMError` rather than a
+  manually-defined version of what the automatic bridging produces. This should
+  have no effect on existing working code, but the manual definition was
+  missing a few things supplied by the automatic bridging.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,27 @@ x.y.z Release notes (yyyy-MM-dd)
   manually-defined version of what the automatic bridging produces. This should
   have no effect on existing working code, but the manual definition was
   missing a few things supplied by the automatic bridging.
+* Some sync errors sent by the server include a link to the server-side logs
+  associated with that error. This link is now exposed in the `serverLogURL`
+  property on `SyncError` (or `RLMServerLogURLKey` userInfo field when using NSError).
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
-* None.
+* Many sync and app errors were reported using undocumented internal error
+  codes and/or domains and could not be progammatically handled. Some notable
+  things which now have public error codes instead of unstable internal ones:
+  - `Realm.Error.subscriptionFailed`: The server rejected a flexible sync subscription.
+  - `AppError.invalidPassword`: A login attempt failed due to a bad password.
+  - `AppError.accountNameInUse`: A registration attempt failed due to the account name being in use.
+  - `AppError.httpRequestFailed`: A HTTP request to Atlas App Services
+    completed with an error HTTP code. The failing code is available in the
+    `httpStatusCode` property.
+  - Many other less common error codes have been added to `AppError`.
+  - All sync errors other than `SyncError.clientResetError` reported incorrect
+    error codes.
+  (since v10.0.0).
+* `UserAPIKey.objectId` was incorrectly bridged to Swift as `RLMObjectId` to
+  `ObjectId`. This may produce warnings about an unneccesary cast if you were
+  previously casting it to the correct type (since v10.0.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/ObjectServerTests/RLMAsymmetricSyncServerTests.mm
+++ b/Realm/ObjectServerTests/RLMAsymmetricSyncServerTests.mm
@@ -263,22 +263,23 @@ RLM_COLLECTION_TYPE(PersonAsymmetric);
 
 - (void)testOpenLocalRealmWithAsymmetricObjectError {
     RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
-    configuration.objectClasses =  @[PersonAsymmetric.self];
+    configuration.objectClasses = @[PersonAsymmetric.self];
     NSError *error;
     RLMRealm *realm = [RLMRealm realmWithConfiguration:configuration error:&error];
     XCTAssertNil(realm);
-    XCTAssertNotNil(error);
+    RLMValidateErrorContains(error, RLMErrorDomain, RLMErrorFail,
+                             @"Asymmetric table 'PersonAsymmetric' not allowed in a local Realm");
 }
 
-// FIXME: Enable this test when this is implemented on core. Core should validate if the schema includes an asymmetric table for a PBS configuration and throw an error.
-- (void)fixme_testOpenPBSConfigurationWithAsymmetricObjectError {
+- (void)testOpenPBSConfigurationWithAsymmetricObjectError {
     RLMUser *user = [self userForTest:_cmd];
     RLMRealmConfiguration *configuration = [user configurationWithPartitionValue:NSStringFromSelector(_cmd)];
     configuration.objectClasses = @[PersonAsymmetric.self];
     NSError *error;
     RLMRealm *realm = [RLMRealm realmWithConfiguration:configuration error:&error];
     XCTAssertNil(realm);
-    XCTAssertNotNil(error);
+    RLMValidateErrorContains(error, RLMErrorDomain, RLMErrorFail,
+                             @"Asymmetric table 'PersonAsymmetric' not allowed in partition based sync");
 }
 
 - (void)testCreateAsymmetricObjects {

--- a/Realm/ObjectServerTests/RLMFlexibleSyncServerTests.mm
+++ b/Realm/ObjectServerTests/RLMFlexibleSyncServerTests.mm
@@ -901,15 +901,19 @@
     }];
     CHECK_COUNT(3, Person, realm);
 
-    auto ex = [self expectationWithDescription:@"should client reset"];
-    [self.flexibleSyncApp syncManager].errorHandler = ^(NSError * error, RLMSyncSession *) {
-        XCTAssertNotNil(error);
+    RLMObjectId *invalidObjectPK = [RLMObjectId objectId];
+    auto ex = [self expectationWithDescription:@"should revert write"];
+    self.flexibleSyncApp.syncManager.errorHandler = ^(NSError *error, RLMSyncSession *) {
+        RLMValidateError(error, RLMSyncErrorDomain, RLMSyncErrorWriteRejected,
+                         @"Client attempted a write that is outside of permissions or query filters; it has been reverted");
         [ex fulfill];
     };
     [realm transactionWithBlock:^{
-        [realm addObject:[[Person alloc] initWithPrimaryKey:[RLMObjectId objectId] age:10 firstName:@"Nic" lastName:@"Cages"]];
+        [realm addObject:[[Person alloc] initWithPrimaryKey:invalidObjectPK age:10 firstName:@"Nic" lastName:@"Cages"]];
     }];
     [self waitForExpectations:@[ex] timeout:20];
+    [self waitForDownloadsForRealm:realm];
+    CHECK_COUNT(3, Person, realm);
 }
 
 - (void)testFlexibleSyncInitialSubscription {
@@ -1002,6 +1006,7 @@
     [RLMRealm asyncOpenWithConfiguration:config
                            callbackQueue:dispatch_get_main_queue()
                                 callback:^(RLMRealm *realm, NSError *error) {
+        XCTAssertNotNil(realm);
         XCTAssertNil(error);
         XCTAssertEqual(realm.subscriptions.count, 1UL);
         // Adding this sleep, because there seems to be a timing issue after this commit in baas
@@ -1012,7 +1017,7 @@
         CHECK_COUNT(11, Person, realm);
         [ex fulfill];
     }];
-    [self waitForExpectationsWithTimeout:30.0 handler:nil];
+    [self waitForExpectationsWithTimeout:90.0 handler:nil];
     XCTAssertEqual(openCount, 1);
 
     __block RLMRealm *realm;
@@ -1021,12 +1026,13 @@
                            callbackQueue:dispatch_get_main_queue()
                                 callback:^(RLMRealm *r, NSError *error) {
         realm = r;
+        XCTAssertNotNil(realm);
         XCTAssertNil(error);
         XCTAssertEqual(realm.subscriptions.count, 2UL);
         CHECK_COUNT(16, Person, realm);
         [ex2 fulfill];
     }];
-    [self waitForExpectationsWithTimeout:30.0 handler:nil];
+    [self waitForExpectationsWithTimeout:90.0 handler:nil];
     XCTAssertEqual(openCount, 2);
 
     [self dispatchAsyncAndWait:^{
@@ -1071,9 +1077,8 @@
     [RLMRealm asyncOpenWithConfiguration:config
                            callbackQueue:dispatch_get_main_queue()
                                 callback:^(RLMRealm *realm, NSError *error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqual(error.code, ETIMEDOUT);
-        XCTAssertEqual(error.domain, NSPOSIXErrorDomain);
+        RLMValidateError(error, NSPOSIXErrorDomain, ETIMEDOUT,
+                         @"Sync connection was not fully established in time");
         XCTAssertNil(realm);
         [ex fulfill];
     }];
@@ -1093,11 +1098,9 @@
     [RLMRealm asyncOpenWithConfiguration:config
                            callbackQueue:dispatch_get_main_queue()
                                 callback:^(RLMRealm *realm, NSError *error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqual(error.code, 2);
-        XCTAssertTrue([error.domain isEqualToString: @"io.realm.sync.flx"]); // This is a flexible sync error when the query property is not a queryable field, realm is opened but the subscription could not be completed.
+        RLMValidateError(error, RLMErrorDomain, RLMErrorSubscriptionFailed,
+                         @"Client provided query with bad syntax: unsupported query for table \"UUIDPrimaryKeyObject\": key \"strCol\" is not a queryable field");
         XCTAssertNotNil(realm);
-
         [ex fulfill];
     }];
     [self waitForExpectationsWithTimeout:30.0 handler:nil];

--- a/Realm/ObjectServerTests/SwiftAsymmetricSyncServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftAsymmetricSyncServerTests.swift
@@ -157,17 +157,13 @@ class SwiftAsymmetricSyncTests: SwiftSyncTestCase {
         }
     }
 
-    // FIXME: Enable this test when this is implemented on core. Core should validate if the schema includes an asymmetric table for a PBS configuration and throw an error.
-    func fixme_testOpenPBSConfigurationRealmWithAsymmetricObjectError() throws {
+    func testOpenPBSConfigurationRealmWithAsymmetricObjectError() throws {
         let user = try logInUser(for: basicCredentials(app: self.flexibleSyncApp), app: self.flexibleSyncApp)
         var configuration = user.configuration(partitionValue: #function)
         configuration.objectTypes = [SwiftObjectAsymmetric.self]
 
-        do {
-            _ = try Realm(configuration: configuration)
-            XCTFail("Opening a local Realm with an `Asymmetric` table should fail")
-        } catch {
-            XCTAssertNotNil(error)
+        XCTAssertThrowsError(try Realm(configuration: configuration)) { error in
+            XCTAssert(error.localizedDescription.contains("Asymmetric table 'SwiftObjectAsymmetric' not allowed in partition based sync"))
         }
     }
 }

--- a/Realm/RLMApp.mm
+++ b/Realm/RLMApp.mm
@@ -211,15 +211,6 @@ namespace {
 
 @end
 
-NSError *RLMAppErrorToNSError(realm::app::AppError const& appError) {
-    return [[NSError alloc] initWithDomain:@(appError.error_code.category().name())
-                                      code:appError.error_code.value()
-                                  userInfo:@{
-                                      @(appError.error_code.category().name()) : @(appError.error_code.message().data()),
-                                      NSLocalizedDescriptionKey : @(appError.message.c_str())
-                                  }];
-}
-
 #pragma mark RLMAppSubscriptionToken
 @implementation RLMAppSubscriptionToken {
 @public

--- a/Realm/RLMConstants.h
+++ b/Realm/RLMConstants.h
@@ -152,9 +152,10 @@ typedef RLM_ERROR_ENUM(NSInteger, RLMError, RLMErrorDomain) {
 
     /// Denotates an error where an input value was invalid.
     RLMErrorInvalidInput = 13,
-};
 
-#pragma mark - Constants
+    /// A subscription was rejected by the server.
+    RLMErrorSubscriptionFailed = 14,
+};
 
 #pragma mark - Notification Constants
 

--- a/Realm/RLMConstants.m
+++ b/Realm/RLMConstants.m
@@ -22,7 +22,6 @@ RLMNotification const RLMRealmRefreshRequiredNotification = @"RLMRealmRefreshReq
 RLMNotification const RLMRealmDidChangeNotification = @"RLMRealmDidChangeNotification";
 
 NSString * const RLMErrorDomain = @"io.realm";
-
 NSString * const RLMUnknownSystemErrorDomain = @"io.realm.unknown";
 
 NSString * const RLMExceptionName = @"RLMException";
@@ -34,3 +33,5 @@ NSString * const RLMRealmCoreVersionKey = @"RLMRealmCoreVersion";
 NSString * const RLMInvalidatedKey = @"invalidated";
 
 NSString * const RLMBackupRealmConfigurationErrorKey = @"RLMBackupRealmConfiguration";
+NSString * const RLMServerLogURLKey = @"Server Log URL";
+NSString * const RLMHTTPStatusCodeKey = @"HTTP Status Code";

--- a/Realm/RLMSyncUtil.h
+++ b/Realm/RLMSyncUtil.h
@@ -29,18 +29,18 @@ extern NSString *const kRLMSyncPathOfRealmBackupCopyKey;
 /// A user info key for use with certain error types.
 extern NSString *const kRLMSyncErrorActionTokenKey;
 
+/// A user info key present in sync errors which originate from the server, containing the URL of the server-side logs associated with the error.
+extern NSString * const RLMServerLogURLKey;
+
+/// A user info key containing a HTTP status code. Some ``RLMAppError`` codes include this, most notably ``RLMAppErrorHttpRequestFailed``.
+extern NSString * const RLMHTTPStatusCodeKey;
+
 /**
  The error domain string for all SDK errors related to errors reported
  by the synchronization manager error handler, as well as general sync
  errors that don't fall into any of the other categories.
  */
 extern NSString *const RLMSyncErrorDomain;
-
-/**
- The error domain string for all SDK errors related to the authentication
- endpoint.
- */
-extern NSString *const RLMSyncAuthErrorDomain;
 
 /**
 The error domain string for all SDK errors related to the Atlas App Services
@@ -60,16 +60,16 @@ extern NSString *const RLMFlexibleSyncErrorDomain;
 typedef RLM_ERROR_ENUM(NSInteger, RLMSyncError, RLMSyncErrorDomain) {
 
     /// An error that indicates a problem with the session (a specific Realm opened for sync).
-    RLMSyncErrorClientSessionError      = 4,
+    RLMSyncErrorClientSessionError = 4,
 
     /// An error that indicates a problem with a specific user.
-    RLMSyncErrorClientUserError         = 5,
+    RLMSyncErrorClientUserError = 5,
 
     /**
      An error that indicates an internal, unrecoverable problem
      with the underlying synchronization engine.
      */
-    RLMSyncErrorClientInternalError     = 6,
+    RLMSyncErrorClientInternalError = 6,
 
     /**
      An error that indicates the Realm needs to be reset.
@@ -90,7 +90,7 @@ typedef RLM_ERROR_ENUM(NSInteger, RLMSyncError, RLMSyncErrorDomain) {
      was backed up on the server.
 
      The client reset process can be initiated in one of two ways.
-     
+
      The `userInfo` dictionary contains an opaque token object under the key
      `kRLMSyncErrorActionTokenKey`. This token can be passed into
      `+[RLMSyncSession immediatelyHandleError:]` in order to immediately perform the client
@@ -108,29 +108,25 @@ typedef RLM_ERROR_ENUM(NSInteger, RLMSyncError, RLMSyncErrorDomain) {
 
      @see `-[NSError rlmSync_errorActionToken]`, `-[NSError rlmSync_clientResetBackedUpRealmPath]`
      */
-    RLMSyncErrorClientResetError        = 7,
+    RLMSyncErrorClientResetError = 7,
 
     /**
-     An error that indicates an authentication error occurred.
-
-     The `kRLMSyncUnderlyingErrorKey` key in the user info dictionary will contain the
-     underlying error, which is guaranteed to be under the `RLMSyncAuthErrorDomain`
-     error domain.
+     Not used.
      */
-    RLMSyncErrorUnderlyingAuthError     = 8,
+    RLMSyncErrorUnderlyingAuthError = 8,
 
     /**
      An error that indicates the user does not have permission to perform an operation
      upon a synced Realm. For example, a user may receive this error if they attempt to
      open a Realm they do not have at least read access to, or write to a Realm they only
      have read access to.
-     
+
      This error may also occur if a user incorrectly opens a Realm they have read-only
      permissions to without using the `asyncOpen()` APIs.
 
      A Realm that suffers a permission denied error is, by default, flagged so that its
      local copy will be deleted the next time the application starts.
-     
+
      The `userInfo` dictionary contains an opaque token object under the key
      `kRLMSyncErrorActionTokenKey`. This token can be passed into
      `+[RLMSyncSession immediatelyHandleError:]` in order to immediately delete the local
@@ -140,10 +136,20 @@ typedef RLM_ERROR_ENUM(NSInteger, RLMSyncError, RLMSyncErrorDomain) {
 
      @warning It is strongly recommended that, if a Realm has encountered a permission denied
               error, its files be deleted before attempting to re-open it.
-     
+
      @see `-[NSError rlmSync_errorActionToken]`
      */
-    RLMSyncErrorPermissionDeniedError   = 9,
+    RLMSyncErrorPermissionDeniedError = 9,
+
+    /**
+     An error that indicates that the server has reverted a write made by this
+     client. This can happen due to not having write permission, or because an
+     object was created in a flexible sync Realm which does not match any
+     active subscriptions.
+
+     This error is informational and does not require any explicit handling.
+     */
+    RLMSyncErrorWriteRejected = 10,
 };
 
 /**
@@ -151,70 +157,79 @@ typedef RLM_ERROR_ENUM(NSInteger, RLMSyncError, RLMSyncErrorDomain) {
  */
 typedef RLM_ERROR_ENUM(NSInteger, RLMFlexibleSyncError, RLMFlexibleSyncErrorDomain) {
     /// An error describing why the subscription set synchronization failed.
-    RLMFlexibleSyncErrorStatusError     = 1,
+    RLMFlexibleSyncErrorStatusError = 1,
 
     /// An error while committing a subscription write.
-    RLMFlexibleSyncErrorCommitSubscriptionSetError     = 2,
+    RLMFlexibleSyncErrorCommitSubscriptionSetError = 2,
 
     /// An error while refreshing the subscription set state.
-    RLMFlexibleSyncErrorRefreshSubscriptionSetError     = 3,
+    RLMFlexibleSyncErrorRefreshSubscriptionSetError = 3,
 };
 
-/// An error which is related to authentication to Atlas App Services.
-typedef RLM_ERROR_ENUM(NSInteger, RLMSyncAuthError, RLMSyncAuthErrorDomain) {
-    /// An error that indicates that the response received from the authentication server was malformed.
-    RLMSyncAuthErrorBadResponse                     = 1,
-
-    /// An error that indicates that the supplied Realm path was invalid, or could not be resolved by the authentication
-    /// server.
-    RLMSyncAuthErrorBadRemoteRealmPath              = 2,
-
-    /// An error that indicates that the response received from the authentication server was an HTTP error code. The
-    /// `userInfo` dictionary contains the actual error code value.
-    RLMSyncAuthErrorHTTPStatusCodeError             = 3,
-
-    /// An error that indicates a problem with the session (a specific Realm opened for sync).
-    RLMSyncAuthErrorClientSessionError              = 4,
-
-    /// An error that indicates that the provided credentials are ill-formed.
-    RLMSyncAuthErrorInvalidParameters               = 601,
-
-    /// An error that indicates that no Realm path was included in the URL.
-    RLMSyncAuthErrorMissingPath                     = 602,
-
-    /// An error that indicates that the provided credentials are invalid.
-    RLMSyncAuthErrorInvalidCredential               = 611,
-
-    /// An error that indicates that the user with provided credentials does not exist.
-    RLMSyncAuthErrorUserDoesNotExist                = 612,
-
-    /// An error that indicates that the user cannot be registered as it exists already.
-    RLMSyncAuthErrorUserAlreadyExists               = 613,
-
-    /// An error that indicates the path is invalid or the user doesn't have access to that Realm.
-    RLMSyncAuthErrorAccessDeniedOrInvalidPath       = 614,
-
-    /// An error that indicates the refresh token was invalid.
-    RLMSyncAuthErrorInvalidAccessToken              = 615,
-
-    /// An error that indicates the file at the given path can't be shared.
-    RLMSyncAuthErrorFileCannotBeShared              = 703,
-};
-
-/// An error which is related to authentication to Atlas App Services.
+/// An error which occurred when making a request to Atlas App Services.
 typedef RLM_ERROR_ENUM(NSInteger, RLMAppError, RLMAppErrorDomain) {
     /// An unknown error has occured
-    RLMAppErrorUnknown                        = -1,
-    
-    /// An error that indicates that the session is invalid
-    RLMAppErrorInvalidSession                 = 2,
-    
-    /// An error that indicates that the request sent to the server was invalid
-    RLMAppErrorBadRequest                     = 48,
-    
-    /// An error that indicates the user cannot be found
-    RLMAppErrorUserNotFound                   = 45
-};
+    RLMAppErrorUnknown = -1,
 
+    /// A HTTP request completed with an error status code. The failing status
+    /// code can be found in the ``RLMHTTPStatusCodeKey`` key of the userInfo
+    /// dictionary.
+    RLMAppErrorHttpRequestFailed = 1,
+
+    /// A user's session is in an invalid state. Logging out and back in may rectify this.
+    RLMAppErrorInvalidSession,
+    /// A request sent to the server was malformed in some way.
+    RLMAppErrorBadRequest,
+    /// A request was made using a nonexistent user.
+    RLMAppErrorUserNotFound,
+    /// A request was made against an App using a User which does not belong to that App.
+    RLMAppErrorUserAppDomainMismatch,
+    /// The auth provider has limited the domain names which can be used for email addresses, and the given one is not allowed.
+    RLMAppErrorDomainNotAllowed,
+    /// The request body size exceeded a server-configured limit.
+    RLMAppErrorReadSizeLimitExceeded,
+    /// A request had an invalid parameter.
+    RLMAppErrorInvalidParameter,
+    /// A request was missing a required parameter.
+    RLMAppErrorMissingParameter,
+    /// Executing the requested server function failed with an error.
+    RLMAppErrorFunctionExecutionError,
+    /// The server encountered an internal error.
+    RLMAppErrorInternalServerError,
+    /// Authentication failed due to the request auth provider not existing.
+    RLMAppErrorAuthProviderNotFound,
+    /// The requested value does not exist.
+    RLMAppErrorValueNotFound,
+    /// The value being created already exists.
+    RLMAppErrorValueAlreadyExists,
+    /// A value with the same name as the value being created already exists.
+    RLMAppErrorValueDuplicateName,
+    /// The called server function does not exist.
+    RLMAppErrorFunctionNotFound,
+    /// The called server function has a syntax error.
+    RLMAppErrorFunctionSyntaxError,
+    /// The called server function is invalid in some way.
+    RLMAppErrorFunctionInvalid,
+    /// Registering an API key with the auth provider failed due to it already existing.
+    RLMAppErrorAPIKeyAlreadyExists,
+    /// The operation failed due to exceeding the server-configured time limit.
+    RLMAppErrorExecutionTimeLimitExceeded,
+    /// The body of the called function does not define a callable thing.
+    RLMAppErrorNotCallable,
+    /// Email confirmation failed for a user because the user has already confirmed their email.
+    RLMAppErrorUserAlreadyConfirmed,
+    /// The user cannot be used because it has been disabled.
+    RLMAppErrorUserDisabled,
+    /// An auth error occurred which does not have a more specific error code.
+    RLMAppErrorAuthError,
+    /// Account registration failed due to the user name already being taken.
+    RLMAppErrorAccountNameInUse,
+    /// A login request failed due to an invalid password.
+    RLMAppErrorInvalidPassword,
+    /// Operation failed due to server-side maintenance.
+    RLMAppErrorMaintenanceInProgress,
+    /// Operation failed due to an error reported by MongoDB.
+    RLMAppErrorMongoDBError,
+};
 
 NS_ASSUME_NONNULL_END

--- a/Realm/RLMSyncUtil.mm
+++ b/Realm/RLMSyncUtil.mm
@@ -18,19 +18,9 @@
 
 #import "RLMSyncUtil_Private.hpp"
 
-#import "RLMObject_Private.hpp"
-#import "RLMRealmConfiguration_Private.hpp"
-#import "RLMRealm_Private.hpp"
-#import "RLMSyncConfiguration_Private.hpp"
 #import "RLMUser_Private.hpp"
-#import "RLMUtil.hpp"
-
-#import <realm/object-store/shared_realm.hpp>
-#import <realm/object-store/sync/sync_user.hpp>
-#import <realm/sync/config.hpp>
 
 NSString *const RLMSyncErrorDomain = @"io.realm.sync";
-NSString *const RLMSyncAuthErrorDomain = @"io.realm.sync.auth";
 NSString *const RLMAppErrorDomain = @"io.realm.app";
 
 NSString *const RLMFlexibleSyncErrorDomain = @"io.realm.sync.flx";
@@ -54,23 +44,16 @@ static_assert((int)RLMClientResetModeRecoverUnsyncedChanges == (int)realm::Clien
 static_assert((int)RLMClientResetModeRecoverOrDiscardUnsyncedChanges == (int)realm::ClientResyncMode::RecoverOrDiscard);
 static_assert((int)RLMClientResetModeManual == (int)realm::ClientResyncMode::Manual);
 
+static_assert(int(RLMSyncStopPolicyImmediately) == int(SyncSessionStopPolicy::Immediately));
+static_assert(int(RLMSyncStopPolicyLiveIndefinitely) == int(SyncSessionStopPolicy::LiveIndefinitely));
+static_assert(int(RLMSyncStopPolicyAfterChangesUploaded) == int(SyncSessionStopPolicy::AfterChangesUploaded));
 
 SyncSessionStopPolicy translateStopPolicy(RLMSyncStopPolicy stopPolicy) {
-    switch (stopPolicy) {
-        case RLMSyncStopPolicyImmediately:              return SyncSessionStopPolicy::Immediately;
-        case RLMSyncStopPolicyLiveIndefinitely:         return SyncSessionStopPolicy::LiveIndefinitely;
-        case RLMSyncStopPolicyAfterChangesUploaded:     return SyncSessionStopPolicy::AfterChangesUploaded;
-    }
-    REALM_UNREACHABLE();    // Unrecognized stop policy.
+    return static_cast<SyncSessionStopPolicy>(stopPolicy);
 }
 
-RLMSyncStopPolicy translateStopPolicy(SyncSessionStopPolicy stop_policy) {
-    switch (stop_policy) {
-        case SyncSessionStopPolicy::Immediately:            return RLMSyncStopPolicyImmediately;
-        case SyncSessionStopPolicy::LiveIndefinitely:       return RLMSyncStopPolicyLiveIndefinitely;
-        case SyncSessionStopPolicy::AfterChangesUploaded:   return RLMSyncStopPolicyAfterChangesUploaded;
-    }
-    REALM_UNREACHABLE();
+RLMSyncStopPolicy translateStopPolicy(SyncSessionStopPolicy stopPolicy) {
+    return static_cast<RLMSyncStopPolicy>(stopPolicy);
 }
 
 CocoaSyncUserContext& context_for(const std::shared_ptr<realm::SyncUser>& user)
@@ -78,49 +61,8 @@ CocoaSyncUserContext& context_for(const std::shared_ptr<realm::SyncUser>& user)
     return *std::static_pointer_cast<CocoaSyncUserContext>(user->binding_context());
 }
 
-NSError *make_sync_error(RLMSyncSystemErrorKind kind, NSString *description, NSInteger code, NSDictionary *custom) {
-    NSMutableDictionary *buffer = [custom ?: @{} mutableCopy];
-    buffer[NSLocalizedDescriptionKey] = description;
-    if (code != NSNotFound) {
-        buffer[kRLMSyncErrorStatusCodeKey] = @(code);
-    }
-
-    RLMSyncError errorCode;
-    switch (kind) {
-        case RLMSyncSystemErrorKindClientReset:
-            errorCode = RLMSyncErrorClientResetError;
-            break;
-        case RLMSyncSystemErrorKindPermissionDenied:
-            errorCode = RLMSyncErrorPermissionDeniedError;
-            break;
-        case RLMSyncSystemErrorKindUser:
-            errorCode = RLMSyncErrorClientUserError;
-            break;
-        case RLMSyncSystemErrorKindSession:
-            errorCode = RLMSyncErrorClientSessionError;
-            break;
-        case RLMSyncSystemErrorKindConnection:
-        case RLMSyncSystemErrorKindClient:
-        case RLMSyncSystemErrorKindUnknown:
-            errorCode = RLMSyncErrorClientInternalError;
-            break;
-    }
+NSError *make_sync_error(std::error_code error) {
     return [NSError errorWithDomain:RLMSyncErrorDomain
-                               code:errorCode
-                           userInfo:[buffer copy]];
-}
-
-NSError *make_sync_error(NSError *wrapped_auth_error) {
-    return [NSError errorWithDomain:RLMSyncErrorDomain
-                               code:RLMSyncErrorUnderlyingAuthError
-                           userInfo:@{kRLMSyncUnderlyingErrorKey: wrapped_auth_error}];
-}
-
-NSError *make_sync_error(std::error_code sync_error, RLMSyncSystemErrorKind kind) {
-    return [NSError errorWithDomain:RLMSyncErrorDomain
-                               code:kind
-                           userInfo:@{
-                                      NSLocalizedDescriptionKey: @(sync_error.message().c_str()),
-                                      kRLMSyncErrorStatusCodeKey: @(sync_error.value())
-                                      }];
+                               code:error.value()
+                           userInfo:@{NSLocalizedDescriptionKey: @(error.message().c_str())}];
 }

--- a/Realm/RLMSyncUtil_Private.h
+++ b/Realm/RLMSyncUtil_Private.h
@@ -22,18 +22,6 @@
 #import <Realm/RLMRealmConfiguration.h>
 #import <Realm/RLMCredentials.h>
 
-typedef NS_ENUM(NSUInteger, RLMSyncSystemErrorKind) {
-    // Specific
-    RLMSyncSystemErrorKindClientReset,
-    RLMSyncSystemErrorKindPermissionDenied,
-    // General
-    RLMSyncSystemErrorKindClient,
-    RLMSyncSystemErrorKindConnection,
-    RLMSyncSystemErrorKindSession,
-    RLMSyncSystemErrorKindUser,
-    RLMSyncSystemErrorKindUnknown,
-};
-
 @class RLMUser;
 
 typedef void(^RLMSyncCompletionBlock)(NSError * _Nullable, NSDictionary * _Nullable);

--- a/Realm/RLMSyncUtil_Private.hpp
+++ b/Realm/RLMSyncUtil_Private.hpp
@@ -21,14 +21,8 @@
 #import "RLMSyncConfiguration_Private.h"
 
 #import <realm/object-store/sync/sync_manager.hpp>
-#import <realm/util/optional.hpp>
 
-@class RLMSyncErrorResponseModel;
 class CocoaSyncUserContext;
-
-namespace realm {
-enum class AccessLevel;
-}
 
 realm::SyncSessionStopPolicy translateStopPolicy(RLMSyncStopPolicy stopPolicy);
 RLMSyncStopPolicy translateStopPolicy(realm::SyncSessionStopPolicy stop_policy);
@@ -43,12 +37,4 @@ CocoaSyncUserContext& context_for(const std::shared_ptr<realm::SyncUser>& user);
 
 #pragma mark - Error construction
 
-NSError *make_auth_error_bad_response(NSDictionary *json=nil);
-NSError *make_auth_error_http_status(NSInteger status);
-NSError *make_auth_error_client_issue();
-NSError *make_auth_error(RLMSyncErrorResponseModel *responseModel);
-
-// Set 'code' to NSNotFound to not actually have an error code.
-NSError *make_sync_error(RLMSyncSystemErrorKind kind, NSString *description, NSInteger code, NSDictionary *custom);
-NSError *make_sync_error(NSError *wrapped_auth_error);
-NSError *make_sync_error(std::error_code, RLMSyncSystemErrorKind kind=RLMSyncSystemErrorKindSession);
+NSError *make_sync_error(std::error_code);

--- a/Realm/RLMUserAPIKey.h
+++ b/Realm/RLMUserAPIKey.h
@@ -34,8 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// the response when an API key is first created.
 @property (nonatomic, readonly, nullable) NSString *key;
 
-/// The ObjectId of the user
-@property (nonatomic, readonly) RLMObjectId *objectId;
+/// The ObjectId of the API key
+@property (nonatomic, readonly) RLMObjectId *objectId NS_REFINED_FOR_SWIFT;
 
 @end
 

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -43,6 +43,7 @@
 #if REALM_ENABLE_SYNC
 #import "RLMSyncUtil.h"
 #import <realm/sync/client.hpp>
+#import <realm/object-store/sync/app.hpp>
 #endif
 
 #include <sys/sysctl.h>
@@ -380,27 +381,115 @@ NSError *RLMMakeError(RLMError code, const realm::RealmFileException& exception)
                                       @"Underlying": underlying.length == 0 ? @"n/a" : underlying}];
 }
 
+namespace {
+RLMAppError translateAppError(realm::app::ServiceErrorCode code) {
+    using ec = realm::app::ServiceErrorCode;
+    switch (code) {
+        case ec::account_name_in_use:           return RLMAppErrorAccountNameInUse;
+        case ec::api_key_already_exists:        return RLMAppErrorAPIKeyAlreadyExists;
+        case ec::auth_error:                    return RLMAppErrorAuthError;
+        case ec::auth_provider_not_found:       return RLMAppErrorAuthProviderNotFound;
+        case ec::domain_not_allowed:            return RLMAppErrorDomainNotAllowed;
+        case ec::execution_time_limit_exceeded: return RLMAppErrorExecutionTimeLimitExceeded;
+        case ec::function_execution_error:      return RLMAppErrorFunctionExecutionError;
+        case ec::function_invalid:              return RLMAppErrorFunctionInvalid;
+        case ec::function_not_found:            return RLMAppErrorFunctionNotFound;
+        case ec::function_syntax_error:         return RLMAppErrorFunctionSyntaxError;
+        case ec::invalid_email_password:        return RLMAppErrorInvalidPassword;
+        case ec::invalid_session:               return RLMAppErrorInvalidSession;
+        case ec::maintenance_in_progress:       return RLMAppErrorMaintenanceInProgress;
+        case ec::missing_parameter:             return RLMAppErrorMissingParameter;
+        case ec::mongodb_error:                 return RLMAppErrorMongoDBError;
+        case ec::not_callable:                  return RLMAppErrorNotCallable;
+        case ec::read_size_limit_exceeded:      return RLMAppErrorReadSizeLimitExceeded;
+        case ec::user_already_confirmed:        return RLMAppErrorUserAlreadyConfirmed;
+        case ec::user_app_domain_mismatch:      return RLMAppErrorUserAppDomainMismatch;
+        case ec::user_disabled:                 return RLMAppErrorUserDisabled;
+        case ec::user_not_found:                return RLMAppErrorUserNotFound;
+        case ec::value_already_exists:          return RLMAppErrorValueAlreadyExists;
+        case ec::value_duplicate_name:          return RLMAppErrorValueDuplicateName;
+        case ec::value_not_found:               return RLMAppErrorValueNotFound;
+
+        case ec::arguments_not_allowed:
+        case ec::bad_request:
+        case ec::invalid_parameter:
+            return RLMAppErrorBadRequest;
+
+        case ec::internal_server_error:
+        case ec::aws_error:
+        case ec::gcm_error:
+        case ec::http_error:
+        case ec::twilio_error:
+            return RLMAppErrorInternalServerError;
+
+        default:
+            return RLMAppErrorUnknown;
+    }
+}
+} // anonymous namespace
+
 NSError *RLMMakeError(std::system_error const& exception) {
-    int code = exception.code().value();
-    BOOL isGenericCategoryError = (exception.code().category() == std::generic_category());
-    NSString *category = @(exception.code().category().name());
+    auto code = exception.code();
+    NSInteger errorCode = code.value();
+    // core reports some posix error codes with a private category that it does not expose properly.
+    BOOL isGenericCategoryError = code.category() == std::generic_category()
+                               || strcmp(code.category().name(), "realm.basic_system") == 0;
     NSString *errorDomain = isGenericCategoryError ? NSPOSIXErrorDomain : RLMUnknownSystemErrorDomain;
+    NSMutableDictionary *userInfo = [NSMutableDictionary new];
+    userInfo[NSLocalizedDescriptionKey] = @(exception.what());
+
+    // FIXME: remove these in v11
+    userInfo[@"Error Code"] = @(code.value());
+    userInfo[@"Category"] = @(code.category().name());
+
 #if REALM_ENABLE_SYNC
-    if (exception.code().category() == realm::sync::client_error_category()) {
-        if (exception.code().value() == static_cast<int>(realm::sync::Client::Error::connect_timeout)) {
+    if (code.category() == realm::sync::client_error_category()) {
+        if (code.value() == static_cast<int>(realm::sync::Client::Error::connect_timeout)) {
             errorDomain = NSPOSIXErrorDomain;
-            code = ETIMEDOUT;
+            errorCode = ETIMEDOUT;
         }
         else {
             errorDomain = RLMSyncErrorDomain;
         }
     }
+    else if (code.category() == realm::app::service_error_category()) {
+        errorDomain = RLMAppErrorDomain;
+        errorCode = translateAppError(static_cast<realm::app::ServiceErrorCode>(exception.code().value()));
+    }
+    else if (code.category() == realm::app::http_error_category()) {
+        errorDomain = RLMAppErrorDomain;
+        errorCode = RLMAppErrorHttpRequestFailed;
+        userInfo[RLMHTTPStatusCodeKey] = @(exception.code().value());
+    }
 #endif
 
-    return [NSError errorWithDomain:errorDomain code:code
-                           userInfo:@{NSLocalizedDescriptionKey: @(exception.what()),
-                                      @"Error Code": @(exception.code().value()),
-                                      @"Category": category}];
+    return [NSError errorWithDomain:errorDomain code:errorCode userInfo:userInfo.copy];
+}
+
+NSError *RLMAppErrorToNSError(realm::app::AppError const& appError) {
+    NSMutableDictionary *userInfo = [NSMutableDictionary new];
+    userInfo[NSLocalizedDescriptionKey] = RLMStringViewToNSString(appError.message);
+    if (!appError.link_to_server_logs.empty()) {
+        userInfo[RLMServerLogURLKey] = RLMStringViewToNSString(appError.link_to_server_logs);
+    }
+    if (appError.http_status_code) {
+        userInfo[RLMHTTPStatusCodeKey] = @(*appError.http_status_code);
+    }
+
+    NSString *domain = RLMAppErrorDomain;
+    NSInteger code = RLMAppErrorUnknown;
+    if (appError.is_http_error()) {
+        code = RLMAppErrorHttpRequestFailed;
+    }
+    else if (appError.is_service_error()) {
+        auto errCode = realm::app::ServiceErrorCode(appError.error_code.value());
+        if (errCode == realm::app::ServiceErrorCode::none) {
+            return nil;
+        }
+        code = translateAppError(errCode);
+    }
+
+    return [[NSError alloc] initWithDomain:domain code:code userInfo:userInfo.copy];
 }
 
 void RLMSetErrorOrThrow(NSError *error, NSError **outError) {

--- a/Realm/TestUtils/include/RLMAssertions.h
+++ b/Realm/TestUtils/include/RLMAssertions.h
@@ -118,6 +118,44 @@ FOUNDATION_EXTERN bool RLMHasCachedRealmForPath(NSString *path);
     XCTAssertEqual([exception.userInfo[NSUnderlyingErrorKey] code], expectedCode, __VA_ARGS__); \
 })
 
+#define RLMValidateError(error, errDomain, errCode, msg) do {                                           \
+    XCTAssertNotNil(error);                                                                             \
+    XCTAssertEqual(error.domain, errDomain);                                                            \
+    XCTAssertEqual(error.code, errCode);                                                                \
+    XCTAssertEqualObjects(error.localizedDescription, msg);                                             \
+} while (0)
+
+#define RLMValidateErrorContains(error, errDomain, errCode, msg) do {                                   \
+    XCTAssertNotNil(error);                                                                             \
+    XCTAssertEqual(error.domain, errDomain);                                                            \
+    XCTAssertEqual(error.code, errCode);                                                                \
+    XCTAssert([error.localizedDescription containsString:msg],                                          \
+              @"'%@' should contain '%@'", error.localizedDescription, msg);                            \
+} while (0)
+
+#define RLMValidateRealmErrorContains(macroError, errCode, msg, path) do {                              \
+    NSError* error2 = (NSError*)macroError;                                                             \
+    RLMValidateErrorContains(error2, RLMErrorDomain, errCode, ([NSString stringWithFormat:msg, path])); \
+    XCTAssertEqualObjects(error2.userInfo[NSFilePathErrorKey], path);                                   \
+} while (0)
+
+#define RLMAssertRealmException(expr, errCode, msg, path) do {                                          \
+    NSException* exception = RLMAssertThrows(expr);                                                     \
+    XCTAssertEqual(exception.name, RLMExceptionName);                                                   \
+    NSString* reason = [NSString stringWithFormat:msg, path];                                           \
+    XCTAssertEqualObjects(exception.reason, reason);                                                    \
+    RLMValidateRealmError2(exception.userInfo[NSUnderlyingErrorKey], errCode, msg, path);               \
+} while (0)
+
+#define RLMAssertRealmExceptionContains(expr, errCode, msg, path) do {                                  \
+    NSException* exception = RLMAssertThrows(expr);                                                     \
+    XCTAssertEqual(exception.name, RLMExceptionName);                                                   \
+    NSString* reason = [NSString stringWithFormat:msg, path];                                           \
+    XCTAssert([exception.reason containsString:reason],                                                 \
+              @"'%@' should contain '%@'", exception.reason, reason);                                   \
+    RLMValidateRealmErrorContains(exception.userInfo[NSUnderlyingErrorKey], errCode, msg, path);        \
+} while (0)
+
 #define RLMValidateRealmError(macro_error, macro_errnum, macro_description, macro_underlying)            \
 ({                                                                                                       \
     NSString *macro_dsc = macro_description;                                                             \

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -2702,8 +2702,7 @@
     RLMValidateRealmError(error, RLMErrorFileAccess, @"Unable to open a realm at path", @"Is a directory");
 }
 
-#if TARGET_OS_TV
-#else
+#if !TARGET_OS_TV
 - (void)testRealmFifoError
 {
     NSFileManager *manager = [NSFileManager defaultManager];
@@ -2723,7 +2722,6 @@
 
     NSError *error;
     XCTAssertNil([RLMRealm realmWithConfiguration:configuration error:&error], @"Should not have been able to open FIFO");
-    XCTAssertNotNil(error);
     RLMValidateRealmError(error, RLMErrorFileAccess, @"Is a directory", nil);
 
     realm::DBOptions::set_sys_tmp_dir(std::move(oldTempDir));

--- a/RealmSwift/App.swift
+++ b/RealmSwift/App.swift
@@ -94,6 +94,13 @@ public typealias PushClient = RLMPushClient
 
 /// An object which is used within UserAPIKeyProviderClient
 public typealias UserAPIKey = RLMUserAPIKey
+extension UserAPIKey {
+
+/// The ObjectId of the API key.
+    public var objectId: ObjectId {
+        __objectId as! ObjectId
+    }
+}
 
 /**
 `Credentials`is an enum representing supported authentication types for Atlas App Services.

--- a/RealmSwift/App.swift
+++ b/RealmSwift/App.swift
@@ -256,6 +256,19 @@ extension App: ObservableObject {
 }
 
 @available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, macCatalyst 13.0, macCatalystApplicationExtension 13.0, *)
+private func promisify(_ fn: @escaping (@escaping (Error?) -> Void) -> Void) -> Future<Void, Error> {
+    return Future<Void, Error> { promise in
+        fn { error in
+            if let error = error {
+                promise(.failure(error))
+            } else {
+                promise(.success(()))
+            }
+        }
+    }
+}
+
+@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, macCatalyst 13.0, macCatalystApplicationExtension 13.0, *)
 public extension EmailPasswordAuth {
     /**
      Registers a new email identity with the username/password provider,
@@ -266,14 +279,8 @@ public extension EmailPasswordAuth {
      @returns A publisher that eventually return `Result.success` or `Error`.
     */
     func registerUser(email: String, password: String) -> Future<Void, Error> {
-        return Future<Void, Error> { promise in
-            self.registerUser(email: email, password: password) { error in
-                if let error = error {
-                    promise(.failure(error))
-                } else {
-                    promise(.success(()))
-                }
-            }
+        promisify {
+            self.registerUser(email: email, password: password, completion: $0)
         }
     }
 
@@ -285,14 +292,8 @@ public extension EmailPasswordAuth {
      @returns A publisher that eventually return `Result.success` or `Error`.
     */
     func confirmUser(_ token: String, tokenId: String) -> Future<Void, Error> {
-        return Future<Void, Error> { promise in
-            self.confirmUser(token, tokenId: tokenId) { error in
-                if let error = error {
-                    promise(.failure(error))
-                } else {
-                    promise(.success(()))
-                }
-            }
+        promisify {
+            self.confirmUser(token, tokenId: tokenId, completion: $0)
         }
     }
 
@@ -303,14 +304,8 @@ public extension EmailPasswordAuth {
      @returns A publisher that eventually return `Result.success` or `Error`.
     */
     func resendConfirmationEmail(email: String) -> Future<Void, Error> {
-        return Future<Void, Error> { promise in
-            self.resendConfirmationEmail(email) { error in
-                if let error = error {
-                    promise(.failure(error))
-                } else {
-                    promise(.success(()))
-                }
-            }
+        promisify {
+            self.resendConfirmationEmail(email, completion: $0)
         }
     }
 
@@ -321,14 +316,8 @@ public extension EmailPasswordAuth {
      @returns A publisher that eventually return `Result.success` or `Error`.
      */
     func retryCustomConfirmation(email: String) -> Future<Void, Error> {
-        return Future<Void, Error> { promise in
-            self.retryCustomConfirmation(email) { error in
-                if let error = error {
-                    promise(.failure(error))
-                } else {
-                    promise(.success(()))
-                }
-            }
+        promisify {
+            self.retryCustomConfirmation(email, completion: $0)
         }
     }
 
@@ -338,14 +327,8 @@ public extension EmailPasswordAuth {
      @returns A publisher that eventually return `Result.success` or `Error`.
     */
     func sendResetPasswordEmail(email: String) -> Future<Void, Error> {
-        return Future<Void, Error> { promise in
-            self.sendResetPasswordEmail(email) { error in
-                if let error = error {
-                    promise(.failure(error))
-                } else {
-                    promise(.success(()))
-                }
-            }
+        promisify {
+            self.sendResetPasswordEmail(email, completion: $0)
         }
     }
 
@@ -359,14 +342,8 @@ public extension EmailPasswordAuth {
      @returns A publisher that eventually return `Result.success` or `Error`.
     */
     func resetPassword(to: String, token: String, tokenId: String) -> Future<Void, Error> {
-        return Future<Void, Error> { promise in
-            self.resetPassword(to: to, token: token, tokenId: tokenId) { error in
-                if let error = error {
-                    promise(.failure(error))
-                } else {
-                    promise(.success(()))
-                }
-            }
+        promisify {
+            self.resetPassword(to: to, token: token, tokenId: tokenId, completion: $0)
         }
     }
 
@@ -380,14 +357,8 @@ public extension EmailPasswordAuth {
      @returns A publisher that eventually return `Result.success` or `Error`.
     */
     func callResetPasswordFunction(email: String, password: String, args: [AnyBSON]) -> Future<Void, Error> {
-        return Future<Void, Error> { promise in
-            self.callResetPasswordFunction(email: email, password: password, args: args) { error in
-                if let error = error {
-                    promise(.failure(error))
-                } else {
-                    promise(.success(()))
-                }
-            }
+        promisify {
+            self.callResetPasswordFunction(email: email, password: password, args: args, $0)
         }
     }
 }
@@ -426,14 +397,8 @@ public extension APIKeyAuth {
      @returns A publisher that eventually return `Result.success` or `Error`.
      */
     func deleteAPIKey(_ objectId: ObjectId) -> Future<Void, Error> {
-        return Future { promise in
-            self.deleteAPIKey(objectId) { (error) in
-                if let error = error {
-                    promise(.failure(error))
-                } else {
-                    promise(.success(Void()))
-                }
-            }
+        promisify {
+            self.deleteAPIKey(objectId, completion: $0)
         }
     }
 
@@ -443,14 +408,8 @@ public extension APIKeyAuth {
      @returns A publisher that eventually return `Result.success` or `Error`.
      */
     func enableAPIKey(_ objectId: ObjectId) -> Future<Void, Error> {
-        return Future { promise in
-            self.enableAPIKey(objectId) { (error) in
-                if let error = error {
-                    promise(.failure(error))
-                } else {
-                    promise(.success(Void()))
-                }
-            }
+        promisify {
+            self.enableAPIKey(objectId, completion: $0)
         }
     }
 
@@ -460,14 +419,8 @@ public extension APIKeyAuth {
      @returns A publisher that eventually return `Result.success` or `Error`.
      */
     func disableAPIKey(_ objectId: ObjectId) -> Future<Void, Error> {
-        return Future { promise in
-            self.disableAPIKey(objectId) { (error) in
-                if let error = error {
-                    promise(.failure(error))
-                } else {
-                    promise(.success(Void()))
-                }
-            }
+        promisify {
+            self.disableAPIKey(objectId, completion: $0)
         }
     }
 }
@@ -489,14 +442,8 @@ public extension PushClient {
     /// @param user - device's user
     /// @returns A publisher that eventually return `Result.success` or `Error`.
     func registerDevice(token: String, user: User) -> Future<Void, Error> {
-        return Future { promise in
-            self.registerDevice(token: token, user: user) { (error) in
-                if let error = error {
-                    promise(.failure(error))
-                } else {
-                    promise(.success(Void()))
-                }
-            }
+        promisify {
+            self.registerDevice(token: token, user: user, completion: $0)
         }
     }
 
@@ -504,14 +451,8 @@ public extension PushClient {
     /// @param user - devoce's user
     /// @returns A publisher that eventually return `Result.success` or `Error`.
     func deregisterDevice(user: User) -> Future<Void, Error> {
-        return Future { promise in
-            self.deregisterDevice(user: user) { (error) in
-                if let error = error {
-                    promise(.failure(error))
-                } else {
-                    promise(.success(Void()))
-                }
-            }
+        promisify {
+            self.deregisterDevice(user: user, completion: $0)
         }
     }
 }

--- a/RealmSwift/Error.swift
+++ b/RealmSwift/Error.swift
@@ -43,7 +43,7 @@ extension Realm.Error {
 
 // MARK: Equatable
 
-//extension Realm.Error: Equatable {}
+extension Realm.Error: Equatable {}
 
 // FIXME: we should not be defining this but it's a breaking change to remove
 /// Returns a Boolean indicating whether the errors are identical.

--- a/RealmSwift/Error.swift
+++ b/RealmSwift/Error.swift
@@ -33,92 +33,21 @@ extension Realm {
      }
      ```
     */
-    @frozen public struct Error {
-        public typealias Code = RLMError.Code
-
-        /// Error thrown by Realm if no other specific error is returned when a realm is opened.
-        public static let fail: Code = .fail
-
-        /// Error thrown by Realm for any I/O related exception scenarios when a realm is opened.
-        public static let fileAccess: Code = .fileAccess
-
-        /// Error thrown by Realm if the user does not have permission to open or create
-        /// the specified file in the specified access mode when the realm is opened.
-        public static let filePermissionDenied: Code = .filePermissionDenied
-
-        /// Error thrown by Realm if the file already exists when a copy should be written.
-        public static let fileExists: Code = .fileExists
-
-        /// Error thrown by Realm if no file was found when a realm was opened as
-        /// read-only or if the directory part of the specified path was not found
-        /// when a copy should be written.
-        public static let fileNotFound: Code = .fileNotFound
-
-        /// Error thrown by Realm if the database file is currently open in another process which
-        /// cannot share with the current process due to an architecture mismatch.
-        public static let incompatibleLockFile: Code = .incompatibleLockFile
-
-        /// Error thrown by Realm if a file format upgrade is required to open the file,
-        /// but upgrades were explicitly disabled.
-        public static let fileFormatUpgradeRequired: Code = .fileFormatUpgradeRequired
-
-        /// Error thrown by Realm if there is insufficient available address space.
-        public static let addressSpaceExhausted: Code = .addressSpaceExhausted
-
-        /// Error thrown by Realm if there is a schema version mismatch, so that a migration is required.
-        public static let schemaMismatch: Code = .schemaMismatch
-
-        /// :nodoc:
-        public var code: Code {
-            return (_nsError as! RLMError).code
-        }
-
-        /// :nodoc:
-        public let _nsError: NSError
-
-        /// :nodoc:
-        public init(_nsError error: NSError) {
-            _nsError = error
-        }
-
-        /// Realm configuration that can be used to open the backup copy of a Realm file
-        ///
-        /// Only applicable to `incompatibleSyncedFile`. Will be `nil` for all other errors.
-        public var backupConfiguration: Realm.Configuration? {
-            let configuration = userInfo[RLMBackupRealmConfigurationErrorKey] as! RLMRealmConfiguration?
-            return configuration.map(Realm.Configuration.fromRLMRealmConfiguration)
-        }
-
-        /// This error could be returned by completion block when no success and no error were produced
-        public static let callFailed = Error(.fail, userInfo: [NSLocalizedDescriptionKey: "Call failed"])
-    }
+    public typealias Error = RLMError
 }
 
-/// :nodoc:
-// Provide bridging from errors with domain RLMErrorDomain to Error.
-extension Realm.Error: _BridgedStoredNSError {
-    /// :nodoc:
-    public static let _nsErrorDomain = RLMErrorDomain
-    /// :nodoc:
-    public static let errorDomain = RLMErrorDomain
+extension Realm.Error {
+    /// This error could be returned by completion block when no success and no error were produced
+    public static let callFailed = Realm.Error(Realm.Error.fail, userInfo: [NSLocalizedDescriptionKey: "Call failed"])
 }
 
 // MARK: Equatable
 
-extension Realm.Error: Equatable {}
+//extension Realm.Error: Equatable {}
 
+// FIXME: we should not be defining this but it's a breaking change to remove
 /// Returns a Boolean indicating whether the errors are identical.
 public func == (lhs: Error, rhs: Error) -> Bool {
     return lhs._code == rhs._code
         && lhs._domain == rhs._domain
-}
-
-// MARK: Pattern Matching
-
-/**
- Pattern matching matching for `Realm.Error`, so that the instances can be used with Swift's
- `do { ... } catch { ... }` syntax.
-*/
-public func ~= (lhs: Realm.Error, rhs: Error) -> Bool {
-    return lhs == rhs
 }

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -149,16 +149,29 @@ extension SyncError {
     public func deleteRealmUserInfo() -> SyncError.ActionToken? {
         return _nsError.__rlmSync_errorActionToken()
     }
+
+    /**
+     Sync errors which originate from the server also produce server-side logs
+     which may contain useful information. When applicable, this field contains
+     the url of those logs, and `nil` otherwise.
+     */
+    public var serverLogURL: URL? {
+        (userInfo[RLMServerLogURLKey] as? String).flatMap(URL.init)
+    }
 }
 
 /**
- An error associated with network requests made to the authentication server. This type of error
- may be returned in the callback block to `SyncUser.logIn()` upon certain types of failed login
- attempts (for example, if the request is malformed or if the server is experiencing an issue).
-
- - see: `RLMSyncAuthError`
+ An error which occurred when making a request to Atlas App Services. Most User
+ and App functions which can fail report errors of this type.
  */
-public typealias SyncAuthError = RLMSyncAuthError
+public typealias AppError = RLMAppError
+
+extension AppError {
+    /// When applicable, the HTTP status code which resulted in this error.
+    var httpStatusCode: Int? {
+        userInfo[RLMHTTPStatusCodeKey] as? Int
+    }
+}
 
 /**
  An enum which can be used to specify the level of logging.
@@ -174,38 +187,6 @@ public typealias SyncLogLevel = RLMSyncLogLevel
  - see: `RLMIdentityProvider`
  */
 public typealias Provider = RLMIdentityProvider
-
-/**
- * How the Realm client should validate the identity of the server for secure connections.
- *
- * By default, when connecting to Atlas App Services over HTTPS, Realm will
- * validate the server's HTTPS certificate using the system trust store and root
- * certificates. For additional protection against man-in-the-middle (MITM)
- * attacks and similar vulnerabilities, you can pin a certificate or public key,
- * and reject all others, even if they are signed by a trusted CA.
- */
-@frozen public enum ServerValidationPolicy {
-    /// Perform no validation and accept potentially invalid certificates.
-    ///
-    /// - warning: DO NOT USE THIS OPTION IN PRODUCTION.
-    case none
-
-    /// Use the default server trust evaluation based on the system-wide CA
-    /// store. Any certificate signed by a trusted CA will be accepted.
-    case system
-
-    /// Use a specific pinned certificate to validate the server identify.
-    ///
-    /// This will only connect to a server if one of the server certificates
-    /// matches the certificate stored at the given local path and that
-    /// certificate has a valid trust chain.
-    ///
-    /// On macOS, the certificate files may be in any of the formats supported
-    /// by SecItemImport(), including PEM and .cer (see SecExternalFormat for a
-    /// complete list of possible formats). On iOS and other platforms, only
-    /// DER .cer files are supported.
-    case pinCertificate(path: URL)
-}
 
 /**
  An enum used to determines file recovery behavior in the event of a client reset.

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -1223,10 +1223,8 @@ class MigrationTests: TestCase {
         }
 
         let config = Realm.Configuration(fileURL: defaultRealmURL(), objectTypes: [SwiftEmployeeObject.self])
-        autoreleasepool {
-            assertFails(.schemaMismatch) {
-                try Realm(configuration: config)
-            }
+        assertFails(.schemaMismatch) {
+            try Realm(configuration: config)
         }
     }
 
@@ -1243,10 +1241,8 @@ class MigrationTests: TestCase {
         }
         config.deleteRealmIfMigrationNeeded = true
 
-        autoreleasepool {
-            assertSucceeds {
-                _ = try Realm(configuration: config)
-            }
+        assertSucceeds {
+            _ = try Realm(configuration: config)
         }
     }
 
@@ -1266,10 +1262,8 @@ class MigrationTests: TestCase {
         let originalImp = class_getMethodImplementation(metaClass, #selector(RLMObjectBase.sharedSchema))
         class_replaceMethod(metaClass, #selector(RLMObjectBase.sharedSchema), imp, "@@:")
 
-        autoreleasepool {
-            assertFails(.schemaMismatch) {
-                try Realm()
-            }
+        assertFails(.schemaMismatch) {
+            try Realm()
         }
 
         let migrationBlock: MigrationBlock = { _, _ in

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -57,16 +57,17 @@ class RealmTests: TestCase {
         }
     }
 
-    func testReadOnlyFile() {
-        autoreleasepool {
-            let realm = try! Realm(fileURL: testRealmURL())
-            try! realm.write {
+    func testReadOnlyFile() throws {
+        try autoreleasepool {
+            let realm = try Realm(fileURL: testRealmURL())
+            try realm.write {
                 realm.create(SwiftStringObject.self, value: ["a"])
             }
         }
 
         let fileManager = FileManager.default
-        try! fileManager.setAttributes([ FileAttributeKey.immutable: true ], ofItemAtPath: testRealmURL().path)
+        try fileManager.setAttributes([FileAttributeKey.immutable: true],
+                                      ofItemAtPath: testRealmURL().path)
 
         // Should not be able to open read-write
         assertFails(.fileAccess) {
@@ -79,7 +80,8 @@ class RealmTests: TestCase {
             XCTAssertEqual(1, realm.objects(SwiftStringObject.self).count)
         }
 
-        try! fileManager.setAttributes([ FileAttributeKey.immutable: false ], ofItemAtPath: testRealmURL().path)
+        try fileManager.setAttributes([FileAttributeKey.immutable: false],
+                                      ofItemAtPath: testRealmURL().path)
     }
 
     func testReadOnlyRealmMustExist() {
@@ -98,7 +100,7 @@ class RealmTests: TestCase {
         let fileManager = FileManager.default
         let permissions = try! fileManager
             .attributesOfItem(atPath: testRealmURL().path)[FileAttributeKey.posixPermissions] as! NSNumber
-        try! fileManager.setAttributes([ FileAttributeKey.posixPermissions: 0000 ],
+        try! fileManager.setAttributes([FileAttributeKey.posixPermissions: 0000],
                                        ofItemAtPath: testRealmURL().path)
 
         assertFails(.filePermissionDenied) {
@@ -151,17 +153,12 @@ class RealmTests: TestCase {
     }
 
     func testInitFailable() {
-        autoreleasepool {
-            _ = try! Realm()
-        }
-
         FileManager.default.createFile(atPath: defaultRealmURL().path,
             contents: "a".data(using: String.Encoding.utf8, allowLossyConversion: false),
             attributes: nil)
 
         assertFails(.fileAccess) {
             _ = try Realm()
-            XCTFail("Realm creation should have failed")
         }
     }
 
@@ -1027,7 +1024,7 @@ class RealmTests: TestCase {
         } catch Realm.Error.fileAccess {
             // Success to catch the error
         } catch {
-            XCTFail("Failed to bridge RLMError to Realm.Error")
+            XCTFail("Unexpected error \(error)")
         }
         do {
             _ = try Realm(configuration: Realm.Configuration(fileURL: defaultRealmURL(), readOnly: true))
@@ -1035,7 +1032,7 @@ class RealmTests: TestCase {
         } catch Realm.Error.fileNotFound {
             // Success to catch the error
         } catch {
-            XCTFail("Failed to bridge RLMError to Realm.Error")
+            XCTFail("Unexpected error \(error)")
         }
     }
 

--- a/RealmSwift/Tests/SectionedResultsTests.swift
+++ b/RealmSwift/Tests/SectionedResultsTests.swift
@@ -276,7 +276,7 @@ extension ModernAllTypesProjection {
 }
 
 class SectionedResultsTestsBase: RLMTestCaseBase {
-    func createObjects() {
+    func createObjects(_ r: Realm? = nil) -> Realm {
         let o1 = ModernAllTypesObject()
         o1.stringCol = "banana"
         o1.arrayString.append(objectsIn: ["banana", "box", "apple", "chalk"])
@@ -287,18 +287,18 @@ class SectionedResultsTestsBase: RLMTestCaseBase {
         o3.stringCol = "apple"
         let o4 = ModernAllTypesObject()
         o4.stringCol = "chalk"
-        let realm = try! Realm()
+        let realm = try! r ?? Realm(configuration: .init(inMemoryIdentifier: "sectioned results test"))
         try! realm.write {
             realm.deleteAll()
             realm.add([o1, o2, o3, o4])
         }
+        return realm
     }
 }
 
 class SectionedResultsTests: SectionedResultsTestsBase {
     func testCreationFromResults() {
-        createObjects()
-        let realm = try! Realm()
+        let realm = createObjects()
         let results = realm.objects(ModernAllTypesObject.self)
 
         func assert(ascending: Bool, sectionCount: Int, sectionKeys: [String]) {
@@ -321,8 +321,7 @@ class SectionedResultsTests: SectionedResultsTestsBase {
     }
 
     func testCreationFromList() {
-        createObjects()
-        let realm = try! Realm()
+        let realm = createObjects()
         let list = realm.objects(ModernAllTypesObject.self)[0].arrayString
 
         func assert(ascending: Bool, sectionCount: Int, sectionKeys: [String]) {
@@ -336,8 +335,7 @@ class SectionedResultsTests: SectionedResultsTestsBase {
     }
 
     func testCreateFromMutableSet() {
-        createObjects()
-        let realm = try! Realm()
+        let realm = createObjects()
         let set = realm.objects(ModernAllTypesObject.self)[0].setString
 
         func assert(ascending: Bool, sectionCount: Int, sectionKeys: [String]) {
@@ -351,16 +349,14 @@ class SectionedResultsTests: SectionedResultsTestsBase {
     }
 
     func testAllKeys() {
-        createObjects()
-        let realm = try! Realm()
+        let realm = createObjects()
         let results = realm.objects(ModernAllTypesObject.self)
         let sectionedResults = results.sectioned(by: \.firstLetter, ascending: true)
         XCTAssertEqual(sectionedResults.allKeys, ["a", "b", "c"])
     }
 
     func testSubscript() {
-        createObjects()
-        let realm = try! Realm()
+        let realm = createObjects()
         let results = realm.objects(ModernAllTypesObject.self)
         let sectionedResults = results.sectioned(by: \.firstLetter, ascending: true)
         let section = sectionedResults[0]
@@ -372,8 +368,7 @@ class SectionedResultsTests: SectionedResultsTestsBase {
     }
 
     func testObservation() {
-        createObjects()
-        let realm = try! Realm()
+        let realm = createObjects()
         let results = realm.objects(ModernAllTypesObject.self)
         let sectionedResults = results.sectioned(by: \.firstLetter, ascending: true)
         let ex = expectation(description: "initial notification")
@@ -409,8 +404,7 @@ class SectionedResultsTests: SectionedResultsTestsBase {
     }
 
     func testObserveWithKeyPathFilter() {
-        createObjects()
-        let realm = try! Realm()
+        let realm = createObjects()
         let results = realm.objects(ModernAllTypesObject.self)
         let sectionedResults = results.sectioned(by: \.firstLetter, ascending: true)
 
@@ -450,8 +444,7 @@ class SectionedResultsTests: SectionedResultsTestsBase {
     }
 
     func testObserveWithKeyPathFilterOnSection() {
-        createObjects()
-        let realm = try! Realm()
+        let realm = createObjects()
         let results = realm.objects(ModernAllTypesObject.self)
         let sectionedResults = results.sectioned(by: \.firstLetter, ascending: true)[0]
 
@@ -486,8 +479,7 @@ class SectionedResultsTests: SectionedResultsTestsBase {
     }
 
     func testObserveOnQueue() {
-        createObjects()
-        let realm = try! Realm()
+        let realm = createObjects()
         let results = realm.objects(ModernAllTypesObject.self)
         let sectionedResults = results.sectioned(by: \.firstLetter, ascending: true)
         let sema = DispatchSemaphore(value: 0)
@@ -544,8 +536,7 @@ class SectionedResultsTests: SectionedResultsTestsBase {
     }
 
     func testObservationOnSection() {
-        createObjects()
-        let realm = try! Realm()
+        let realm = createObjects()
         let results = realm.objects(ModernAllTypesObject.self)
         let sectionedResults = results.sectioned(by: \.firstLetter, ascending: true)
         let section1 = sectionedResults[0]
@@ -623,8 +614,7 @@ class SectionedResultsTests: SectionedResultsTestsBase {
     }
 
     func testObservationOnSectionOnQueue() {
-        let realm = try! Realm()
-        createObjects()
+        let realm = createObjects()
         let results = realm.objects(ModernAllTypesObject.self)
         let sectionedResults = results.sectioned(by: \.firstLetter, ascending: true)
         let section1 = sectionedResults[0]
@@ -713,8 +703,7 @@ class SectionedResultsTests: SectionedResultsTestsBase {
     }
 
     func testFrozenResults() {
-        createObjects()
-        let realm = try! Realm()
+        let realm = createObjects()
         let frozenResults = realm.objects(ModernAllTypesObject.self).freeze()
         XCTAssertTrue(frozenResults.isFrozen)
         try! realm.write {
@@ -742,16 +731,15 @@ class SectionedResultsTests: SectionedResultsTestsBase {
     }
 
     func testFrozen() {
-        let realm = try! Realm()
+        let realm = createObjects()
         let results = realm.objects(ModernAllTypesObject.self)
         XCTAssertFalse(results.isFrozen)
 
-        func assert(ascending: Bool, sectionCount: Int, sectionKeys: [String]) {
-            createObjects()
+        func assert(ascending: Bool, sectionCount: Int, sectionKeys: [String], newSection: String) {
             let frozenSectionedResults = results.sectioned(by: \.firstLetter, ascending: ascending).freeze()
             try! realm.write {
                 let o = ModernAllTypesObject()
-                o.stringCol = "z"
+                o.stringCol = newSection
                 realm.add(o)
             }
             XCTAssertTrue(frozenSectionedResults.isFrozen)
@@ -761,23 +749,22 @@ class SectionedResultsTests: SectionedResultsTestsBase {
                 return XCTFail("Could not produce thawed sectioned results")
             }
             XCTAssertFalse(thawed.isFrozen)
-            XCTAssertEqual(thawed.count, 4)
-            XCTAssertEqual(thawed.map { $0.key }, ascending ? sectionKeys + ["z"] : ["z"] + sectionKeys)
+            XCTAssertEqual(thawed.count, sectionCount + 1)
+            XCTAssertEqual(thawed.map { $0.key }, ascending ? sectionKeys + [newSection]
+                                                            : [newSection] + sectionKeys)
         }
 
-        assert(ascending: true, sectionCount: 3, sectionKeys: ["a", "b", "c"])
-        assert(ascending: false, sectionCount: 3, sectionKeys: ["c", "b", "a"])
+        assert(ascending: true, sectionCount: 3, sectionKeys: ["a", "b", "c"], newSection: "d")
+        assert(ascending: false, sectionCount: 4, sectionKeys: ["d", "c", "b", "a"], newSection: "e")
     }
 
     func testFrozenSection() {
-        let realm = try! Realm()
+        let realm = createObjects()
         let results = realm.objects(ModernAllTypesObject.self)
         XCTAssertFalse(results.isFrozen)
-        createObjects()
 
         func assert(ascending: Bool, beforeCount: Int, afterCount: Int, sectionKey: String) {
             let frozenSection = results.sectioned(by: \.firstLetter, ascending: ascending)[0].freeze()
-            createObjects()
             try! realm.write {
                 let o = ModernAllTypesObject()
                 o.stringCol = sectionKey
@@ -801,8 +788,7 @@ class SectionedResultsTests: SectionedResultsTestsBase {
 
 class SectionedResultsProjectionTests: SectionedResultsTestsBase {
     func testCreationFromResults() {
-        createObjects()
-        let realm = try! Realm()
+        let realm = createObjects()
         let results = realm.objects(ModernAllTypesProjection.self)
 
         func assert(ascending: Bool, sectionCount: Int, sectionKeys: [String]) {
@@ -832,8 +818,7 @@ class SectionedResultsProjectionTests: SectionedResultsTestsBase {
     }
 
     func testCreationFromList() {
-        createObjects()
-        let realm = try! Realm()
+        let realm = createObjects()
         let list = realm.objects(ModernAllTypesProjection.self)[0].arrayString
 
         func assert(ascending: Bool, sectionCount: Int, sectionKeys: [String]) {
@@ -847,8 +832,7 @@ class SectionedResultsProjectionTests: SectionedResultsTestsBase {
     }
 
     func testCreateFromMutableSet() {
-        createObjects()
-        let realm = try! Realm()
+        let realm = createObjects()
         let set = realm.objects(ModernAllTypesProjection.self)[0].setString
 
         func assert(ascending: Bool, sectionCount: Int, sectionKeys: [String]) {
@@ -862,8 +846,7 @@ class SectionedResultsProjectionTests: SectionedResultsTestsBase {
     }
 
     func testObservation() {
-        createObjects()
-        let realm = try! Realm()
+        let realm = createObjects()
         let results = realm.objects(ModernAllTypesProjection.self)
         let sectionedResults = results.sectioned(by: \.firstLetter, ascending: true)
         let ex = expectation(description: "initial notification")
@@ -899,8 +882,7 @@ class SectionedResultsProjectionTests: SectionedResultsTestsBase {
     }
 
     func testObserveOnQueue() {
-        createObjects()
-        let realm = try! Realm()
+        let realm = createObjects()
         let results = realm.objects(ModernAllTypesProjection.self)
         let sectionedResults = results.sectioned(by: \.firstLetter, ascending: true)
         let sema = DispatchSemaphore(value: 0)
@@ -957,8 +939,7 @@ class SectionedResultsProjectionTests: SectionedResultsTestsBase {
     }
 
     func testObservationOnSection() {
-        createObjects()
-        let realm = try! Realm()
+        let realm = createObjects()
         let results = realm.objects(ModernAllTypesProjection.self)
         let sectionedResults = results.sectioned(by: \.firstLetter, ascending: true)
         let section1 = sectionedResults[0]
@@ -1036,8 +1017,7 @@ class SectionedResultsProjectionTests: SectionedResultsTestsBase {
     }
 
     func testObservationOnSectionOnQueue() {
-        let realm = try! Realm()
-        createObjects()
+        let realm = createObjects()
         let results = realm.objects(ModernAllTypesObject.self)
         let sectionedResults = results.sectioned(by: \.firstLetter, ascending: true)
         let section1 = sectionedResults[0]
@@ -1126,8 +1106,7 @@ class SectionedResultsProjectionTests: SectionedResultsTestsBase {
     }
 
     func testFrozenResults() {
-        createObjects()
-        let realm = try! Realm()
+        let realm = createObjects()
         let frozenResults = realm.objects(ModernAllTypesProjection.self).freeze()
         XCTAssertTrue(frozenResults.isFrozen)
         try! realm.write {
@@ -1155,16 +1134,15 @@ class SectionedResultsProjectionTests: SectionedResultsTestsBase {
     }
 
     func testFrozen() {
-        let realm = try! Realm()
+        let realm = createObjects()
         let results = realm.objects(ModernAllTypesObject.self)
         XCTAssertFalse(results.isFrozen)
 
-        func assert(ascending: Bool, sectionCount: Int, sectionKeys: [String]) {
-            createObjects()
+        func assert(ascending: Bool, sectionCount: Int, sectionKeys: [String], newSection: String) {
             let frozenSectionedResults = results.sectioned(by: \.firstLetter, ascending: ascending).freeze()
             try! realm.write {
                 let o = ModernAllTypesObject()
-                o.stringCol = "z"
+                o.stringCol = newSection
                 realm.add(o)
             }
             XCTAssertTrue(frozenSectionedResults.isFrozen)
@@ -1174,21 +1152,20 @@ class SectionedResultsProjectionTests: SectionedResultsTestsBase {
                 return XCTFail("Could not produce thawed sectioned results")
             }
             XCTAssertFalse(thawed.isFrozen)
-            XCTAssertEqual(thawed.count, 4)
-            XCTAssertEqual(thawed.map { $0.key }, ascending ? sectionKeys + ["z"] : ["z"] + sectionKeys)
+            XCTAssertEqual(thawed.count, sectionCount + 1)
+            XCTAssertEqual(thawed.map { $0.key }, ascending ? sectionKeys + [newSection] : [newSection] + sectionKeys)
         }
 
-        assert(ascending: true, sectionCount: 3, sectionKeys: ["a", "b", "c"])
-        assert(ascending: false, sectionCount: 3, sectionKeys: ["c", "b", "a"])
+        assert(ascending: true, sectionCount: 3, sectionKeys: ["a", "b", "c"], newSection: "d")
+        assert(ascending: false, sectionCount: 4, sectionKeys: ["d", "c", "b", "a"], newSection: "e")
     }
 
     func testFrozenSection() {
-        let realm = try! Realm()
+        let realm = createObjects()
         let results = realm.objects(ModernAllTypesObject.self)
         XCTAssertFalse(results.isFrozen)
 
         func assert(ascending: Bool, sectionKey: String, beforeCount: Int, afterCount: Int) {
-            createObjects()
             let frozenSection = results.sectioned(by: \.firstLetter, ascending: ascending)[0].freeze()
             try! realm.write {
                 let o = ModernAllTypesObject()
@@ -1211,8 +1188,7 @@ class SectionedResultsProjectionTests: SectionedResultsTestsBase {
     }
 
     func testFastEnumeration() {
-        let realm = try! Realm()
-        createObjects()
+        let realm = createObjects()
         let results = realm.objects(ModernAllTypesObject.self)
         let sectionedResults = results.sectioned(by: \.firstLetter, ascending: true)
         var keys = ["a", "b", "c"]

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -175,7 +175,7 @@ extension XCTestCase {
     func assertSucceeds(message: String? = nil, fileName: StaticString = #file,
                         lineNumber: UInt = #line, block: () throws -> Void) {
         do {
-            try block()
+            try autoreleasepool(invoking: block)
         } catch {
             XCTFail("Expected no error, but instead caught <\(error)>.",
                 file: (fileName), line: lineNumber)
@@ -186,14 +186,16 @@ extension XCTestCase {
                         fileName: StaticString = #file, lineNumber: UInt = #line,
                         block: () throws -> T) {
         do {
-            _ = try block()
+            _ = try autoreleasepool(invoking: block)
             XCTFail("Expected to catch <\(expectedError)>, but no error was thrown.",
-                file: (fileName), line: lineNumber)
+                file: fileName, line: lineNumber)
         } catch let e as Realm.Error where e.code == expectedError {
-            // Success!
+            if message != nil {
+                XCTAssertEqual(e.localizedDescription, message, file: fileName, line: lineNumber)
+            }
         } catch {
             XCTFail("Expected to catch <\(expectedError)>, but instead caught <\(error)>.",
-                file: (fileName), line: lineNumber)
+                file: fileName, line: lineNumber)
         }
     }
 
@@ -201,14 +203,14 @@ extension XCTestCase {
                         fileName: StaticString = #file, lineNumber: UInt = #line,
                         block: () throws -> T) {
         do {
-            _ = try block()
+            _ = try autoreleasepool(invoking: block)
             XCTFail("Expected to catch <\(expectedError)>, but no error was thrown.",
-                file: (fileName), line: lineNumber)
+                file: fileName, line: lineNumber)
         } catch let e where e._code == expectedError._code {
             // Success!
         } catch {
             XCTFail("Expected to catch <\(expectedError)>, but instead caught <\(error)>.",
-                file: (fileName), line: lineNumber)
+                file: fileName, line: lineNumber)
         }
     }
 


### PR DESCRIPTION
Many sync and app errors had error codes from `RLMSyncSystemErrorKind` (a private enum), `realm::ProtocolError`, `realm::ServiceErrorCode` or `realm::ClientErrorCode` (not exposed in the SDK at all), and often add error domains which were just arbitrary strings from core. This meant that most of the errors weren't actually handleable without relying on internal implementation details. This changes it so that (almost) all errors have a well-defined domain+error code pair, and adds many missing error codes to make that possible.

RLMAppError is a subset of the error codes in `ServiceErrorCode` which includes only the ones which can actually be hit via our API. There's a bunch which are only applicable to the admin API, or not at all (e.g. GCM related things, which Google shut down a few years ago).

`Realm.Error` predates `NS_ERROR_ENUM` and manually defines exactly what the automatic bridging now does, so change it to just be a typealias.

All of the tests which assert that an error occurred now also validate that it's the expected error. In the process I switched many of the tests over to using the Combine versions of the App APIs as it makes basic operations like logging in one line instead of 5+, and makes it easier to verify that every single operation is actually checking appropriately for success/failure.

`ServerValidationPolicy` and `RLMSyncAuthError ` have been unused since v10 and should have been deleted then.

The sectioned results tests created `default.realm` but didn't clean it up, which made some other tests fail depending on the order the test cases run. I switched them over to using an in-memory realm to solve this.