### PR TITLE
Fix issue with ObservedResults and searchable

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -4,40 +4,40 @@
 # This is a generated file produced by scripts/pr-ci-matrix.rb.
 
 xcode_version:
-# - 13.4.1
-# - 14.0.1
-# - 14.1
+ - 13.4.1
+ - 14.0.1
+ - 14.1
  - 14.2
 target:
-# - docs
-# - swiftlint
-# - osx
-# - osx-encryption
-# - osx-object-server
-# - swiftpm
-# - swiftpm-debug
-# - swiftpm-address
-# - swiftpm-thread
-# - swiftpm-ios
-# - ios-static
-# - ios-dynamic
-# - watchos
-# - tvos
-# - osx-swift
-# - ios-swift
-# - tvos-swift
-# - osx-swift-evolution
-# - ios-swift-evolution
-# - tvos-swift-evolution
-# - catalyst
-# - catalyst-swift
-# - xcframework
-# - cocoapods-osx
-# - cocoapods-ios
-# - cocoapods-ios-dynamic
-# - cocoapods-watchos
+ - docs
+ - swiftlint
+ - osx
+ - osx-encryption
+ - osx-object-server
+ - swiftpm
+ - swiftpm-debug
+ - swiftpm-address
+ - swiftpm-thread
+ - swiftpm-ios
+ - ios-static
+ - ios-dynamic
+ - watchos
+ - tvos
+ - osx-swift
+ - ios-swift
+ - tvos-swift
+ - osx-swift-evolution
+ - ios-swift-evolution
+ - tvos-swift-evolution
+ - catalyst
+ - catalyst-swift
+ - xcframework
+ - cocoapods-osx
+ - cocoapods-ios
+ - cocoapods-ios-dynamic
+ - cocoapods-watchos
  - swiftui-ios
-# - swiftui-server-osx
+ - swiftui-server-osx
 configuration:
  - N/A
 

--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -4,40 +4,40 @@
 # This is a generated file produced by scripts/pr-ci-matrix.rb.
 
 xcode_version:
- - 13.4.1
- - 14.0.1
- - 14.1
+# - 13.4.1
+# - 14.0.1
+# - 14.1
  - 14.2
 target:
- - docs
- - swiftlint
- - osx
- - osx-encryption
- - osx-object-server
- - swiftpm
- - swiftpm-debug
- - swiftpm-address
- - swiftpm-thread
- - swiftpm-ios
- - ios-static
- - ios-dynamic
- - watchos
- - tvos
- - osx-swift
- - ios-swift
- - tvos-swift
- - osx-swift-evolution
- - ios-swift-evolution
- - tvos-swift-evolution
- - catalyst
- - catalyst-swift
- - xcframework
- - cocoapods-osx
- - cocoapods-ios
- - cocoapods-ios-dynamic
- - cocoapods-watchos
+# - docs
+# - swiftlint
+# - osx
+# - osx-encryption
+# - osx-object-server
+# - swiftpm
+# - swiftpm-debug
+# - swiftpm-address
+# - swiftpm-thread
+# - swiftpm-ios
+# - ios-static
+# - ios-dynamic
+# - watchos
+# - tvos
+# - osx-swift
+# - ios-swift
+# - tvos-swift
+# - osx-swift-evolution
+# - ios-swift-evolution
+# - tvos-swift-evolution
+# - catalyst
+# - catalyst-swift
+# - xcframework
+# - cocoapods-osx
+# - cocoapods-ios
+# - cocoapods-ios-dynamic
+# - cocoapods-watchos
  - swiftui-ios
