### PR TITLE
Fix concurrency warnings in Projection and related types

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,41 +7,16 @@ included:
   - examples/installation/ios/swift
   - examples/ios/swift
   - examples/tvos/swift
+type_name:
+  allowed_symbols:
+    - _
 identifier_name:
+  allowed_symbols:
+    - _
   min_length: # not possible to disable this partial rule, so set it to zero
     warning: 0
     error: 0
   excluded:
-    - _constructForTesting()
-    - _constructPredicate()
-    - _id
-    - _name(for:)
-    - _nilValue()
-    - _nsError
-    - _nsErrorDomain
-    - _observe(_:)
-    - _observe(_:_:)
-    - _observe(_:_:_:)
-    - _observe(_:on:_:)
-    - _publisher
-    - _realmColumnNames()
-    - _realmObjectName()
-    - _rlmCollection
-    - _rlmCollection()
-    - _rlmDefaultValue()
-    - _rlmFromObjc(_:)
-    - _rlmFromObjc(_:insideOptional:)
-    - _rlmGetProperty(_:_:)
-    - _rlmGetPropertyOptional(_:_:)
-    - _rlmKeyPathRecorder(with:)
-    - _rlmObjcValue
-    - _rlmOptional
-    - _rlmPopulateProperty(_:)
-    - _rlmRequireObjc
-    - _rlmRequiresCaching
-    - _rlmSetAccessor(_:)
-    - _rlmSetProperty(_:_:_:)
-    - _rlmType
     - id
     - pk
     - to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Improve performance of creating Projection objects and of change
