### PR TITLE
Add Sendable annotations to the obj-c API

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -2431,7 +2431,7 @@
 				CLASSPREFIX = RLM;
 				LastSwiftUpdateCheck = 1230;
 				LastTestingUpgradeCheck = 0510;
-				LastUpgradeCheck = 1400;
+				LastUpgradeCheck = 1410;
 				ORGANIZATIONNAME = Realm;
 				TargetAttributes = {
 					3F1A5E711992EB7400F45F4C = {

--- a/Realm/NSError+RLMSync.h
+++ b/Realm/NSError+RLMSync.h
@@ -16,9 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability)
 
 @class RLMSyncErrorActionToken;
 
@@ -43,4 +43,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability)

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -23,7 +23,7 @@
 typedef NS_ENUM(NSUInteger, RLMSyncStopPolicy);
 typedef void(^RLMSyncBasicErrorReportingBlock)(NSError * _Nullable);
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface RealmServer : NSObject
 + (RealmServer *)shared;
@@ -169,7 +169,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)waitForSessionTermination;
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)
 
 #define WAIT_FOR_SEMAPHORE(macro_semaphore, macro_timeout) do {                                                        \
     int64_t delay_in_ns = (int64_t)(macro_timeout * NSEC_PER_SEC);                                                     \

--- a/Realm/ObjectServerTests/RLMUser+ObjectServerTests.h
+++ b/Realm/ObjectServerTests/RLMUser+ObjectServerTests.h
@@ -18,7 +18,7 @@
 
 #import <Realm/Realm.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface RLMUser (ObjectServerTests)
 
@@ -29,4 +29,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/ObjectServerTests/RLMWatchTestUtility.h
+++ b/Realm/ObjectServerTests/RLMWatchTestUtility.h
@@ -20,7 +20,7 @@
 #import <Realm/RLMMongoCollection.h>
 #import <XCTest/XCTest.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /// Used to process watch change events and assert tests.
 @interface RLMWatchTestUtility : XCTestCase <RLMChangeEventDelegate>
@@ -44,4 +44,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 @end
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMAPIKeyAuth.h
+++ b/Realm/RLMAPIKeyAuth.h
@@ -20,7 +20,7 @@
 
 @class RLMUserAPIKey, RLMObjectId;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /// Provider client for user API keys.
 @interface RLMAPIKeyAuth : RLMProviderClient
@@ -88,4 +88,4 @@ typedef void(^RLMUserAPIKeysBlock)(NSArray<RLMUserAPIKey *> *  _Nullable, NSErro
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMAccessor.h
+++ b/Realm/RLMAccessor.h
@@ -16,11 +16,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 
 @class RLMObjectSchema, RLMProperty, RLMObjectBase;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability)
 
 //
 // Accessors Class Creation/Caching
@@ -50,4 +50,4 @@ void RLMReplaceClassNameMethod(Class accessorClass, NSString *className);
 // Replace sharedSchema method for the given class
 void RLMReplaceSharedSchemaMethod(Class accessorClass, RLMObjectSchema * __nullable schema);
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability)

--- a/Realm/RLMApp.h
+++ b/Realm/RLMApp.h
@@ -16,10 +16,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 #import <AuthenticationServices/AuthenticationServices.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @protocol RLMNetworkTransport, RLMBSON;
 
@@ -38,7 +38,7 @@ typedef void(^RLMOptionalErrorBlock)(NSError * _Nullable);
 @interface RLMAppConfiguration : NSObject
 
 /// A custom base URL to request against.
-@property (nonatomic, strong, nullable) NSString* baseURL;
+@property (nonatomic, strong, nullable) NSString *baseURL;
 
 /// The custom transport for network calls to the server.
 @property (nonatomic, strong, nullable) id<RLMNetworkTransport> transport;
@@ -90,6 +90,7 @@ Create a new Realm App configuration.
 
  This interface provides access to login and authentication.
  */
+RLM_SWIFT_SENDABLE
 @interface RLMApp : NSObject
 
 /// The configuration for this Realm app.
@@ -172,11 +173,7 @@ to obtain a reference to an RLMApp.
 
 @end
 
-NS_ASSUME_NONNULL_END
-
 #pragma mark - Sign In With Apple Extension
-
-NS_ASSUME_NONNULL_BEGIN
 
 API_AVAILABLE(ios(13.0), macos(10.15), tvos(13.0), watchos(6.0))
 /// Use this delegate to be provided a callback once authentication has succeed or failed
@@ -206,4 +203,4 @@ API_AVAILABLE(ios(13.0), macos(10.15), tvos(13.0), watchos(6.0))
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMApp.mm
+++ b/Realm/RLMApp.mm
@@ -153,11 +153,14 @@ namespace {
     return nil;
 }
 
