### PR TITLE
Fix linker errors when building release builds with Xcode 14.1 + SPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+x.y.z Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
+* Fix linker errors when building a release build with Xcode 14.1 when installing via SPM ([#7995](https://github.com/realm/realm-swift/issues/7995)).
+
+<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
+
+### Compatibility
+* Realm Studio: 11.0.0 or later.
+* APIs are backwards compatible with all previous releases in the 10.x.y series.
+* Carthage release for Swift is built with Xcode 14.0.1.
+* CocoaPods: 1.10 or later.
+* Xcode: 13.1-14.1.
+
+### Internal
+* Upgraded realm-core from ? to ?
+
 10.32.1 Release notes (2022-10-25)
 =============================================================
 

--- a/RealmSwift/Impl/RealmCollectionImpl.swift
+++ b/RealmSwift/Impl/RealmCollectionImpl.swift
@@ -27,7 +27,7 @@ import Realm
 // The functions don't need to be documented here because Xcode/DocC inherit
 // the documentation from the RealmCollection protocol definition, and jazzy
 // excludes this file entirely.
-internal protocol RealmCollectionImpl: RealmCollection where Index == Int, SubSequence == Slice<Self> {
+internal protocol RealmCollectionImpl: RealmCollection where Index == Int, SubSequence == Slice<Self>, Iterator == RLMIterator<Element> {
     var collection: RLMCollection { get }
     init(collection: RLMCollection)
 }
@@ -141,10 +141,6 @@ extension RealmCollectionImpl {
     }
     public func thaw() -> Self? {
         return Self(collection: collection.thaw())
-    }
-
-    public func makeIterator() -> RLMIterator<Element> {
-        return RLMIterator(collection: collection)
     }
 
     public func sectioned<Key: _Persistable>(sortDescriptors: [SortDescriptor],

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -80,7 +80,6 @@ import Realm
     }
 
     // MARK: Implementation
-
     internal init(propertyName: String, handle: RLMLinkingObjectsHandle?) {
         self.propertyName = propertyName
         self.handle = handle
@@ -97,4 +96,9 @@ import Realm
     internal var propertyName: String
     internal var handle: RLMLinkingObjectsHandle?
     internal var lastAccessedNames: NSMutableArray?
+
+    /// :nodoc:
+    public func makeIterator() -> RLMIterator<Element> {
+        return RLMIterator(collection: collection)
+    }
 }

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -357,6 +357,11 @@ extension List: MutableCollection {
             move(from: offset, to: d)
         }
     }
+
+    /// :nodoc:
+    public func makeIterator() -> RLMIterator<Element> {
+        return RLMIterator(collection: collection)
+    }
 }
 
 // MARK: - Codable

--- a/RealmSwift/MutableSet.swift
+++ b/RealmSwift/MutableSet.swift
@@ -217,6 +217,11 @@ public final class MutableSet<Element: RealmCollectionValue>: RLMSwiftCollection
     }
 
     /// :nodoc:
+    public func makeIterator() -> RLMIterator<Element> {
+        return RLMIterator(collection: collection)
+    }
+
+    /// :nodoc:
     public func index(of object: Element) -> Int? {
         fatalError("index(of:) is not available on MutableSet")
     }

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -228,7 +228,7 @@ public protocol RealmCollectionBase: RandomAccessCollection, LazyCollectionProto
 /**
  A homogenous collection of `Object`s which can be retrieved, filtered, sorted, and operated upon.
 */
-public protocol RealmCollection: RealmCollectionBase, Equatable {
+public protocol RealmCollection: RealmCollectionBase, Equatable where Iterator == RLMIterator<Element> {
     // MARK: Properties
 
     /// The Realm which manages the collection, or `nil` for unmanaged collections.
@@ -1248,6 +1248,12 @@ extension RealmCollection {
     public static func == (lhs: AnyRealmCollection<Element>, rhs: AnyRealmCollection<Element>) -> Bool {
         lhs.collection.isEqual(rhs.collection)
     }
+
+    /// :nodoc:
+    public func makeIterator() -> RLMIterator<Element> {
+        return RLMIterator(collection: collection)
+    }
+
 }
 
 extension AnyRealmCollection: Encodable where Element: Encodable {}

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -141,6 +141,12 @@ extension Projection: KeypathSortable {}
     public static func == (lhs: Results<Element>, rhs: Results<Element>) -> Bool {
         lhs.collection.isEqual(rhs.collection)
     }
+
+    /// :nodoc:
+    public func makeIterator() -> RLMIterator<Element> {
+        return RLMIterator(collection: collection)
+    }
+
 }
 
 extension Results: Encodable where Element: Encodable {}


### PR DESCRIPTION
When building a Swift package via Xcode (and _not_ swift build), Realm Swift gets prelinked into a single object file with LTO enabled. This results in all `internal` symbols getting internal linkage (which despite using the same word, are two mostly unrelated concepts), notably including `RealmCollectionImpl`. For everything but `makeIterator()`, this doesn't matter because all of the calls to `RealmCollectionImpl` are virtual calls made via the `RealmCollection` protocol. The call to `Sequence.makeIterator()`, however, gets devirtualized in Xcode 14.1 and the call site refers directly to `RealmCollectionImpl.makeIterator()`, which is a minor optimization that breaks due to the symbol not being exported.

Either this is a Swift bug or what we're doing with `RealmCollectionImpl` simply isn't valid, but for now we should just work around the specific problem.

Fixes #7995.