+  notifications on projections ([PR #8050](https://github.com/realm/realm-swift/pull/8050)).
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
-* None.
+* Object change notifications on projections only included the first projected
+  property for each source property ([PR #8050](https://github.com/realm/realm-swift/pull/8050), since v10.21.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/RealmSwift/Aliases.swift
+++ b/RealmSwift/Aliases.swift
@@ -137,7 +137,6 @@ extension ObjectBase {
      - parameter block: The block to call with information about changes to the object.
      - returns: A token which must be held for as long as you want updates to be delivered.
      */
-    // swiftlint:disable:next identifier_name
     internal func _observe<T: ObjectBase>(keyPaths: [String]? = nil,
                                           on queue: DispatchQueue? = nil,
                                           _ block: @escaping (ObjectChange<T>) -> Void) -> NotificationToken {

--- a/RealmSwift/Combine.swift
+++ b/RealmSwift/Combine.swift
@@ -2537,12 +2537,12 @@ public enum RealmPublishers {
         }
     }
 
+    // swiftlint:disable type_name
     /// A publisher which delivers thread-confined collection changesets to a
     /// serial dispatch queue.
     ///
     /// Create using `.threadSafeReference().receive(on: queue)` on a publisher
     /// that emits `RealmCollectionChange`.
-    // swiftlint:disable:next type_name
     @frozen public struct DeferredHandoverSectionedResultsChangeset<Upstream: Publisher, T: RealmSectionedResult, S: Scheduler>: Publisher where Upstream.Output == RealmSectionedResultsChange<T> {
         /// :nodoc:
         public typealias Failure = Upstream.Failure
@@ -2610,6 +2610,7 @@ public enum RealmPublishers {
                 .receive(subscriber: subscriber)
         }
     }
+    // swiftlint:enable type_name
 
     /// A publisher which delivers thread-confined collection changesets to a
     /// serial dispatch queue.

--- a/RealmSwift/Decimal128.swift
+++ b/RealmSwift/Decimal128.swift
@@ -238,8 +238,6 @@ extension Decimal128: Numeric {
     ///   - lhs: The first value to multiply.
     ///   - rhs: The second value to multiply.
     public static func *= (lhs: inout Decimal128, rhs: Decimal128) {
-        // Swiftlint wants us to use *= but this is the definition of *=
-        // swiftlint:disable:next shorthand_operator
         lhs = lhs * rhs
     }
 

--- a/RealmSwift/Impl/RealmCollectionImpl.swift
+++ b/RealmSwift/Impl/RealmCollectionImpl.swift
@@ -159,11 +159,9 @@ extension RealmCollectionImpl {
 // A helper protocol which lets us check for Optional in where clauses
 public protocol OptionalProtocol {
     associatedtype Wrapped
-    // swiftlint:disable:next identifier_name
     func _rlmInferWrappedType() -> Wrapped
 }
 
 extension Optional: OptionalProtocol {
-    // swiftlint:disable:next identifier_name
     public func _rlmInferWrappedType() -> Wrapped { return self! }
 }

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -210,7 +210,6 @@ public final class List<Element: RealmCollectionValue>: RLMSwiftCollectionBase, 
         rlmArray.exchangeObject(at: UInt(index1), withObjectAt: UInt(index2))
     }
 
-    // swiftlint:disable:next identifier_name
     @objc class func _unmanagedCollection() -> RLMArray<AnyObject> {
         if let type = Element.self as? ObjectBase.Type {
             return RLMArray(objectClassName: type.className())

--- a/RealmSwift/Map.swift
+++ b/RealmSwift/Map.swift
@@ -642,7 +642,6 @@ public final class Map<Key: _MapKey, Value: RealmCollectionValue>: RLMSwiftColle
         return Map(objc: rlmDictionary.thaw())
     }
 
-    // swiftlint:disable:next identifier_name
     @objc class func _unmanagedCollection() -> RLMDictionary<AnyObject, AnyObject> {
         if let type = Value.self as? HasClassName.Type ?? Value.PersistedType.self as? HasClassName.Type {
             return RLMDictionary(objectClassName: type.className(), keyType: Key._rlmType)

--- a/RealmSwift/MutableSet.swift
+++ b/RealmSwift/MutableSet.swift
@@ -188,7 +188,6 @@ public final class MutableSet<Element: RealmCollectionValue>: RLMSwiftCollection
         rlmSet.union(other.rlmSet)
     }
 
-    // swiftlint:disable:next identifier_name
     @objc class func _unmanagedCollection() -> RLMSet<AnyObject> {
         if let type = Element.self as? ObjectBase.Type {
             return RLMSet(objectClassName: type.className())

--- a/RealmSwift/PersistedProperty.swift
+++ b/RealmSwift/PersistedProperty.swift
@@ -347,9 +347,9 @@ extension Persisted where Value.PersistedType: _PrimaryKey {
     }
 }
 
-/// :nodoc:
 // Constraining the LinkingObjects initializer to only LinkingObjects require
 // doing so via a protocol which only that type conforms to.
+/// :nodoc:
 public protocol LinkingObjectsProtocol {
     init(fromType: Element.Type, property: String)
     associatedtype Element

--- a/RealmSwift/Query.swift
+++ b/RealmSwift/Query.swift
@@ -850,7 +850,7 @@ extension Optional: _QueryBinary where Wrapped: _Persistable, Wrapped.PersistedT
 
 // MARK: QueryNode -
 
-fileprivate indirect enum QueryNode {
+private indirect enum QueryNode {
     enum Operator: String {
         case or = "||"
         case and = "&&"

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -479,7 +479,6 @@ extension Projection: _ObservedResultsValue { }
     public typealias Element = ResultType
     private class Storage: ObservableResultsStorage<Results<ResultType>> {
         override func updateValue() {
-            /// A base value to reset the state of the query if a user reassigns the `filter` or `sortDescriptor`
             let realm = try! Realm(configuration: configuration ?? Realm.Configuration.defaultConfiguration)
             var value = realm.objects(ResultType.self)
             if let sortDescriptor = sortDescriptor {
@@ -635,7 +634,6 @@ extension Projection: _ObservedResultsValue { }
 
     private class Storage: ObservableResultsStorage<SectionedResults<Key, ResultType>> {
         override func updateValue() {
-            /// A base value to reset the state of the query if a user reassigns the `filter` or `sortDescriptor`
             let realm = try! Realm(configuration: configuration ?? Realm.Configuration.defaultConfiguration)
             var results = realm.objects(ResultType.self)
 

--- a/RealmSwift/Tests/MapTests.swift
+++ b/RealmSwift/Tests/MapTests.swift
@@ -715,7 +715,7 @@ class MapTests: TestCase {
             case .initial(let map):
                 XCTAssertNotNil(map)
                 exp.fulfill()
-            case .update(_, deletions: _, insertions: _, modifications: _):
+            case .update:
                 XCTFail("should not get here for this test")
             case .error:
                 XCTFail("should not get here for this test")

--- a/RealmSwift/Tests/ModernObjectCreationTests.swift
+++ b/RealmSwift/Tests/ModernObjectCreationTests.swift
@@ -904,7 +904,7 @@ class ModernObjectCreationTests: TestCase {
     }
 
     func testAddObjectCycle() {
-        weak var weakObj1: ModernCircleObject? = nil, weakObj2: ModernCircleObject? = nil
+        weak var weakObj1: ModernCircleObject?, weakObj2: ModernCircleObject?
 
         autoreleasepool {
             let obj1 = ModernCircleObject(value: [])

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -1068,7 +1068,7 @@ class ObjectCreationTests: TestCase {
     }
 
     func testAddObjectCycle() {
-        weak var weakObj1: SwiftCircleObject? = nil, weakObj2: SwiftCircleObject? = nil
+        weak var weakObj1: SwiftCircleObject?, weakObj2: SwiftCircleObject?
 
         autoreleasepool {
             let obj1 = SwiftCircleObject(value: [])

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -181,12 +181,12 @@ class ObjectTests: TestCase {
 
         let intObj = SwiftPrimaryIntObject()
         intObj.intCol = 1
-        intObj.intCol = 0; // can change primary key unattached
+        intObj.intCol = 0 // can change primary key unattached
         XCTAssertEqual(0, intObj.intCol)
 
         let optionalIntObj = SwiftPrimaryOptionalIntObject()
         optionalIntObj.intCol.value = 1
-        optionalIntObj.intCol.value = 0; // can change primary key unattached
+        optionalIntObj.intCol.value = 0 // can change primary key unattached
         XCTAssertEqual(0, optionalIntObj.intCol.value)
 
         let stringObj = SwiftPrimaryStringObject()

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -1306,7 +1306,7 @@ class RealmTests: TestCase {
             switch change {
             case .initial:
                 return // ignore
-            case .update(_, deletions: _, insertions: _, modifications: _):
+            case .update:
                 updateComplete.fulfill()
             case .error:
                 XCTFail("should not get here for this test")

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -672,7 +672,6 @@ class SwiftObjectiveCTypesObject: Object {
 }
 
 class SwiftComputedPropertyNotIgnoredObject: Object {
-    // swiftlint:disable:next identifier_name
     @objc dynamic var _urlBacking = ""
 
     // Dynamic; no ivar

--- a/examples/ios/swift/ListSwiftUI/Views/ContentView.swift
+++ b/examples/ios/swift/ListSwiftUI/Views/ContentView.swift
@@ -284,7 +284,6 @@ struct ContentView: View {
 }
 
 #if DEBUG
-// swiftlint:disable type_name
 struct Content_Preview: PreviewProvider {
     static var previews: some View {
         ContentView()


### PR DESCRIPTION
Concurrency checking wants us to use `withLock()` to guard access to the schema cache, and requires marking the schema cache as unchecked sendable. While refactoring to support this I also fixed an unrelated problem (object change notifications were incorrect if a property was projected more than one time) and cut down on some redundant object allocations. The schema lock is a moderately hot path since we hit it every time we allocate an object, so I made it use the faster os_unfair_lock when possible.

The changes to unrelated files are to make the latest version of swiftlint happy.