+static void setOptionalString(std::optional<std::string>& dst, NSString *src) {
+    std::string tmp;
+    RLMNSStringToStdString(tmp, src);
+    dst = tmp.empty() ? util::none : std::optional(std::move(tmp));
+}
+
 - (void)setBaseURL:(nullable NSString *)baseURL {
-    std::string base_url;
-    RLMNSStringToStdString(base_url, baseURL);
-    _config.base_url = base_url.empty() ? util::none : std::optional(base_url);
-    return;
+    setOptionalString(_config.base_url, baseURL);
 }
 
 - (id<RLMNetworkTransport>)transport {
@@ -180,10 +183,7 @@ namespace {
 }
 
 - (void)setLocalAppName:(nullable NSString *)localAppName {
-    std::string local_app_name;
-    RLMNSStringToStdString(local_app_name, localAppName);
-    _config.local_app_name = local_app_name.empty() ? util::none : std::optional(local_app_name);
-    return;
+    setOptionalString(_config.local_app_name, localAppName);
 }
 
 - (NSString *)localAppVersion {
@@ -195,10 +195,7 @@ namespace {
 }
 
 - (void)setLocalAppVersion:(nullable NSString *)localAppVersion {
-    std::string local_app_version;
-    RLMNSStringToStdString(local_app_version, localAppVersion);
-    _config.local_app_version = local_app_version.empty() ? util::none : std::optional(local_app_version);
-    return;
+    setOptionalString(_config.local_app_version, localAppVersion);
 }
 
 - (NSUInteger)defaultRequestTimeoutMS {

--- a/Realm/RLMApp_Private.h
+++ b/Realm/RLMApp_Private.h
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMApp.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /// Observer block for app notifications.
 typedef void(^RLMAppNotificationBlock)(RLMApp *);
@@ -48,4 +48,4 @@ typedef void(^RLMAppNotificationBlock)(RLMApp *);
 + (void)resetAppCache;
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMApp_Private.hpp
+++ b/Realm/RLMApp_Private.hpp
@@ -22,13 +22,11 @@
 
 #import <memory>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface RLMAppConfiguration ()
 
 - (realm::app::App::Config&)config;
-
-- (void)setAppId:(NSString *)appId;
 
 - (instancetype)initWithConfig:(const realm::app::App::Config&)config;
 
@@ -48,4 +46,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 NSError * RLMAppErrorToNSError(realm::app::AppError const& appError);
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMArray.h
+++ b/Realm/RLMArray.h
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMCollection.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMObject, RLMResults<RLMObjectType>;
 
@@ -649,4 +649,4 @@ __attribute__((warn_unused_result));
 - (instancetype)initWithObjectClassName:(NSString *)objectClassName;
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMArray_Private.h
+++ b/Realm/RLMArray_Private.h
@@ -21,7 +21,7 @@
 
 @class RLMObjectBase, RLMProperty;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface RLMArray ()
 - (instancetype)initWithObjectClassName:(NSString *)objectClassName;
@@ -41,4 +41,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 void RLMArrayValidateMatchingObjectType(RLMArray *array, id value);
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMAsymmetricObject.h
+++ b/Realm/RLMAsymmetricObject.h
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMObjectBase.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMObjectSchema, RLMPropertyDescriptor;
 /**
@@ -95,4 +95,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMClassInfo.hpp
+++ b/Realm/RLMClassInfo.hpp
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 
 #import <realm/table_ref.hpp>
 #import <realm/util/optional.hpp>
@@ -35,7 +35,7 @@ namespace realm {
 class RLMObservationInfo;
 @class RLMRealm, RLMSchema, RLMObjectSchema, RLMProperty;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 namespace std {
 // Add specializations so that NSString can be used as the key for hash containers
@@ -145,4 +145,4 @@ private:
     std::unordered_map<NSString *, RLMClassInfo> m_objects;
 };
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMCollection.h
+++ b/Realm/RLMCollection.h
@@ -16,12 +16,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
-
 #import <Realm/RLMConstants.h>
 #import <Realm/RLMThreadSafeReference.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @protocol RLMValue;
 @class RLMRealm, RLMResults, RLMSortDescriptor, RLMNotificationToken, RLMCollectionChange, RLMSectionedResults;
@@ -611,4 +609,4 @@ __attribute__((warn_unused_result));
 - (NSArray<NSIndexPath *> *)modificationsInSection:(NSUInteger)section;
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMCollection_Private.h
+++ b/Realm/RLMCollection_Private.h
@@ -22,12 +22,12 @@
 
 @protocol RLMFastEnumerable;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 void RLMCollectionSetValueForKey(id<RLMFastEnumerable> collection, NSString *key, id _Nullable value);
 FOUNDATION_EXTERN NSString *RLMDescriptionWithMaxDepth(NSString *name, id<RLMCollection> collection, NSUInteger depth);
 FOUNDATION_EXTERN void RLMAssignToCollection(id<RLMCollection> collection, id value);
-FOUNDATION_EXTERN id _Nullable (*_Nullable RLMSwiftBridgeValue)(id);
+FOUNDATION_EXTERN void RLMSetSwiftBridgeCallback(id _Nullable (*_Nonnull)(id));
 
 typedef RLM_CLOSED_ENUM(int32_t, RLMCollectionType) {
     RLMCollectionTypeArray = 0,
@@ -35,4 +35,4 @@ typedef RLM_CLOSED_ENUM(int32_t, RLMCollectionType) {
     RLMCollectionTypeDictionary = 2
 };
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMConstants.h
+++ b/Realm/RLMConstants.h
@@ -18,7 +18,21 @@
 
 #import <Foundation/Foundation.h>
 
-NS_ASSUME_NONNULL_BEGIN
+#ifdef NS_HEADER_AUDIT_BEGIN
+#define RLM_HEADER_AUDIT_BEGIN NS_HEADER_AUDIT_BEGIN
+#define RLM_HEADER_AUDIT_END NS_HEADER_AUDIT_END
+#else
+#define RLM_HEADER_AUDIT_BEGIN(...) NS_ASSUME_NONNULL_BEGIN
+#define RLM_HEADER_AUDIT_END(...) NS_ASSUME_NONNULL_END
+#endif
+
+#ifdef NS_SWIFT_SENDABLE
+#define RLM_SWIFT_SENDABLE NS_SWIFT_SENDABLE
+#else
+#define RLM_SWIFT_SENDABLE
+#endif
+
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 // Swift 5 considers NS_ENUM to be "open", meaning there could be values present
 // other than the defined cases (which allows adding more cases later without
@@ -214,4 +228,4 @@ extern NSString * const RLMRealmCoreVersionKey;
 /** The corresponding key is the Realm invalidated property name. */
 extern NSString * const RLMInvalidatedKey;
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMCredentials.h
+++ b/Realm/RLMCredentials.h
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMSyncUtil.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 @protocol RLMBSON;
 
 /// A token representing an identity provider's credentials.
@@ -120,6 +120,6 @@ extern RLMIdentityProvider const RLMIdentityProviderServerAPIKey;
 /// :nodoc:
 + (instancetype)new __attribute__((unavailable("RLMAppCredentials cannot be created directly")));
 
-NS_ASSUME_NONNULL_END
-
 @end
+
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMDecimal128.h
+++ b/Realm/RLMDecimal128.h
@@ -16,9 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /**
  A 128-bit IEEE 754-2008 decimal floating point number.
@@ -29,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  this type stores up to 34 digits of significand and an exponent from -6143 to
  6144.
  */
+RLM_SWIFT_SENDABLE
 @interface RLMDecimal128 : NSObject <NSCopying>
 /// Creates a new zero-initialized decimal128.
 - (instancetype)init;
@@ -106,4 +107,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMDictionary.h
+++ b/Realm/RLMDictionary.h
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMCollection.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMObject, RLMResults<RLMObjectType>, RLMDictionaryChange;
 
@@ -554,4 +554,4 @@ __attribute__((warn_unused_result));
 @property (nonatomic, readonly) NSArray<id> *deletions;
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMDictionary_Private.h
+++ b/Realm/RLMDictionary_Private.h
@@ -20,7 +20,7 @@
 
 @class RLMObjectBase, RLMProperty;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface RLMDictionary ()
 - (instancetype)initWithObjectClassName:(NSString *)objectClassName keyType:(RLMPropertyType)keyType;
@@ -43,4 +43,4 @@ FOUNDATION_EXTERN NSString *RLMDictionaryDescriptionWithMaxDepth(NSString *name,
 id RLMDictionaryKey(RLMDictionary *dictionary, id key) REALM_HIDDEN;
 id RLMDictionaryValue(RLMDictionary *dictionary, id value) REALM_HIDDEN;
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMEmailPasswordAuth.h
+++ b/Realm/RLMEmailPasswordAuth.h
@@ -23,7 +23,7 @@
 /// A block type used to report an error
 typedef void(^RLMEmailPasswordAuthOptionalErrorBlock)(NSError * _Nullable);
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /**
   A client for the email/password authentication provider which
@@ -114,5 +114,5 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)
 

--- a/Realm/RLMEmbeddedObject.h
+++ b/Realm/RLMEmbeddedObject.h
@@ -16,12 +16,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
-
 #import <Realm/RLMObjectBase.h>
 #import <Realm/RLMThreadSafeReference.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMObjectSchema, RLMPropertyDescriptor, RLMRealm, RLMNotificationToken, RLMPropertyChange;
 typedef void (^RLMObjectChangeBlock)(BOOL deleted,
@@ -366,4 +364,4 @@ typedef void (^RLMObjectChangeBlock)(BOOL deleted,
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMEvent.h
+++ b/Realm/RLMEvent.h
@@ -16,7 +16,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
 #import <Realm/RLMConstants.h>
 
 #ifdef __cplusplus
@@ -27,7 +26,7 @@ struct AuditConfig;
 }
 #endif
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMRealm, RLMUser, RLMRealmConfiguration;
 typedef RLM_CLOSED_ENUM(NSUInteger, RLMSyncLogLevel);
@@ -56,4 +55,4 @@ FOUNDATION_EXTERN void RLMEventUpdateMetadata(struct RLMEventContext *context,
 #endif
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMFindOneAndModifyOptions.h
+++ b/Realm/RLMFindOneAndModifyOptions.h
@@ -16,9 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 @protocol RLMBSON;
 
 /// Options to use when executing a `findOneAndUpdate`, `findOneAndReplace`,
@@ -56,4 +56,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMFindOptions.h
+++ b/Realm/RLMFindOptions.h
@@ -16,9 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @protocol RLMBSON;
 
@@ -52,4 +52,4 @@ NS_SWIFT_UNAVAILABLE("Please see FindOption");
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMFindOptions_Private.hpp
+++ b/Realm/RLMFindOptions_Private.hpp
@@ -20,10 +20,10 @@
 
 #import <realm/object-store/sync/mongo_collection.hpp>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface RLMFindOptions ()
 - (realm::app::MongoCollection::FindOptions)_findOptions;
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMMigration.h
+++ b/Realm/RLMMigration.h
@@ -16,9 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMSchema;
 @class RLMArray;
@@ -124,4 +124,4 @@ typedef void (^RLMObjectMigrationBlock)(RLMObject * __nullable oldObject, RLMObj
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMMigration_Private.h
+++ b/Realm/RLMMigration_Private.h
@@ -24,7 +24,7 @@ namespace realm {
     class Schema;
 }
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface RLMMigration ()
 
@@ -37,4 +37,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMMongoClient.h
+++ b/Realm/RLMMongoClient.h
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMMongoDatabase.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMApp;
 
@@ -43,4 +43,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMMongoClient_Private.hpp
+++ b/Realm/RLMMongoClient_Private.hpp
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMMongoClient.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMUser;
 
@@ -30,5 +30,5 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)
 

--- a/Realm/RLMMongoCollection.h
+++ b/Realm/RLMMongoCollection.h
@@ -20,7 +20,7 @@
 
 #import <Realm/RLMNetworkTransport.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 @protocol RLMBSON;
 
 @class RLMFindOptions, RLMFindOneAndModifyOptions, RLMUpdateResult, RLMChangeStream, RLMObjectId;
@@ -315,4 +315,4 @@ typedef void(^RLMMongoDeleteBlock)(NSDictionary<NSString *, id<RLMBSON>> * _Null
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMMongoCollection_Private.hpp
+++ b/Realm/RLMMongoCollection_Private.hpp
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMMongoCollection.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMUser;
 @protocol RLMChangeEventDelegate;
@@ -43,4 +43,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMMongoDatabase.h
+++ b/Realm/RLMMongoDatabase.h
@@ -16,9 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMMongoCollection;
 
@@ -46,4 +46,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMMongoDatabase_Private.hpp
+++ b/Realm/RLMMongoDatabase_Private.hpp
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMMongoClient.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMUser;
 
@@ -33,4 +33,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMNetworkTransport.h
+++ b/Realm/RLMNetworkTransport.h
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMConstants.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /// Allowed HTTP methods to be used with `RLMNetworkTransport`.
 typedef RLM_CLOSED_ENUM(int32_t, RLMHTTPMethod) {
@@ -127,4 +127,4 @@ typedef void(^RLMNetworkTransportCompletionBlock)(RLMResponse *);
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -16,12 +16,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
-
+#import <Realm/RLMConstants.h>
 #import <Realm/RLMObjectBase.h>
 #import <Realm/RLMThreadSafeReference.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMNotificationToken;
 @class RLMObjectSchema;
@@ -809,4 +808,4 @@ __attribute__((deprecated("RLM_ARRAY_TYPE has been deprecated. Use RLM_COLLECTIO
 @protocol RLM_OBJECT_SUBCLASS <NSObject>   \
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMObjectBase.h
+++ b/Realm/RLMObjectBase.h
@@ -16,9 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMRealm;
 @class RLMSchema;
@@ -160,4 +160,4 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RealmSwiftAsymmetricObject : RLMObjectBase
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMObjectBase_Dynamic.h
+++ b/Realm/RLMObjectBase_Dynamic.h
@@ -20,7 +20,7 @@
 
 @class RLMObjectSchema, RLMRealm;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability)
 
 /**
  Returns the Realm that manages the object, if one exists.
@@ -79,4 +79,4 @@ FOUNDATION_EXTERN id _Nullable RLMObjectBaseObjectForKeyedSubscript(RLMObjectBas
  */
 FOUNDATION_EXTERN void RLMObjectBaseSetObjectForKeyedSubscript(RLMObjectBase * _Nullable object, NSString *key, id _Nullable obj);
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability)

--- a/Realm/RLMObjectBase_Private.h
+++ b/Realm/RLMObjectBase_Private.h
@@ -20,7 +20,7 @@
 
 @class RLMArray<RLMObjectType>;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability)
 
 // RLMObjectBase private
 @interface RLMObjectBase ()
@@ -31,4 +31,4 @@ NS_ASSUME_NONNULL_BEGIN
 + (bool)isAsymmetric;
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability)

--- a/Realm/RLMObjectId.h
+++ b/Realm/RLMObjectId.h
@@ -16,9 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /**
  A 12-byte (probably) unique object identifier.
@@ -34,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
  ObjectIds are intended to be fast to generate. Sorting by an ObjectId field
  will typically result in the objects being sorted in creation order.
  */
+RLM_SWIFT_SENDABLE
 @interface RLMObjectId : NSObject <NSCopying>
 /// Creates a new randomly-initialized ObjectId.
 + (nonnull instancetype)objectId NS_SWIFT_NAME(generate());
@@ -75,4 +76,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMObjectSchema.h
+++ b/Realm/RLMObjectSchema.h
@@ -16,9 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMProperty;
 
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  Object schemas map to tables in the core database.
  */
+RLM_SWIFT_SENDABLE
 @interface RLMObjectSchema : NSObject<NSCopying>
 
 #pragma mark - Properties
@@ -79,4 +80,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMObjectSchema_Private.h
+++ b/Realm/RLMObjectSchema_Private.h
@@ -20,7 +20,7 @@
 
 #import <objc/runtime.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability)
 
 // RLMObjectSchema private
 @interface RLMObjectSchema () {
@@ -72,4 +72,4 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithClassName:(NSString *)objectClassName objectClass:(Class)objectClass properties:(NSArray *)properties;
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability)

--- a/Realm/RLMObjectStore.h
+++ b/Realm/RLMObjectStore.h
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,7 +30,7 @@ typedef NS_ENUM(NSUInteger, RLMUpdatePolicy) {
     RLMUpdatePolicyUpdateAll = 2,
 };
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability)
 
 void RLMVerifyHasPrimaryKey(Class cls);
 
