### PR TITLE
Check for schema version before client reset callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ x.y.z Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
-* None.
+* The client reset callbacks no longer attempt to open a realm without an initialized schema ([PR #8125](https://github.com/realm/realm-swift/pull/8125))
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ x.y.z Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
-* The client reset callbacks no longer attempt to open a realm without an initialized schema ([PR #8125](https://github.com/realm/realm-swift/pull/8125))
+* Client reset callbacks no longer attempt to open a realm without an initialized schema ([PR #8125](https://github.com/realm/realm-swift/pull/8125))
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -81,28 +81,6 @@ static NSString *generateRandomString(int num) {
 
 #pragma mark - Authentication and Tokens
 
-- (void)testSetSchemaVersion {
-    RLMRealmConfiguration *configNV = [RLMRealmConfiguration defaultConfiguration];
-    configNV.configRef.schema_version = RLMNotVersioned;
-    @autoreleasepool {
-        [RLMRealm realmWithConfiguration:configNV error:nil];
-    }
-    // This error is thrown when the schema version at url is not versioned.
-    RLMAssertThrowsWithReason([RLMRealm schemaVersionAtURL:configNV.fileURL encryptionKey:nil error:nil], @"Cannot open an uninitialized realm in read-only mode");
-
-    realm::BeforeClientResetWrapper wrapper = {
-        .block = ^(RLMRealm * _Nonnull beforeFrozen) {
-            // If I get called with a not versioned realm the test fails
-        }
-    };
-
-    wrapper.block([RLMRealm realmWithConfiguration:configNV error:nil]);
-    RLMRealm *r = [RLMRealm realmWithConfiguration:configNV error:nil];
-
-    wrapper(r->_realm); // one realm should invoke the block
-    wrapper(r->_realm); // while the other should not invoke the block
-}
-
 - (void)testAnonymousAuthentication {
     RLMUser *syncUser = self.anonymousUser;
     RLMUser *currentUser = [self.app currentUser];

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -1535,7 +1535,7 @@ static NSString *randomEmail() {
 
     // Create a config that's not versioned.
     RLMRealmConfiguration *configUnversioned = [RLMRealmConfiguration defaultConfiguration];
-    configUnversioned.configRef.schema_version = RLMNotVersioned; // Not strictly necessary. Already has no version because the realm's never been opened.
+    configUnversioned.configRef.schema_version = RLMNotVersioned;
     std::shared_ptr<realm::Realm> unversioned = realm::Realm::get_shared_realm(configUnversioned.config);
 
     XCTAssertNotEqual(versioned->schema_version(), RLMNotVersioned);
@@ -1561,7 +1561,7 @@ static NSString *randomEmail() {
 
     // Create a config that's not versioned.
     RLMRealmConfiguration *configUnversioned = [RLMRealmConfiguration defaultConfiguration];
-    configUnversioned.configRef.schema_version = RLMNotVersioned; // Not strictly necessary. Already has no version because the realm's never been opened.
+    configUnversioned.configRef.schema_version = RLMNotVersioned;
     std::shared_ptr<realm::Realm> unversioned = realm::Realm::get_shared_realm(configUnversioned.config);
 
     auto unversionedTsr = realm::ThreadSafeReference(unversioned);

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -26,7 +26,6 @@
 #import "RLMCredentials.h"
 #import "RLMObjectSchema_Private.hpp"
 #import "RLMRealm+Sync.h"
-#import "RLMRealmConfiguration_Private.h"
 #import "RLMRealmConfiguration_Private.hpp"
 #import "RLMRealmUtil.hpp"
 #import "RLMRealm_Dynamic.h"
@@ -1552,17 +1551,14 @@ static NSString *randomEmail() {
     configUnversioned.configRef.schema_version = RLMNotVersioned; // Not strictly necessary. Already has no version because the realm's never been opened.
     std::shared_ptr<realm::Realm> unversioned = realm::Realm::get_shared_realm(configUnversioned.config);
 
-    XCTestExpectation *afterExpectation = [self expectationWithDescription:@"block called once"];
+    XCTestExpectation *afterExpectation = [self expectationWithDescription:@"block is not called"];
     afterExpectation.inverted = true;
 
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wunused-parameter"
     realm::AfterClientResetWrapper afterWrapper = {
-        .block = ^(RLMRealm * _Nonnull beforeFrozen, RLMRealm * _Nonnull after) {
+        .block = ^(RLMRealm * _Nonnull, RLMRealm * _Nonnull) {
             [afterExpectation fulfill];
         }
     };
-    #pragma clang diagnostic pop // unused parameter warning
 
     auto unversionedTsr = realm::ThreadSafeReference(unversioned);
     XCTAssertEqual(unversioned->schema_version(), RLMNotVersioned);

--- a/Realm/RLMSyncConfiguration.h
+++ b/Realm/RLMSyncConfiguration.h
@@ -120,7 +120,7 @@ typedef NS_ENUM(NSUInteger, RLMClientResetMode) {
  A block type used to report before a client reset will occur.
  The `beforeFrozen` is a frozen copy of the local state prior to client reset.
  */
-RLM_SWIFT_SENDABLE // invoked on a backgroun thread
+RLM_SWIFT_SENDABLE // invoked on a background thread
 typedef void(^RLMClientResetBeforeBlock)(RLMRealm * _Nonnull beforeFrozen);
 
 /**

--- a/Realm/RLMSyncConfiguration.mm
+++ b/Realm/RLMSyncConfiguration.mm
@@ -99,7 +99,7 @@ void AfterClientResetWrapper::operator()(std::shared_ptr<realm::Realm> local, re
     }
 }
 
-} // anonymous namespace
+} // namespace realm
 
 @interface RLMSyncConfiguration () {
     std::unique_ptr<realm::SyncConfig> _config;

--- a/Realm/RLMSyncConfiguration_Private.hpp
+++ b/Realm/RLMSyncConfiguration_Private.hpp
@@ -20,15 +20,38 @@
 
 #import <functional>
 #import <memory>
+#import <string>
 
 namespace realm {
+class Realm;
 class SyncSession;
 struct SyncConfig;
 struct SyncError;
 using SyncSessionErrorHandler = void(std::shared_ptr<SyncSession>, SyncError);
+class ThreadSafeReference;
 }
 
 RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
+
+namespace realm {
+
+struct CallbackSchema {
+    bool dynamic;
+    std::string path;
+    RLMSchema *customSchema;
+
+    RLMSchema *getSchema(realm::Realm& realm);
+};
+
+struct BeforeClientResetWrapper : CallbackSchema {
+    RLMClientResetBeforeBlock block;
+    void operator()(std::shared_ptr<realm::Realm> local);
+};
+struct AfterClientResetWrapper : CallbackSchema {
+    RLMClientResetAfterBlock block;
+    void operator()(std::shared_ptr<realm::Realm> local, realm::ThreadSafeReference remote, bool);
+};
+}
 
 @interface RLMSyncConfiguration ()
 

--- a/Realm/RLMSyncConfiguration_Private.hpp
+++ b/Realm/RLMSyncConfiguration_Private.hpp
@@ -20,38 +20,15 @@
 
 #import <functional>
 #import <memory>
-#import <string>
 
 namespace realm {
-class Realm;
 class SyncSession;
 struct SyncConfig;
 struct SyncError;
 using SyncSessionErrorHandler = void(std::shared_ptr<SyncSession>, SyncError);
-class ThreadSafeReference;
 }
 
 RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
-
-namespace realm {
-
-struct CallbackSchema {
-    bool dynamic;
-    std::string path;
-    RLMSchema *customSchema;
-
-    RLMSchema *getSchema(realm::Realm& realm);
-};
-
-struct BeforeClientResetWrapper : CallbackSchema {
-    RLMClientResetBeforeBlock block;
-    void operator()(std::shared_ptr<realm::Realm> local);
-};
-struct AfterClientResetWrapper : CallbackSchema {
-    RLMClientResetAfterBlock block;
-    void operator()(std::shared_ptr<realm::Realm> local, realm::ThreadSafeReference remote, bool);
-};
-}
 
 @interface RLMSyncConfiguration ()
 


### PR DESCRIPTION
It's possible for a realm with no schema version to experience a client reset. If this happens, the callback wrappers shouldn't be called. Otherwise a crash can occur at [set_schema_subset](https://github.com/realm/realm-swift/blob/master/Realm/RLMRealm.mm#L352) in realmWithSharedRealm. From internal ticket [40981](https://jira.mongodb.org/browse/HELP-40981) and #8126