### PR TITLE
Eliminate some redundant updates in SwiftUI components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,13 @@ x.y.z Release notes (yyyy-MM-dd)
   terminated at a certain point in the process of comitting a write
   transaciton. ([Core PR #5993](https://github.com/realm/realm-core/pull/5993), since v10.21.1)
 * `@AsyncOpen` and `@AutoOpen` would begin and then cancel a second async open
-  operation (since v10.12.0).
+  operation ([PR #8038](https://github.com/realm/realm-swift/pull/8038), since v10.12.0).
 * Changing the search text when using the searchable SwiftUI extension would
-  trigger multiple updates on the View for each change (since v10.19.0).
-* Changing the filter or search properties of an `@ObservedResults` would
-  trigger up to three updates on the View (since v10.6.0).
+  trigger multiple updates on the View for each change
+  ([PR #8038](https://github.com/realm/realm-swift/pull/8038), since v10.19.0).
+* Changing the filter or search properties of an `@ObservedResults` or
+  `@ObservedSectionedResults` would trigger up to three updates on the View
+  ([PR #8038](https://github.com/realm/realm-swift/pull/8038), since v10.6.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,34 @@ x.y.z Release notes (yyyy-MM-dd)
       @Persisted var firstName: String
       @Persisted var birthDate: Date
       @Persisted var age: Int
-      
+
       override class public func propertiesMapping() -> [String : String] {
           ["firstName"; "first_name",
            "birthDate"; "birth_date"]
       }
   }
   ```
-  This is very helpful in cases where you want to name a property differently 
+  This is very helpful in cases where you want to name a property differently
   from your `Device Sync` JSON schema.
   This API is only available for old and modern object declaration syntax on the
   `RealmSwift` SDK.
+* Flexible sync bootstraps now apply 1MB of changesets per write transaction
+  rather than applying all of them in a single write transaction.
+  ([Core PR #5999](https://github.com/realm/realm-core/pull/5999)).
 
 ### Fixed
-* Fix a race condition which could result in "operation cancelled" errors being delivered to async open callbacks rather than the actual sync error which caused things to fail ([PR #5968](https://github.com/realm/realm-core/pull/5968), since the introduction of async open).
-* Bootstraps will not be applied in a single write transaction - they will be applied 1MB of changesets at a time, or as configured by the SDK ([#5999](https://github.com/realm/realm-core/pull/5999), since v10.27.0).
-* Fix database corruption and encryption issues on apple platforms, reported in several bugs listed in the PR. ([PR #5993](https://github.com/realm/realm-core/pull/5993), since v10.21.1)
+* Fix a race condition which could result in "operation cancelled" errors being
+  delivered to async open callbacks rather than the actual sync error which
+  caused things to fail ([Core PR #5968](https://github.com/realm/realm-core/pull/5968), since the introduction of async open).
+* Fix database corruption issues which could happen if an application was
+  terminated at a certain point in the process of comitting a write
+  transaciton. ([Core PR #5993](https://github.com/realm/realm-core/pull/5993), since v10.21.1)
+* `@AsyncOpen` and `@AutoOpen` would begin and then cancel a second async open
+  operation (since v10.12.0).
+* Changing the search text when using the searchable SwiftUI extension would
+  trigger multiple updates on the View for each change (since v10.19.0).
+* Changing the filter or search properties of an `@ObservedResults` would
+  trigger up to three updates on the View (since v10.6.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -243,8 +243,8 @@ private class ObservableStorage<ObservedType>: ObservableObject where ObservedTy
         }
     }
 
-    var objectWillChange: ObservableStoragePublisher<ObservedType>
-    var keyPaths: [String]?
+    let objectWillChange: ObservableStoragePublisher<ObservedType>
+    let keyPaths: [String]?
 
     init(_ value: ObservedType, _ keyPaths: [String]? = nil) {
         self.value = value.realm != nil && !value.isInvalidated ? value.thaw() ?? value : value
@@ -262,6 +262,55 @@ private class ObservableStorage<ObservedType>: ObservableObject where ObservedTy
         self.value = value.realm != nil && !value.isInvalidated ? value.thaw() ?? value : value
         self.objectWillChange = ObservableStoragePublisher(value, keyPaths)
         self.keyPaths = keyPaths
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+private class ObservableResultsStorage<T>: ObservableStorage<T> where T: RealmSubscribable & ThreadConfined & Equatable {
+    var setupHasRun = false
+    func didSet() {
+        if setupHasRun {
+            setupValue()
+            setupHasRun = true
+        }
+    }
+
+    func setupValue() {
+        fatalError()
+    }
+
+    var sortDescriptor: SortDescriptor? {
+        didSet {
+            didSet()
+        }
+    }
+
+    var filter: NSPredicate? {
+        didSet {
+            didSet()
+        }
+    }
+    var configuration: Realm.Configuration? {
+        didSet {
+            didSet()
+        }
+    }
+
+    var searchFilter: NSPredicate? {
+        didSet {
+            didSet()
+        }
+    }
+
+    private var searchString: String = ""
+    fileprivate func searchText<T: ObjectBase>(_ text: String, on keyPath: KeyPath<T, String>) {
+        guard text != searchString else { return }
+        if text.isEmpty {
+            searchFilter = nil
+        } else {
+            searchFilter = Query<T>()[dynamicMember: keyPath].contains(text).predicate
+        }
+        searchString = text
     }
 }
 
@@ -421,90 +470,42 @@ extension Projection: _ObservedResultsValue { }
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 @propertyWrapper public struct ObservedResults<ResultType>: DynamicProperty, BoundCollection where ResultType: _ObservedResultsValue & RealmFetchable & KeypathSortable & Identifiable {
     public typealias Element = ResultType
-    private class Storage: ObservableStorage<Results<ResultType>> {
-        var setupHasRun = false
-        private func didSet() {
-            if setupHasRun {
-                setupValue()
-            }
-        }
-
-        func setupValue() {
+    private class Storage: ObservableResultsStorage<Results<ResultType>> {
+        override func setupValue() {
             /// A base value to reset the state of the query if a user reassigns the `filter` or `sortDescriptor`
             let realm = try! Realm(configuration: configuration ?? Realm.Configuration.defaultConfiguration)
-            value = realm.objects(ResultType.self)
+            var value = realm.objects(ResultType.self)
             if let sortDescriptor = sortDescriptor {
                 value = value.sorted(byKeyPath: sortDescriptor.keyPath, ascending: sortDescriptor.ascending)
             }
 
-            let filters = [searchFilter, filter ?? `where`].compactMap { $0 }
+            let filters = [searchFilter, filter].compactMap { $0 }
             if !filters.isEmpty {
                 let compoundFilter = NSCompoundPredicate(andPredicateWithSubpredicates: filters)
                 value = value.filter(compoundFilter)
             }
-            setupHasRun = true
-        }
-
-        var sortDescriptor: SortDescriptor? {
-            didSet {
-                didSet()
-            }
-        }
-
-        var filter: NSPredicate? {
-            didSet {
-                didSet()
-            }
-        }
-        var `where`: NSPredicate? {
-            didSet {
-                didSet()
-            }
-        }
-        var configuration: Realm.Configuration? {
-            didSet {
-                didSet()
-            }
-        }
-
-        var searchString: String = ""
-        var searchFilter: NSPredicate? {
-            didSet {
-                didSet()
-            }
+            self.value = value
         }
     }
 
     @Environment(\.realmConfiguration) var configuration
     @ObservedObject private var storage: Storage
-    /// :nodoc:
     fileprivate func searchText<T: ObjectBase>(_ text: String, on keyPath: KeyPath<T, String>) {
-        if text.isEmpty {
-            if storage.searchFilter != nil {
-                storage.searchFilter = nil
-            }
-        } else if text != storage.searchString {
-            storage.searchFilter = Query<T>()[dynamicMember: keyPath].contains(text).predicate
-        }
-        storage.searchString = text
+        storage.searchText(text, on: keyPath)
     }
+
     /// Stores an NSPredicate used for filtering the Results. This is mutually exclusive
     /// to the `where` parameter.
     @State public var filter: NSPredicate? {
         willSet {
-            storage.where = nil
             storage.filter = newValue
         }
     }
     /// Stores a type safe query used for filtering the Results. This is mutually exclusive
     /// to the `filter` parameter.
     @State public var `where`: ((Query<ResultType>) -> Query<Bool>)? {
-        // The introduction of this property produces a compiler bug in
-        // Xcode 12.5.1. So Swift Queries are supported on Xcode 13 and above
-        // when used with SwiftUI.
         willSet {
-            storage.filter = nil
-            storage.where = newValue?(Query()).predicate
+            storage.filter = newValue?(Query()).predicate
         }
     }
     /// :nodoc:
@@ -605,7 +606,7 @@ extension Projection: _ObservedResultsValue { }
         self.sortDescriptor = sortDescriptor
     }
 
-    public mutating func update() {
+    public func update() {
         // When the view updates, it will inject the @Environment
         // into the propertyWrapper
         if storage.configuration == nil {
@@ -627,20 +628,13 @@ extension Projection: _ObservedResultsValue { }
 @propertyWrapper public struct ObservedSectionedResults<Key: _Persistable & Hashable, ResultType>: DynamicProperty, BoundCollection where ResultType: _ObservedResultsValue & RealmFetchable & KeypathSortable & Identifiable {
     public typealias Element = ResultType
 
-    private class Storage: ObservableStorage<SectionedResults<Key, ResultType>> {
-        var setupHasRun = false
-        private func didSet() {
-            if setupHasRun {
-                setupValue()
-            }
-        }
-
-        func setupValue() {
+    private class Storage: ObservableResultsStorage<SectionedResults<Key, ResultType>> {
+        override func setupValue() {
             /// A base value to reset the state of the query if a user reassigns the `filter` or `sortDescriptor`
             let realm = try! Realm(configuration: configuration ?? Realm.Configuration.defaultConfiguration)
             var results = realm.objects(ResultType.self)
 
-            let filters = [searchFilter, filter ?? `where`].compactMap { $0 }
+            let filters = [searchFilter, filter].compactMap { $0 }
             if !filters.isEmpty {
                 let compoundFilter = NSCompoundPredicate(andPredicateWithSubpredicates: filters)
                 results = results.filter(compoundFilter)
@@ -651,8 +645,6 @@ extension Projection: _ObservedResultsValue { }
             }
 
             value = results.sectioned(sortDescriptors: sortDescriptors, sectionBlock)
-
-            setupHasRun = true
         }
 
         var sortDescriptors: [SortDescriptor] = [] {
@@ -660,30 +652,6 @@ extension Projection: _ObservedResultsValue { }
                 didSet()
             }
         }
-
-        var filter: NSPredicate? {
-            didSet {
-                didSet()
-            }
-        }
-        var `where`: NSPredicate? {
-            didSet {
-                didSet()
-            }
-        }
-        var configuration: Realm.Configuration? {
-            didSet {
-                didSet()
-            }
-        }
-
-        var searchString: String = ""
-        var searchFilter: NSPredicate? {
-            didSet {
-                didSet()
-            }
-        }
-
         var sectionBlock: ((ResultType) -> Key)
         var keyPathString: String?
 
@@ -691,7 +659,7 @@ extension Projection: _ObservedResultsValue { }
              sectionBlock: @escaping ((ResultType) -> Key),
              sortDescriptors: [SortDescriptor],
              keyPathString: String? = nil,
-             keyPaths: [String]? = nil) where ResultType: ObjectBase {
+             keyPaths: [String]? = nil) {
             self.sectionBlock = sectionBlock
             self.sortDescriptors = sortDescriptors
             if let keyPathString = keyPathString {
@@ -701,24 +669,7 @@ extension Projection: _ObservedResultsValue { }
             if self.sortDescriptors.isEmpty {
                 throwRealmException("sortDescriptors must not be empty when sectioning ObservedSectionedResults with `sectionBlock`")
             }
-            super.init(value.sectioned(by: self.sectionBlock, sortDescriptors: self.sortDescriptors), keyPaths)
-        }
-
-        init<BoxedType: ObjectBase>(_ value: Results<ResultType>,
-                                    sectionBlock: @escaping ((ResultType) -> Key),
-                                    sortDescriptors: [SortDescriptor],
-                                    keyPathString: String? = nil,
-                                    keyPaths: [String]? = nil) where ResultType: Projection<BoxedType> {
-            self.sectionBlock = sectionBlock
-            self.sortDescriptors = sortDescriptors
-            if let keyPathString = keyPathString {
-                self.keyPathString = keyPathString
-                self.sortDescriptors.append(.init(keyPath: keyPathString, ascending: true))
-            }
-            if self.sortDescriptors.isEmpty {
-                throwRealmException("sortDescriptors must not be empty when sectioning ObservedSectionedResults with `sectionBlock`")
-            }
-            super.init(value.sectioned(by: self.sectionBlock, sortDescriptors: self.sortDescriptors), keyPaths)
+            super.init(value.sectioned(sortDescriptors: self.sortDescriptors, self.sectionBlock), keyPaths)
         }
     }
 
@@ -726,32 +677,20 @@ extension Projection: _ObservedResultsValue { }
     @ObservedObject private var storage: Storage
     /// :nodoc:
     fileprivate func searchText<T: ObjectBase>(_ text: String, on keyPath: KeyPath<T, String>) {
-        if text.isEmpty {
-            if storage.searchFilter != nil {
-                storage.searchFilter = nil
-            }
-        } else if text != storage.searchString {
-            storage.searchFilter = Query<T>()[dynamicMember: keyPath].contains(text).predicate
-        }
-        storage.searchString = text
+        storage.searchText(text, on: keyPath)
     }
     /// Stores an NSPredicate used for filtering the SectionedResults. This is mutually exclusive
     /// to the `where` parameter.
     @State public var filter: NSPredicate? {
         willSet {
-            storage.where = nil
             storage.filter = newValue
         }
     }
     /// Stores a type safe query used for filtering the SectionedResults. This is mutually exclusive
     /// to the `filter` parameter.
     @State public var `where`: ((Query<ResultType>) -> Query<Bool>)? {
-        // The introduction of this property produces a compiler bug in
-        // Xcode 12.5.1. So Swift Queries are supported on Xcode 13 and above
-        // when used with SwiftUI.
         willSet {
-            storage.filter = nil
-            storage.where = newValue?(Query()).predicate
+            storage.filter = newValue?(Query()).predicate
         }
     }
     /// :nodoc:
@@ -772,24 +711,6 @@ extension Projection: _ObservedResultsValue { }
         return self
     }
 
-    private init<ObjectType: ObjectBase>(type: ResultType.Type,
-                                         sectionBlock: @escaping ((ResultType) -> Key),
-                                         sortDescriptors: [SortDescriptor] = [],
-                                         filter: NSPredicate? = nil,
-                                         keyPaths: [String]? = nil,
-                                         keyPathString: String? = nil,
-                                         configuration: Realm.Configuration? = nil) where ResultType: Projection<ObjectType>, ObjectType: ThreadConfined {
-        let results = Results<ResultType>(RLMResults<ResultType>.emptyDetached())
-        self.storage = Storage(results,
-                               sectionBlock: sectionBlock,
-                               sortDescriptors: sortDescriptors,
-                               keyPathString: keyPathString,
-                               keyPaths: keyPaths)
-        self.storage.configuration = configuration
-        self.filter = filter
-        self.sortDescriptors = sortDescriptors
-    }
-
     private init(type: ResultType.Type,
                  sectionBlock: @escaping ((ResultType) -> Key),
                  sortDescriptors: [SortDescriptor] = [],
@@ -797,7 +718,7 @@ extension Projection: _ObservedResultsValue { }
                  where: ((Query<ResultType>) -> Query<Bool>)? = nil,
                  keyPaths: [String]? = nil,
                  keyPathString: String? = nil,
-                 configuration: Realm.Configuration? = nil) where ResultType: Object {
+                 configuration: Realm.Configuration? = nil) where ResultType: AnyObject {
         let results = Results<ResultType>(RLMResults<ResultType>.emptyDetached())
         self.storage = Storage(results,
                                sectionBlock: sectionBlock,
@@ -1045,7 +966,7 @@ extension Projection: _ObservedResultsValue { }
                   configuration: configuration)
     }
 
-    public mutating func update() {
+    public func update() {
         // When the view updates, it will inject the @Environment
         // into the propertyWrapper
         if storage.configuration == nil {
@@ -1549,7 +1470,30 @@ private class ObservableAsyncOpenStorage: ObservableObject {
         }
     }
 
-    func asyncOpen() {
+    fileprivate func update(_ partitionValue: PartitionValue?, _ configuration: Realm.Configuration) {
+        var open = false
+        if let partitionValue = partitionValue {
+            let bsonValue = AnyBSON(partitionValue: partitionValue)
+            if self.partitionValue != bsonValue {
+                self.partitionValue = bsonValue
+                open = true
+            }
+        }
+
+        // We don't want to use the `defaultConfiguration` from the environment, we only want to use this environment value in @AsyncOpen if is not the default one
+        if configuration != .defaultConfiguration, self.configuration != configuration {
+            if let partitionValue = configuration.syncConfiguration?.partitionValue {
+                self.partitionValue = partitionValue
+            }
+            self.configuration = configuration
+            open = true
+        }
+        if open {
+            self.asyncOpen()
+        }
+    }
+
+    private func asyncOpen() {
         if case let .loggedIn(user) = appState {
             asyncOpenForUser(user)
         }
@@ -1774,24 +1718,8 @@ private class ObservableAsyncOpenStorage: ObservableObject {
         storage = ObservableAsyncOpenStorage(asyncOpenKind: .asyncOpen, app: app, configuration: configuration, partitionValue: nil)
     }
 
-    public mutating func update() {
-        if let partitionValue = partitionValue {
-            let bsonValue = AnyBSON(partitionValue: partitionValue)
-            if storage.partitionValue != bsonValue {
-                storage.partitionValue = bsonValue
-                storage.asyncOpen()
-            }
-        }
-
-        // We don't want to use the `defaultConfiguration` from the environment, we only want to use this environment value in @AsyncOpen if is not the default one
-        if configuration != .defaultConfiguration,
-           storage.configuration != configuration {
-            if let partitionValue = configuration.syncConfiguration?.partitionValue {
-                storage.partitionValue = partitionValue
-            }
-            storage.configuration = configuration
-            storage.asyncOpen()
-        }
+    public func update() {
+        storage.update(partitionValue, configuration)
     }
 }
 
@@ -1899,24 +1827,8 @@ private class ObservableAsyncOpenStorage: ObservableObject {
         storage = ObservableAsyncOpenStorage(asyncOpenKind: .autoOpen, app: app, configuration: configuration, partitionValue: nil)
     }
 
-    public mutating func update() {
-        if let partitionValue = partitionValue {
-            let bsonValue = AnyBSON(partitionValue: partitionValue)
-            if storage.partitionValue != bsonValue {
-                storage.partitionValue = bsonValue
-                storage.asyncOpen()
-            }
-        }
-
-        // We don't want to use the `defaultConfiguration` from the environment, we only want to use this environment value in @AutoOpen if is not the default one
-        if configuration != .defaultConfiguration,
-           storage.configuration != configuration {
-            if let partitionValue = configuration.syncConfiguration?.partitionValue {
-                storage.partitionValue = partitionValue
-            }
-            storage.configuration = configuration
-            storage.asyncOpen()
-        }
+    public func update() {
+        storage.update(partitionValue, configuration)
     }
 }
 
@@ -2023,9 +1935,7 @@ extension View {
                                           keyPath: KeyPath<T, String>, placement: SearchFieldPlacement = .automatic,
                                           prompt: LocalizedStringKey) -> some View {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
-        return searchable(text: text,
-                          placement: placement,
-                          prompt: prompt)
+        return searchable(text: text, placement: placement, prompt: prompt)
     }
 
     /// Marks this view as searchable, which configures the display of a search field.
@@ -2304,9 +2214,7 @@ extension View {
                                                keyPath: KeyPath<T, String>, placement: SearchFieldPlacement = .automatic,
                                                prompt: LocalizedStringKey) -> some View {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
-        return searchable(text: text,
-                          placement: placement,
-                          prompt: prompt)
+        return searchable(text: text, placement: placement, prompt: prompt)
     }
 
     /// Marks this view as searchable, which configures the display of a search field.


### PR DESCRIPTION
While adding Sendable annotations to the SwiftUI stuff I extracted some duplicated code and fixed some minor issues. Updating the search text for searchable triggered two updates because it modified both `filter` and `where`, which each triggered an update. The `where` property on the storage appears to be just totally redundant.

Changing anything on ObservableResults would trigger up to three updates due to storing temporary values in the `@StateObject` property.

AsyncOpen and AutoOpen would start an async open twice if both the partitionValue and configuration environment keys were set.