@@ -95,4 +95,4 @@ RLMObjectBase *RLMCreateObjectAccessor(RLMClassInfo& info, int64_t key) NS_RETUR
 RLMObjectBase *RLMCreateObjectAccessor(RLMClassInfo& info, realm::Obj&& obj) NS_RETURNS_RETAINED;
 #endif
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability)

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMObjectBase_Dynamic.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMProperty, RLMArray;
 typedef NS_ENUM(int32_t, RLMPropertyType);
@@ -99,4 +99,4 @@ FOUNDATION_EXTERN uint64_t RLMObjectBaseGetCombineId(RLMObjectBase *);
 + (void)set:(RLMProperty *)property on:(RLMObjectBase *)parent to:(id)value;
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMProperty.h
+++ b/Realm/RLMProperty.h
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMConstants.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /// :nodoc:
 @protocol RLMInt @end
@@ -55,6 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  These property instances map to columns in the core database.
  */
+RLM_SWIFT_SENDABLE
 @interface RLMProperty : NSObject
 
 #pragma mark - Properties
@@ -144,4 +145,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -22,7 +22,7 @@
 
 @class RLMObjectBase;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability)
 
 BOOL RLMPropertyTypeIsComputed(RLMPropertyType propertyType);
 FOUNDATION_EXTERN void RLMValidateSwiftPropertyName(NSString *name);
