### PR TITLE
Remove warnings @AutoOpen @AsyncOpen and @ObservedResults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ x.y.z Release notes (yyyy-MM-dd)
 * Fix `@AutoOpen` not returning a realm for a flexible sync configuration, 
   when there is no internet connection. 
   ([#7986](https://github.com/realm/realm-swift/issues/7986), since v10.27.0)
+* Fix "Publishing changes from within view updates is not allowed" warnings
+  when using `@ObservedResults` or `@ObservedSectionedResults`. 
+  ([#7908](https://github.com/realm/realm-swift/issues/7908), since XCode 14 Beta 5).
+* Fix "Publishing changes from within view updates is not allowed" warnings
+  when using `@AutoOpen` or `@AsyncOpen`.
+  ([#7908](https://github.com/realm/realm-swift/issues/7908), since XCode 14 Beta 5).
+* Defer `Realm.asyncOpen` execution on `@AsyncOpen` and `@AutoOpen` property wrappers, 
+  until all the environment values are set. This will guarantee the configuration and partition value
+  are set set before opening the realm. ([#7931](https://github.com/realm/realm-swift/issues/7931), since v10.12.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/ObjectServerTests/SwiftUIServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftUIServerTests.swift
@@ -51,6 +51,7 @@ class SwiftUIServerTests: SwiftSyncTestCase {
                                   partitionValue: partitionValue,
                                   configuration: configuration,
                                   timeout: timeout)
+        _ = asyncOpen.wrappedValue // Retrieving the wrappedValue to simulate a SwiftUI environment where this is called when initialising the view.
         asyncOpen.projectedValue
             .sink(receiveValue: handler)
             .store(in: &cancellables)
@@ -286,6 +287,7 @@ class SwiftUIServerTests: SwiftSyncTestCase {
                                 partitionValue: partitionValue,
                                 configuration: configuration,
                                 timeout: timeout)
+        _ = autoOpen.wrappedValue // Retrieving the wrappedValue to simulate a SwiftUI environment where this is called when initialising the view.
         autoOpen.projectedValue
             .sink(receiveValue: handler)
             .store(in: &cancellables)
@@ -399,6 +401,8 @@ class SwiftUIServerTests: SwiftSyncTestCase {
         proxy.dropConnections = true
         let ex = expectation(description: "download-realm-flexible-auto-open-no-connection")
         let autoOpen = AutoOpen(appId: flexibleSyncAppId, configuration: configuration, timeout: 1000)
+
+        _ = autoOpen.wrappedValue // Retrieving the wrappedValue to simulate a SwiftUI environment where this is called when initialising the view.
         autoOpen.projectedValue
             .sink { autoOpenState in
                 if case let .open(realm) = autoOpenState {

--- a/Realm/Tests/SwiftUISyncTestHostUITests/SwiftUISyncTestHostUITests.swift
+++ b/Realm/Tests/SwiftUISyncTestHostUITests/SwiftUISyncTestHostUITests.swift
@@ -216,7 +216,7 @@ extension SwiftUISyncTestHostUITests {
     func testObservedSectionedResults() throws {
         // This test ensures that `@ObservedResults` correctly observes both local
         // and sync changes to a collection.
-        let partitionValue = "test"
+        let partitionValue = "test2"
         let email = "realm_tests_do_autoverify\(randomString(7))@\(randomString(7)).com"
         let email2 = "realm_tests_do_autoverify\(randomString(7))@\(randomString(7)).com"
 
@@ -245,7 +245,7 @@ extension SwiftUISyncTestHostUITests {
         // Test show ListView after syncing realm
         let table = application.tables.firstMatch
         XCTAssertTrue(table.waitForExistence(timeout: 6))
-        XCTAssertEqual(table.cells.count, 4)
+        XCTAssertEqual(table.cells.count, 4) // Includes section headers and cells
         XCTAssertEqual(table.staticTexts.count, 4)
 
         loginUser(.second)
@@ -329,6 +329,33 @@ extension SwiftUISyncTestHostUITests {
 
         let waitingUserView = application.staticTexts["waiting_user_view"]
         XCTAssertTrue(waitingUserView.waitForExistence(timeout: 2))
+    }
+
+    func testAsyncOpenWithDeferRealmConfiguration() throws {
+        let email = "realm_tests_do_autoverify\(randomString(7))@\(randomString(7)).com"
+        let user = try populateForEmail(email, n: 20)
+
+        application.launchEnvironment["email1"] = email
+        application.launchEnvironment["async_view_type"] = "async_open_custom_configuration"
+        application.launchEnvironment["app_id"] = appId
+        application.launchEnvironment["partition_value"] = user.id
+        application.launch()
+
+        asyncOpen()
+
+        // Test show ListView after syncing realm
+        let table = application.tables.firstMatch
+        XCTAssertTrue(table.waitForExistence(timeout: 6))
+        XCTAssertEqual(table.cells.count, 20)
+
+        // Check if there is more than one realm when using environment values.
+        let enumerator = FileManager.default.enumerator(at: clientDataRoot(), includingPropertiesForKeys: [.nameKey, .isDirectoryKey])
+        var counter = 0
+        while let element = enumerator?.nextObject() as? URL {
+            if element.path.hasSuffix(".realm") { counter += 1 }
+        }
+        // Synced Realm and Sync Metadata
+        XCTAssertEqual(counter, 2)
     }
 }
 
@@ -445,6 +472,33 @@ extension SwiftUISyncTestHostUITests {
 
         let waitingUserView = application.staticTexts["waiting_user_view"]
         XCTAssertTrue(waitingUserView.waitForExistence(timeout: 2))
+    }
+
+    func testAutoOpenWithDeferRealmConfiguration() throws {
+        let email = "realm_tests_do_autoverify\(randomString(7))@\(randomString(7)).com"
+        let user = try populateForEmail(email, n: 20)
+
+        application.launchEnvironment["email1"] = email
+        application.launchEnvironment["async_view_type"] = "auto_open_custom_configuration"
+        application.launchEnvironment["app_id"] = appId
+        application.launchEnvironment["partition_value"] = user.id
+        application.launch()
+
+        asyncOpen()
+
+        // Test show ListView after syncing realm
+        let table = application.tables.firstMatch
+        XCTAssertTrue(table.waitForExistence(timeout: 6))
+        XCTAssertEqual(table.cells.count, 20)
+
+        // Check if there is more than one realm when using environment values.
+        let enumerator = FileManager.default.enumerator(at: clientDataRoot(), includingPropertiesForKeys: [.nameKey, .isDirectoryKey])
+        var counter = 0
+        while let element = enumerator?.nextObject() as? URL {
+            if element.path.hasSuffix(".realm") { counter += 1 }
+        }
+        // Synced Realm and Sync Metadata
+        XCTAssertEqual(counter, 2)
     }
 }
 

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -1488,24 +1488,24 @@ private class ObservableAsyncOpenStorage: ObservableObject {
         // we observe the changes in the app state to check for user changes,
         // we store an internal state, so we could react to those changes (user login, user change, logout).
         app.objectWillChange.sink { [weak self] app in
-            switch self?.appState {
+            guard let self = self else { return }
+            switch self.appState {
             case .loggedIn(let user):
                 if let newUser = app.currentUser,
                     user != newUser {
-                    self?.appState = .loggedIn(newUser)
-                    self?.asyncOpenState = .connecting
-                    self?.asyncOpenForUser(user)
+                    self.appState = .loggedIn(newUser)
+                    self.asyncOpenState = .connecting
+                    self.asyncOpenForUser(user)
                 } else if app.currentUser == nil {
-                    self?.asyncOpenState = .waitingForUser
-                    self?.appState = .loggedOut
+                    self.asyncOpenState = .waitingForUser
+                    self.appState = .loggedOut
                 }
             case .loggedOut:
                 if let user = app.currentUser {
-                    self?.appState = .loggedIn(user)
-                    self?.asyncOpenState = .connecting
-                    self?.asyncOpenForUser(user)
+                    self.appState = .loggedIn(user)
+                    self.asyncOpenState = .connecting
+                    self.asyncOpenForUser(user)
                 }
-            default: break // if appState is nil
             }
         }.store(in: &appCancellable)
     }

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -1487,24 +1487,25 @@ private class ObservableAsyncOpenStorage: ObservableObject {
 
         // we observe the changes in the app state to check for user changes,
         // we store an internal state, so we could react to those changes (user login, user change, logout).
-        app.objectWillChange.sink { app in
-            switch self.appState {
+        app.objectWillChange.sink { [weak self] app in
+            switch self?.appState {
             case .loggedIn(let user):
                 if let newUser = app.currentUser,
                     user != newUser {
-                    self.appState = .loggedIn(newUser)
-                    self.asyncOpenState = .connecting
-                    self.asyncOpenForUser(user)
+                    self?.appState = .loggedIn(newUser)
+                    self?.asyncOpenState = .connecting
+                    self?.asyncOpenForUser(user)
                 } else if app.currentUser == nil {
-                    self.asyncOpenState = .waitingForUser
-                    self.appState = .loggedOut
+                    self?.asyncOpenState = .waitingForUser
+                    self?.appState = .loggedOut
                 }
             case .loggedOut:
                 if let user = app.currentUser {
-                    self.appState = .loggedIn(user)
-                    self.asyncOpenState = .connecting
-                    self.asyncOpenForUser(user)
+                    self?.appState = .loggedIn(user)
+                    self?.asyncOpenState = .connecting
+                    self?.asyncOpenForUser(user)
                 }
+            default: break // if appState is nil
             }
         }.store(in: &appCancellable)
     }


### PR DESCRIPTION
Removed warning from @AutoOpen @AsyncOpen and @ObservedResults and @ObservedSectionResults
While working on removing the warning, I fixed an issue, where Realm.asyncOpen was been called twice when used in `@AutoOpen` and `@AsyncOpen`once when initialised and a second time if we injected a environment value, now this is done one when the wrapped value is called on the view, this is a similar approach to what we do in `@ObservedResults`.
Also, I added a note to `@AutoOpen` and `@AsyncOpen`, which encourage users to inject configurations which comes from a user instead of creating a RealmConfiguration and inject it to the property wrapper.