### PR TITLE
Allow setting `cancelAsyncOpenOnNonFatalErrors` from Swift's `SyncConfiguration`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ x.y.z Release notes (yyyy-MM-dd)
 ### Enhancements
 * Improve performance of creating Projection objects and of change
   notifications on projections ([PR #8050](https://github.com/realm/realm-swift/pull/8050)).
-* Allow setting `cancelAsyncOpenOnNonFatalErrors` from Swift's `SyncConfiguration`.
+* Allow initialising any sync configuration with `cancelAsyncOpenOnNonFatalErrors`.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ x.y.z Release notes (yyyy-MM-dd)
 ### Enhancements
 * Improve performance of creating Projection objects and of change
   notifications on projections ([PR #8050](https://github.com/realm/realm-swift/pull/8050)).
+* Allow setting `cancelAsyncOpenOnNonFatalErrors` from Swift's `SyncConfiguration`.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)

--- a/Realm/ObjectServerTests/SwiftFlexibleSyncServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftFlexibleSyncServerTests.swift
@@ -998,23 +998,20 @@ class SwiftFlexibleSyncServerTests: SwiftSyncTestCase {
         let proxy = TimeoutProxyServer(port: 5678, targetPort: 9090)
         try proxy.start()
 
-        let appId = try RealmServer.shared.createApp()
         let appConfig = AppConfiguration(baseURL: "http://localhost:5678",
                                          transport: AsyncOpenConnectionTimeoutTransport(),
                                          localAppName: nil, localAppVersion: nil)
-        let app = App(id: appId, configuration: appConfig)
+        let app = App(id: flexibleSyncAppId, configuration: appConfig)
 
         let syncTimeoutOptions = SyncTimeoutOptions()
-        syncTimeoutOptions.connectTimeout = 1000
+        syncTimeoutOptions.connectTimeout = 2000
         app.syncManager.timeoutOptions = syncTimeoutOptions
 
         let user = try logInUser(for: basicCredentials(app: app), app: app)
-        let config = user.flexibleSyncConfiguration()
-        var syncConfiguration = config.syncConfiguration
-        syncConfiguration?.cancelAsyncOpenOnNonFatalErrors = true
+        let config = user.flexibleSyncConfiguration(cancelAsyncOpenOnNonFatalErrors: true)
 
         autoreleasepool {
-            proxy.delay = 2.0
+            proxy.delay = 3.0
             let ex = expectation(description: "async open")
             Realm.asyncOpen(configuration: config) { result in
                 guard case .failure(let error) = result else {

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -461,7 +461,11 @@ public enum ClientResetMode {
      and the async open will be cancelled.
      */
     public var cancelAsyncOpenOnNonFatalErrors: Bool {
-        config.cancelAsyncOpenOnNonFatalErrors
+        get {
+            return config.cancelAsyncOpenOnNonFatalErrors
+        } set {
+            config.cancelAsyncOpenOnNonFatalErrors = newValue
+        }
     }
 
     internal let config: RLMSyncConfiguration


### PR DESCRIPTION
Allow setting `cancelAsyncOpenOnNonFatalErrors` from Swift's `SyncConfiguration`, similar to what we already do in the Objective-C API `RLMSyncConfiguration. 
There is already a initialiser which allow this for a partition based configuration, but changing `cancelAsyncOpenOnNonFatalErrors` is not allowed for flexible sync configuration or when inserting a client reset into a user's configuration, and adding a initialiser for each of those cases seems like a too much.
This is added by a user request https://github.com/realm/realm-swift/issues/8071