@@ -136,4 +136,4 @@ static inline NSString *RLMTypeToString(RLMPropertyType type) {
                     optional:(BOOL)optional;
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability)

--- a/Realm/RLMProviderClient.h
+++ b/Realm/RLMProviderClient.h
@@ -16,9 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMApp;
 
@@ -36,4 +36,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMPushClient.h
+++ b/Realm/RLMPushClient.h
@@ -16,9 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMApp, RLMUser;
 
@@ -42,4 +42,4 @@ typedef void(^RLMOptionalErrorBlock)(NSError * _Nullable);
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMRealm+Sync.h
+++ b/Realm/RLMRealm+Sync.h
@@ -22,7 +22,7 @@
 
 @class RLMResults, RLMSyncSession;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability)
 
 ///
 @interface RLMRealm (Sync)
@@ -35,4 +35,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability)

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -16,7 +16,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
 #import <Realm/RLMConstants.h>
 
 @class RLMRealmConfiguration, RLMRealm, RLMObject, RLMSchema, RLMMigration, RLMNotificationToken, RLMThreadSafeReference, RLMAsyncOpenTask, RLMSyncSubscriptionSet;
@@ -31,7 +30,7 @@ typedef void(^RLMAsyncOpenRealmCallback)(RLMRealm * _Nullable realm, NSError * _
 /// The Id of the asynchronous transaction.
 typedef unsigned RLMAsyncTransactionId;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /**
  An `RLMRealm` instance (also referred to as "a Realm") represents a Realm
@@ -947,6 +946,7 @@ NS_REFINED_FOR_SWIFT;
  When you wish to stop, call the `-invalidate` method. Notifications are also stopped if
  the token is deallocated.
  */
+RLM_SWIFT_SENDABLE
 @interface RLMNotificationToken : NSObject
 /// Stops notifications for the change subscription that returned this token.
 - (void)invalidate;
@@ -955,4 +955,4 @@ NS_REFINED_FOR_SWIFT;
 - (void)stop __attribute__((unavailable("Renamed to -invalidate."))) NS_REFINED_FOR_SWIFT;
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMRealmConfiguration.h
+++ b/Realm/RLMRealmConfiguration.h
@@ -16,12 +16,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
 #import <Realm/RLMRealm.h>
 
 @class RLMEventConfiguration, RLMSyncConfiguration;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /**
  A block called when opening a Realm for the first time during the life
@@ -193,4 +192,4 @@ typedef void(^RLMFlexibleSyncInitialSubscriptionsBlock)(RLMSyncSubscriptionSet *
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMRealmConfiguration_Private.h
+++ b/Realm/RLMRealmConfiguration_Private.h
@@ -20,7 +20,7 @@
 
 @class RLMSchema, RLMEventConfiguration;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability)
 
 @interface RLMRealmConfiguration ()
 
@@ -47,4 +47,4 @@ NS_ASSUME_NONNULL_BEGIN
 FOUNDATION_EXTERN NSString *RLMRealmPathForFile(NSString *fileName);
 FOUNDATION_EXTERN NSString *RLMRealmPathForFileAndBundleIdentifier(NSString *fileName, NSString *mainBundleIdentifier);
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability)

--- a/Realm/RLMRealm_Dynamic.h
+++ b/Realm/RLMRealm_Dynamic.h
@@ -23,7 +23,7 @@
 
 @class RLMResults<RLMObjectType>;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability)
 
 @interface RLMRealm (Dynamic)
 
@@ -115,4 +115,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability)

--- a/Realm/RLMRealm_Private.h
+++ b/Realm/RLMRealm_Private.h
@@ -20,7 +20,7 @@
 
 @class RLMFastEnumerator;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability)
 
 // Disable syncing files to disk. Cannot be re-enabled. Use only for tests.
 FOUNDATION_EXTERN void RLMDisableSyncToDisk(void);
@@ -62,4 +62,4 @@ BOOL RLMIsRealmCachedAtPath(NSString *path);
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability)

--- a/Realm/RLMResults.h
+++ b/Realm/RLMResults.h
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMCollection.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMObject;
 
@@ -564,4 +564,4 @@ __attribute__((warn_unused_result));
 @interface RLMLinkingObjects<RLMObjectType: RLMObject *> : RLMResults
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMResults_Private.h
+++ b/Realm/RLMResults_Private.h
@@ -20,7 +20,7 @@
 
 @class RLMObjectSchema;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability)
 
 @interface RLMResults ()
 @property (nonatomic, readonly, getter=isAttached) BOOL attached;
@@ -30,4 +30,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability)

--- a/Realm/RLMResults_Private.hpp
+++ b/Realm/RLMResults_Private.hpp
@@ -22,7 +22,7 @@
 
 class RLMClassInfo;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface RLMResults () {
 @public
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (RLMClassInfo *)objectInfo;
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)
 
 // Utility functions
 

--- a/Realm/RLMSchema.h
+++ b/Realm/RLMSchema.h
@@ -16,9 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMObjectSchema;
 
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  Schemas map to collections of tables in the core database.
  */
+RLM_SWIFT_SENDABLE
 @interface RLMSchema : NSObject<NSCopying>
 
 #pragma mark - Properties
@@ -74,4 +75,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSchema_Private.h
+++ b/Realm/RLMSchema_Private.h
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMSchema.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability)
 
 @class RLMRealm;
 