- - swiftui-server-osx
+# - swiftui-server-osx
 configuration:
  - N/A
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ x.y.z Release notes (yyyy-MM-dd)
 ### Fixed
 * Fix moving `List` items to a higher index in SwiftUI results in wrong destination index
   ([#7956](https://github.com/realm/realm-swift/issues/7956), since v10.6.0).
+* Using the `searchable` view modifier with `@ObservedResults` in iOS 16 would cause the collection observation subscription to cancel. ([#8096](https://github.com/realm/realm-swift/issues/8096), since 10.21.0)
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm.xcodeproj/xcshareddata/xcschemes/SwiftUITestHost.xcscheme
+++ b/Realm.xcodeproj/xcshareddata/xcschemes/SwiftUITestHost.xcscheme
@@ -69,6 +69,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "killall Simulator&#10;defaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false&#10;">
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/Realm/Tests/SwiftUITestHost/SwiftUITestHostApp.swift
+++ b/Realm/Tests/SwiftUITestHost/SwiftUITestHostApp.swift
@@ -28,9 +28,11 @@ struct ReminderFormView: View {
             DatePicker("date", selection: $reminder.date)
             Picker("priority", selection: $reminder.priority, content: {
                 ForEach(Reminder.Priority.allCases) { priority in
-                    Text(priority.description).tag(priority)
+                    Text(priority.description)
+                        .tag(priority)
+                        .accessibilityIdentifier(priority.description)
                 }
-            }).accessibilityIdentifier("picker")
+            }).accessibilityIdentifier("priority_picker")
         }
         .navigationTitle(reminder.title)
     }
@@ -164,16 +166,26 @@ struct Footer: View {
 struct ContentView: View {
     @State var searchFilter: String = ""
 
+    var content: some View {
+        VStack {
+            SearchView(searchFilter: $searchFilter)
+            ReminderListResultsView(searchFilter: $searchFilter)
+            Spacer()
+            Footer()
+        }
+        .navigationBarItems(trailing: EditButton())
+        .navigationTitle("reminders")
+    }
+
     var body: some View {
-        NavigationView {
-            VStack {
-                SearchView(searchFilter: $searchFilter)
-                ReminderListResultsView(searchFilter: $searchFilter)
-                Spacer()
-                Footer()
+        if #available(iOS 16.0, *) {
+            NavigationStack {
+                content
             }
-            .navigationBarItems(trailing: EditButton())
-            .navigationTitle("reminders")
+        } else {
+            NavigationView {
+                content
+            }
         }
     }
 }

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -179,7 +179,7 @@ private final class ObservableStoragePublisher<ObjectType>: Publisher where Obje
     public typealias Failure = Never
 
     var subscribers = [AnySubscriber<Void, Never>]()
-    private let value: ObjectType
+    private var value: ObjectType
     private let keyPaths: [String]?
     private let unwrappedValue: ObjectBase?
 
@@ -199,6 +199,11 @@ private final class ObservableStoragePublisher<ObjectType>: Publisher where Obje
         self.value = value
         self.keyPaths = keyPaths
         self.unwrappedValue = value.rootObject
+    }
+
+    // Refresh the publisher with a managed object.
+    func update(value: ObjectType) {
+        self.value = value
     }
 
     func send() {
@@ -237,6 +242,7 @@ private class ObservableStorage<ObservedType>: ObservableObject where ObservedTy
         willSet {
             if newValue != value {
                 objectWillChange.send()
+                objectWillChange.update(value: newValue)
                 objectWillChange.subscribers.forEach {
                     $0.receive(subscription: ObservationSubscription(token: newValue._observe(keyPaths, $0)))
                 }

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -966,7 +966,9 @@ public class UserPublisher: Publisher {
     /// :nodoc:
     public func receive<S>(subscriber: S) where S: Subscriber, S.Failure == Never, Output == S.Input {
         let token = user.subscribe { _ in
-            _ = subscriber.receive(self.user)
+            DispatchQueue.main.async {
+                _ = subscriber.receive(self.user)
+            }
         }
 
         subscriber.receive(subscription: UserSubscription(user: user, token: token))


### PR DESCRIPTION
Addresses issue where observation subscription is cancelled on initial view refresh.
This PR fixes up the SwiftUITests for iOS 16 too.
Fixes: https://github.com/realm/realm-swift/issues/8096
Fixes: https://github.com/realm/realm-swift/issues/8132