### PR TITLE
`@AutoOpen` not returning a realm for a flexible sync configuration, when there was not internet connection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ x.y.z Release notes (yyyy-MM-dd)
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
 * Object change notifications on projections only included the first projected
   property for each source property ([PR #8050](https://github.com/realm/realm-swift/pull/8050), since v10.21.0).
+* Fix `@AutoOpen` not returning a realm for a flexible sync configuration, 
+  when there is no internet connection. 
+  ([#7986](https://github.com/realm/realm-swift/issues/7986), since v10.27.0)
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ x.y.z Release notes (yyyy-MM-dd)
 * Improve performance of creating Projection objects and of change
   notifications on projections ([PR #8050](https://github.com/realm/realm-swift/pull/8050)).
 * Allow initialising any sync configuration with `cancelAsyncOpenOnNonFatalErrors`.
-* Allow setting `cancelAsyncOpenOnNonFatalErrors` from Swift's `SyncConfiguration`.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * Improve performance of creating Projection objects and of change
   notifications on projections ([PR #8050](https://github.com/realm/realm-swift/pull/8050)).
 * Allow initialising any sync configuration with `cancelAsyncOpenOnNonFatalErrors`.
+* Allow setting `cancelAsyncOpenOnNonFatalErrors` from Swift's `SyncConfiguration`.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)

--- a/Realm/ObjectServerTests/SwiftUIServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftUIServerTests.swift
@@ -287,9 +287,7 @@ class SwiftUIServerTests: SwiftSyncTestCase {
                                 configuration: configuration,
                                 timeout: timeout)
         autoOpen.projectedValue
-            .sink { autoOpenState in
-                handler(autoOpenState)
-            }
+            .sink(receiveValue: handler)
             .store(in: &cancellables)
         waitForExpectations(timeout: 10.0)
         autoOpen.cancel()
@@ -373,6 +371,7 @@ class SwiftUIServerTests: SwiftSyncTestCase {
     func testAutoOpenOpenForFlexibleSyncConfigWithoutInternetConnection() throws {
         let proxy = TimeoutProxyServer(port: 5678, targetPort: 9090)
         try proxy.start()
+
         let appConfig = AppConfiguration(baseURL: "http://localhost:5678",
                                          transport: AsyncOpenConnectionTimeoutTransport(),
                                          localAppName: nil,
@@ -392,11 +391,14 @@ class SwiftUIServerTests: SwiftSyncTestCase {
         App.resetAppCache()
 
         let app = App(id: flexibleSyncAppId, configuration: appConfig)
+
         let user = try logInUser(for: basicCredentials(app: app), app: app)
-        
+        var configuration = user.flexibleSyncConfiguration()
+        configuration.objectTypes = [SwiftPerson.self]
+
         proxy.dropConnections = true
-        let ex = expectation(description: "download-realm-auto-open-no-connection")
-        let autoOpen = AutoOpen(appId: flexibleSyncAppId, timeout: 1000)
+        let ex = expectation(description: "download-realm-flexible-auto-open-no-connection")
+        let autoOpen = AutoOpen(appId: flexibleSyncAppId, configuration: configuration, timeout: 1000)
         autoOpen.projectedValue
             .sink { autoOpenState in
                 if case let .open(realm) = autoOpenState {
@@ -405,7 +407,7 @@ class SwiftUIServerTests: SwiftSyncTestCase {
                 }
             }
             .store(in: &cancellables)
-        
+
         waitForExpectations(timeout: 10.0)
         autoOpen.cancel()
 

--- a/Realm/ObjectServerTests/SwiftUIServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftUIServerTests.swift
@@ -369,6 +369,49 @@ class SwiftUIServerTests: SwiftSyncTestCase {
         proxy.stop()
     }
 
+    // In case of no internet connection AutoOpen should return an opened Realm, offline-first approach
+    func testAutoOpenOpenForFlexibleSyncConfigWithoutInternetConnection() throws {
+        let proxy = TimeoutProxyServer(port: 5678, targetPort: 9090)
+        try proxy.start()
+        let appConfig = AppConfiguration(baseURL: "http://localhost:5678",
+                                         transport: AsyncOpenConnectionTimeoutTransport(),
+                                         localAppName: nil,
+                                         localAppVersion: nil)
+
+        try autoreleasepool {
+            try populateFlexibleSyncData { realm in
+                for i in 1...10 {
+                    // Using firstname to query only objects from this test
+                    let person = SwiftPerson(firstName: "\(#function)",
+                                             lastName: "lastname_\(i)",
+                                             age: i)
+                    realm.add(person)
+                }
+            }
+        }
+        App.resetAppCache()
+
+        let app = App(id: flexibleSyncAppId, configuration: appConfig)
+        let user = try logInUser(for: basicCredentials(app: app), app: app)
+        
+        proxy.dropConnections = true
+        let ex = expectation(description: "download-realm-auto-open-no-connection")
+        let autoOpen = AutoOpen(appId: flexibleSyncAppId, timeout: 1000)
+        autoOpen.projectedValue
+            .sink { autoOpenState in
+                if case let .open(realm) = autoOpenState {
+                    XCTAssertTrue(realm.isEmpty) // should not have downloaded anything
+                    ex.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+        
+        waitForExpectations(timeout: 10.0)
+        autoOpen.cancel()
+
+        proxy.stop()
+    }
+
     func testAutoOpenProgressNotification() throws {
         try autoreleasepool {
             let user = try logInUser(for: basicCredentials())

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -1508,7 +1508,7 @@ private class ObservableAsyncOpenStorage: ObservableObject {
         if let partitionValue = partitionValue {
             config = user.configuration(partitionValue: partitionValue, cancelAsyncOpenOnNonFatalErrors: true)
         } else {
-            config = user.flexibleSyncConfiguration()
+            config = user.flexibleSyncConfiguration(cancelAsyncOpenOnNonFatalErrors: true)
         }
 
         // Use the user configuration by default or set configuration with the current user `syncConfiguration`'s.

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -461,11 +461,7 @@ public enum ClientResetMode {
      and the async open will be cancelled.
      */
     public var cancelAsyncOpenOnNonFatalErrors: Bool {
-        get {
-            return config.cancelAsyncOpenOnNonFatalErrors
-        } set {
-            config.cancelAsyncOpenOnNonFatalErrors = newValue
-        }
+        config.cancelAsyncOpenOnNonFatalErrors
     }
 
     internal let config: RLMSyncConfiguration

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -461,7 +461,11 @@ public enum ClientResetMode {
      and the async open will be cancelled.
      */
     public var cancelAsyncOpenOnNonFatalErrors: Bool {
-        config.cancelAsyncOpenOnNonFatalErrors
+        get {
+            return config.cancelAsyncOpenOnNonFatalErrors
+        } set {
+            config.cancelAsyncOpenOnNonFatalErrors = newValue
+        }
     }
 
     internal let config: RLMSyncConfiguration


### PR DESCRIPTION
Fix `@AutoOpen` not returning a realm for a flexible sync configuration, when there was not internet connection.