@@ -55,4 +55,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability)

--- a/Realm/RLMSectionedResults.h
+++ b/Realm/RLMSectionedResults.h
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMCollection.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @protocol RLMValue;
 @class RLMResults<RLMObjectType>;
@@ -918,4 +918,4 @@ NS_ASSUME_NONNULL_BEGIN
                                          queue:(nullable dispatch_queue_t)queue __attribute__((warn_unused_result));
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSectionedResults_Private.hpp
+++ b/Realm/RLMSectionedResults_Private.hpp
@@ -24,7 +24,7 @@
 
 @protocol RLMValue;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface RLMSectionedResultsChange ()
 - (instancetype)initWithChanges:(realm::SectionedResultsChangeSet)indices;
@@ -69,4 +69,4 @@ NSUInteger RLMFastEnumerate(NSFastEnumerationState *state,
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSet.h
+++ b/Realm/RLMSet.h
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMCollection.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMObject, RLMResults<RLMObjectType>;
 
@@ -532,4 +532,4 @@ __attribute__((warn_unused_result));
 - (instancetype)initWithObjectClassName:(NSString *)objectClassName;
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSet_Private.h
+++ b/Realm/RLMSet_Private.h
@@ -21,7 +21,7 @@
 
 @class RLMObjectBase, RLMProperty;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface RLMSet ()
 - (instancetype)initWithObjectClassName:(NSString *)objectClassName;
@@ -40,4 +40,4 @@ void RLMSetValidateMatchingObjectType(RLMSet *set, id value);
 - (instancetype)initWithParent:(RLMObjectBase *)parentObject property:(RLMProperty *)property;
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSwiftCollectionBase.h
+++ b/Realm/RLMSwiftCollectionBase.h
@@ -20,7 +20,7 @@
 
 @class RLMObjectBase, RLMResults, RLMProperty, RLMLinkingObjects;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface RLMSwiftCollectionBase : NSProxy <NSFastEnumeration>
 @property (nonatomic, strong) id<RLMCollection> _rlmCollection;
@@ -43,4 +43,4 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL _isLegacyProperty;
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSwiftProperty.h
+++ b/Realm/RLMSwiftProperty.h
@@ -25,7 +25,7 @@
 extern "C" {
 #endif
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability)
 
 #define REALM_FOR_EACH_SWIFT_PRIMITIVE_TYPE(macro) \
     macro(bool, Bool, bool) \
@@ -64,7 +64,7 @@ RLMArray *_Nonnull RLMGetSwiftPropertyArray(RLMObjectBase *obj, uint16_t);
 RLMSet *_Nonnull RLMGetSwiftPropertySet(RLMObjectBase *obj, uint16_t);
 RLMDictionary *_Nonnull RLMGetSwiftPropertyMap(RLMObjectBase *obj, uint16_t);
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability)
 
 #ifdef __cplusplus
 } // extern "C"

--- a/Realm/RLMSwiftSupport.h
+++ b/Realm/RLMSwiftSupport.h
@@ -16,10 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
 #import <Realm/RLMCollection.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface RLMSwiftSupport : NSObject
 
@@ -28,4 +27,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSwiftValueStorage.h
+++ b/Realm/RLMSwiftValueStorage.h
@@ -16,10 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
 #import <Realm/RLMConstants.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMObjectBase, RLMProperty;
 
@@ -51,4 +50,4 @@ FOUNDATION_EXTERN void RLMInitializeUnmanagedSwiftValueStorage(RLMSwiftValueStor
 /// objects that use the legacy property declaration syntax.
 FOUNDATION_EXTERN NSString *RLMSwiftValueStorageGetPropertyName(RLMSwiftValueStorage *);
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSyncConfiguration.h
+++ b/Realm/RLMSyncConfiguration.h
@@ -26,7 +26,7 @@
 @class RLMUser;
 @protocol RLMBSON;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /**  Determines file behavior during a client reset.
 
@@ -191,4 +191,4 @@ typedef void(^RLMClientResetAfterBlock)(RLMRealm * _Nonnull beforeFrozen, RLMRea
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSyncConfiguration_Private.h
+++ b/Realm/RLMSyncConfiguration_Private.h
@@ -20,7 +20,7 @@
 
 #import <Realm/RLMConstants.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 typedef RLM_CLOSED_ENUM(NSUInteger, RLMSyncStopPolicy) {
     RLMSyncStopPolicyImmediately,
@@ -45,4 +45,4 @@ typedef RLM_CLOSED_ENUM(NSUInteger, RLMSyncStopPolicy) {
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSyncConfiguration_Private.hpp
+++ b/Realm/RLMSyncConfiguration_Private.hpp
@@ -28,7 +28,7 @@ struct SyncError;
 using SyncSessionErrorHandler = void(std::shared_ptr<SyncSession>, SyncError);
 }
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface RLMSyncConfiguration ()
 
@@ -45,4 +45,4 @@ void RLMSetConfigInfoForClientResetCallbacks(realm::SyncConfig& syncConfig, RLMR
 
 NSError *_Nullable RLMTranslateSyncError(realm::SyncError);
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSyncManager.h
+++ b/Realm/RLMSyncManager.h
@@ -16,13 +16,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
-
 #import <Realm/RLMSyncUtil.h>
 
 @class RLMSyncSession, RLMSyncTimeoutOptions, RLMAppConfiguration;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /// An enum representing different levels of sync-related logging that can be configured.
 typedef RLM_CLOSED_ENUM(NSUInteger, RLMSyncLogLevel) {
@@ -219,4 +217,4 @@ typedef void(^RLMSyncErrorReportingBlock)(NSError *, RLMSyncSession * _Nullable)
 @property (nonatomic, readonly) RLMAppConfiguration *appConfiguration;
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSyncManager_Private.hpp
+++ b/Realm/RLMSyncManager_Private.hpp
@@ -38,7 +38,7 @@ class Logger;
 // All private API methods are threadsafe and synchronized, unless denoted otherwise. Since they are expected to be
 // called very infrequently, this should pose no issues.
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface RLMSyncManager ()
 
@@ -58,4 +58,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 std::shared_ptr<realm::util::Logger> RLMWrapLogFunction(RLMSyncLogFunction);
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSyncSession.h
+++ b/Realm/RLMSyncSession.h
@@ -16,8 +16,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
-
 #import <Realm/RLMRealm.h>
 
 /**
@@ -101,7 +99,7 @@ typedef NS_ENUM(NSUInteger, RLMSyncProgressMode) {
  */
 typedef void(^RLMProgressNotificationBlock)(NSUInteger transferredBytes, NSUInteger transferrableBytes);
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /**
  A token object corresponding to a progress notification block on a session object.
@@ -272,4 +270,4 @@ NS_REFINED_FOR_SWIFT;
 - (void)cancel;
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSyncSession_Private.hpp
+++ b/Realm/RLMSyncSession_Private.hpp
@@ -26,7 +26,7 @@ class AsyncOpenTask;
 class SyncSession;
 }
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface RLMSyncSession () {
 @public     // So it's visible to tests
@@ -53,4 +53,4 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) std::shared_ptr<realm::AsyncOpenTask> task;
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSyncSubscription.h
+++ b/Realm/RLMSyncSubscription.h
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 
 @class RLMObjectId;
 
@@ -44,7 +44,7 @@ typedef NS_ENUM(NSUInteger, RLMSyncSubscriptionState) {
     RLMSyncSubscriptionStateSuperseded
 };
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /**
  `RLMSyncSubscription` is  used to define a Flexible Sync subscription obtained from querying a
@@ -337,4 +337,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSyncSubscription_Private.h
+++ b/Realm/RLMSyncSubscription_Private.h
@@ -20,7 +20,7 @@
 
 #import <Realm/RLMRealm.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 #pragma mark - Subscription
 
@@ -67,4 +67,4 @@ NSUInteger RLMFastEnumerate(NSFastEnumerationState *state,
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSyncSubscription_Private.hpp
+++ b/Realm/RLMSyncSubscription_Private.hpp
@@ -23,7 +23,7 @@ class Subscription;
 class SubscriptionSet;
 }
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface RLMSyncSubscription ()
 
@@ -37,4 +37,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSyncUtil.h
+++ b/Realm/RLMSyncUtil.h
@@ -21,7 +21,7 @@
 /// A token originating from Atlas App Services.
 typedef NSString* RLMServerToken;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /// A user info key for use with `RLMSyncErrorClientResetError`.
 extern NSString *const kRLMSyncPathOfRealmBackupCopyKey;
@@ -232,4 +232,4 @@ typedef RLM_ERROR_ENUM(NSInteger, RLMAppError, RLMAppErrorDomain) {
     RLMAppErrorMongoDBError,
 };
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMSyncUtil_Private.h
+++ b/Realm/RLMSyncUtil_Private.h
@@ -29,7 +29,7 @@ typedef void(^RLMSyncBasicErrorReportingBlock)(NSError * _Nullable);
 
 typedef NSString* RLMServerPath;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability)
 
 extern NSString *const kRLMSyncErrorStatusCodeKey;
 extern NSString *const kRLMSyncUnderlyingErrorKey;
@@ -38,4 +38,4 @@ extern NSString *const kRLMSyncUnderlyingErrorKey;
 - (instancetype)init __attribute__((unavailable("This type cannot be created directly"))); \
 + (instancetype)new __attribute__((unavailable("This type cannot be created directly")));
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability)

--- a/Realm/RLMThreadSafeReference.h
+++ b/Realm/RLMThreadSafeReference.h
@@ -16,11 +16,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 
 @class RLMRealm;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /**
  Objects of types which conform to `RLMThreadConfined` can be managed by a Realm, which will make
@@ -67,6 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
  @see `RLMThreadConfined`
  @see `-[RLMRealm resolveThreadSafeReference:]`
  */
+RLM_SWIFT_SENDABLE
 @interface RLMThreadSafeReference<__covariant Confined : id<RLMThreadConfined>> : NSObject
 
 /**
@@ -103,4 +104,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMThreadSafeReference_Private.hpp
+++ b/Realm/RLMThreadSafeReference_Private.hpp
@@ -20,7 +20,7 @@
 
 #import <realm/object-store/thread_safe_reference.hpp>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @protocol RLMThreadConfined_Private <NSObject>
 
@@ -42,4 +42,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMUUID_Private.hpp
+++ b/Realm/RLMUUID_Private.hpp
@@ -22,7 +22,7 @@ namespace realm {
 class UUID;
 }
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface NSUUID (RLMUUIDSupport) <RLMUUID>
 
@@ -31,4 +31,4 @@ NS_ASSUME_NONNULL_BEGIN
 - (realm::UUID)rlm_uuidValue;
 
 @end
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMUpdateResult.h
+++ b/Realm/RLMUpdateResult.h
@@ -16,9 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class RLMObjectId;
 @protocol RLMBSON;
@@ -41,4 +41,4 @@ __attribute__((deprecated("Use documentId instead, which support all BSON types"
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMUpdateResult_Private.hpp
+++ b/Realm/RLMUpdateResult_Private.hpp
@@ -20,8 +20,8 @@
 
 #import <realm/object-store/sync/mongo_collection.hpp>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 @interface RLMUpdateResult ()
 - (instancetype)initWithUpdateResult:(realm::app::MongoCollection::UpdateResult)UpdateResult;
 @end
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMUser.h
+++ b/Realm/RLMUser.h
@@ -16,8 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
-
+#import <Realm/RLMConstants.h>
 #import <Realm/RLMCredentials.h>
 #import <Realm/RLMRealmConfiguration.h>
 #import <Realm/RLMSyncConfiguration.h>
@@ -49,7 +48,7 @@ typedef void(^RLMUserCustomDataBlock)(NSDictionary * _Nullable, NSError * _Nulla
 /// A block type for returning from function calls.
 typedef void(^RLMCallFunctionCompletionBlock)(id<RLMBSON> _Nullable, NSError * _Nullable);
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /**
  A `RLMUser` instance represents a single Realm App user account.
@@ -431,4 +430,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMUserAPIKey.h
+++ b/Realm/RLMUserAPIKey.h
@@ -19,7 +19,7 @@
 #import <Foundation/Foundation.h>
 #import <Realm/RLMObjectId.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /// UserAPIKey model for APIKeys recevied from the server.
 @interface RLMUserAPIKey : NSObject
@@ -39,4 +39,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMUser_Private.h
+++ b/Realm/RLMUser_Private.h
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMUser.h>
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /// Observer block for user notifications.
 typedef void(^RLMUserNotificationBlock)(RLMUser *);
@@ -44,4 +44,4 @@ typedef void(^RLMUserNotificationBlock)(RLMUser *);
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMUser_Private.hpp
+++ b/Realm/RLMUser_Private.hpp
@@ -26,7 +26,7 @@
 
 @class RLMSyncConfiguration, RLMSyncSessionRefreshHandle, RLMApp;
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 class CocoaSyncUserContext : public realm::SyncUserContext {
 public:
@@ -57,4 +57,4 @@ private:
 - (instancetype)initWithUserProfile:(realm::SyncUserProfile)userProfile;
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMValue.h
+++ b/Realm/RLMValue.h
@@ -16,8 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
-
+#import <Realm/RLMConstants.h>
 #import <Realm/RLMDecimal128.h>
 #import <Realm/RLMObject.h>
 #import <Realm/RLMObjectBase.h>

--- a/Realm/TestUtils/include/RLMTestCase.h
+++ b/Realm/TestUtils/include/RLMTestCase.h
@@ -20,7 +20,7 @@
 #import "RLMAssertions.h"
 #import "RLMTestObjects.h"
 
-NS_ASSUME_NONNULL_BEGIN
+RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,4 +60,4 @@ NSData *RLMGenerateKey(void);
 
 @end
 
-NS_ASSUME_NONNULL_END
+RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/RealmSwift/Impl/SchemaDiscovery.swift
+++ b/RealmSwift/Impl/SchemaDiscovery.swift
@@ -191,7 +191,7 @@ private func getProperties(_ cls: RLMObjectBase.Type) -> [RLMProperty] {
 
 internal class ObjectUtil {
     private static let runOnce: Void = {
-        RLMSwiftBridgeValue = { (value: Any) -> Any? in
+        RLMSetSwiftBridgeCallback { (value: Any) -> Any? in
             // `as AnyObject` required on iOS <= 13; it will compile but silently
             // fail to cast otherwise
             if let value = value as AnyObject as? _ObjcBridgeable {


### PR DESCRIPTION
This is mostly just a giant mess of boilerplate changes. NS_HEADER_AUDIT_BEGIN/NS_HEADER_AUDIT_END is a generalization of NS_ASSUME_NONNULL_BEGIN/NS_ASSUME_NONNULL_END to enable also marking things as audited for sendability, which changes the rules for warning generation for unannotated things a bit. It was added in Xcode 14, so we need to use our own define which falls back to the old thing with Xcode 13.

Types which are thread-safe are marked with NS_SWIFT_SENDABLE, which is equivalent to marking them as Sendable in Swift. I had to fiddle with RLMSetSwiftBridgeCallback as assigning to a global variable pretty reasonably produces concurrency warnings.