### PR TITLE
Expose MongoCollection.watch() as an async sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* `MongoCollection.watch().subscribe(on:)` now supports any swift Scheduler
+  rather than only dispatch queues ([PR #8131](https://github.com/realm/realm-swift/pull/8130)).
+* Add an async sequence wrapper for `MongoCollection.watch()`, allowing you to
+  do `for try await change in collection.changeEvents { ... }`
+  ([PR #8131](https://github.com/realm/realm-swift/pull/8130)).
 
 ### Fixed
 * `UserPublisher` incorrectly bounced all notifications to the main thread instead

--- a/Realm.podspec
+++ b/Realm.podspec
@@ -85,6 +85,7 @@ Pod::Spec.new do |s|
                               'include/RLMCollection_Private.h',
                               'include/RLMDictionary_Private.h',
                               'include/RLMEvent.h',
+                              'include/RLMMongoCollection_Private.h',
                               'include/RLMObjectBase_Private.h',
                               'include/RLMObjectSchema_Private.h',
                               'include/RLMObjectStore.h',

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -238,6 +238,8 @@
 		3FC3F915241808B400E27322 /* RLMEmbeddedObject.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3FC3F911241808B300E27322 /* RLMEmbeddedObject.mm */; };
 		3FC3F9172419B63200E27322 /* EmbeddedObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC3F9162419B63100E27322 /* EmbeddedObject.swift */; };
 		3FCB1A7522A9B0A2003807FB /* CodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FCB1A7422A9B0A2003807FB /* CodableTests.swift */; };
+		3FD0D7CE2967CA1E0031C196 /* RLMMongoCollection_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CF76F7D224816AAA00890DD2 /* RLMMongoCollection_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3FD0D7CF2967CA1F0031C196 /* RLMMongoCollection_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CF76F7D224816AAA00890DD2 /* RLMMongoCollection_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3FDCFEB619F6A8D3005E414A /* RLMSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88C36FF19745E5500C9963D /* RLMSupport.swift */; };
 		3FDE338D19C39A87003B7DBA /* RLMSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88C36FF19745E5500C9963D /* RLMSupport.swift */; };
 		3FE267D5264308680030F83C /* CollectionAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE267CF264308670030F83C /* CollectionAccess.swift */; };
@@ -1104,7 +1106,7 @@
 		CF76F7CF24816AA900890DD2 /* RLMMongoCollection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMMongoCollection.h; sourceTree = "<group>"; };
 		CF76F7D024816AAA00890DD2 /* RLMFindOptions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMFindOptions.mm; sourceTree = "<group>"; };
 		CF76F7D124816AAA00890DD2 /* RLMMongoCollection.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMMongoCollection.mm; sourceTree = "<group>"; };
-		CF76F7D224816AAA00890DD2 /* RLMMongoCollection_Private.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMMongoCollection_Private.hpp; sourceTree = "<group>"; };
+		CF76F7D224816AAA00890DD2 /* RLMMongoCollection_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMMongoCollection_Private.h; sourceTree = "<group>"; };
 		CF76F7D324816AAA00890DD2 /* RLMMongoClient_Private.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMMongoClient_Private.hpp; sourceTree = "<group>"; };
 		CF76F7D424816AAA00890DD2 /* RLMFindOptions_Private.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMFindOptions_Private.hpp; sourceTree = "<group>"; };
 		CF76F7D524816AAA00890DD2 /* RLMMongoClient.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMMongoClient.mm; sourceTree = "<group>"; };
@@ -1684,7 +1686,7 @@
 				CF76F7D324816AAA00890DD2 /* RLMMongoClient_Private.hpp */,
 				CF76F7CF24816AA900890DD2 /* RLMMongoCollection.h */,
 				CF76F7D124816AAA00890DD2 /* RLMMongoCollection.mm */,
-				CF76F7D224816AAA00890DD2 /* RLMMongoCollection_Private.hpp */,
+				CF76F7D224816AAA00890DD2 /* RLMMongoCollection_Private.h */,
 				CF76F7D924816AAB00890DD2 /* RLMMongoDatabase.h */,
 				CF76F7DC24816AAB00890DD2 /* RLMMongoDatabase_Private.hpp */,
 				CF76F7CC24816AA800890DD2 /* RLMUpdateResult.h */,
@@ -2036,6 +2038,7 @@
 				5D659EB01BE04556006515A0 /* RLMMigration_Private.h in Headers */,
 				CF76F7FB24816AAB00890DD2 /* RLMMongoClient.h in Headers */,
 				CF76F7E524816AAB00890DD2 /* RLMMongoCollection.h in Headers */,
+				3FD0D7CE2967CA1E0031C196 /* RLMMongoCollection_Private.h in Headers */,
 				CF76F7F924816AAB00890DD2 /* RLMMongoDatabase.h in Headers */,
 				4993221824129E6600A0EC8E /* RLMNetworkTransport.h in Headers */,
 				5D659EB11BE04556006515A0 /* RLMObject.h in Headers */,
@@ -2124,6 +2127,7 @@
 				5DD755AE1BE056DE002800DA /* RLMMigration_Private.h in Headers */,
 				CF76F7FC24816AAB00890DD2 /* RLMMongoClient.h in Headers */,
 				CF76F7E624816AAB00890DD2 /* RLMMongoCollection.h in Headers */,
+				3FD0D7CF2967CA1F0031C196 /* RLMMongoCollection_Private.h in Headers */,
 				CF76F7FA24816AAB00890DD2 /* RLMMongoDatabase.h in Headers */,
 				4993221924129E6600A0EC8E /* RLMNetworkTransport.h in Headers */,
 				5DD755AF1BE056DE002800DA /* RLMObject.h in Headers */,

--- a/Realm/RLMMongoClient.mm
+++ b/Realm/RLMMongoClient.mm
@@ -19,7 +19,7 @@
 #import "RLMMongoClient_Private.hpp"
 
 #import "RLMMongoDatabase_Private.hpp"
-#import "RLMMongoCollection_Private.hpp"
+#import "RLMMongoCollection_Private.h"
 #import "RLMApp_Private.hpp"
 
 #import <realm/object-store/sync/mongo_client.hpp>

--- a/Realm/RLMMongoCollection.h
+++ b/Realm/RLMMongoCollection.h
@@ -44,6 +44,8 @@ RLM_SWIFT_SENDABLE RLM_FINAL // is internally thread-safe
 @interface RLMChangeStream : NSObject<RLMEventDelegate>
 /// Stops a watch streaming session.
 - (void)close;
+/// :nodoc:
+- (instancetype)init NS_UNAVAILABLE;
 @end
 
 /// The `RLMMongoCollection` represents a MongoDB collection.

--- a/Realm/RLMMongoCollection.h
+++ b/Realm/RLMMongoCollection.h
@@ -74,10 +74,12 @@ RLM_SWIFT_SENDABLE // invoked on a background thread
 typedef void(^RLMMongoInsertManyBlock)(NSArray<id<RLMBSON>> * _Nullable, NSError * _Nullable);
 /// Block which returns an array of Documents on a successful find operation, or an error should one occur.
 RLM_SWIFT_SENDABLE // invoked on a background thread
-typedef void(^RLMMongoFindBlock)(NSArray<NSDictionary<NSString *, id<RLMBSON>> *> * _Nullable, NSError * _Nullable);
+typedef void(^RLMMongoFindBlock)(NSArray<NSDictionary<NSString *, id<RLMBSON>> *> * _Nullable,
+                                 NSError * _Nullable);
 /// Block which returns a Document on a successful findOne operation, or an error should one occur.
 RLM_SWIFT_SENDABLE // invoked on a background thread
-typedef void(^RLMMongoFindOneBlock)(NSDictionary<NSString *, id<RLMBSON>> * _Nullable, NSError * _Nullable);
+typedef void(^RLMMongoFindOneBlock)(NSDictionary<NSString *, id<RLMBSON>> * _Nullable_result,
+                                    NSError * _Nullable);
 /// Block which returns the number of Documents in a collection on a successful count operation, or an error should one occur.
 RLM_SWIFT_SENDABLE // invoked on a background thread
 typedef void(^RLMMongoCountBlock)(NSInteger, NSError * _Nullable);
@@ -86,7 +88,8 @@ RLM_SWIFT_SENDABLE // invoked on a background thread
 typedef void(^RLMMongoUpdateBlock)(RLMUpdateResult * _Nullable, NSError * _Nullable);
 /// Block which returns the deleted Document on a successful delete operation, or an error should one occur.
 RLM_SWIFT_SENDABLE // invoked on a background thread
-typedef void(^RLMMongoDeleteBlock)(NSDictionary<NSString *, id<RLMBSON>> * _Nullable, NSError * _Nullable);
+typedef void(^RLMMongoDeleteBlock)(NSDictionary<NSString *, id<RLMBSON>> * _Nullable_result,
+                                   NSError * _Nullable);
 
 /// The name of this mongodb collection.
 @property (nonatomic, readonly) NSString *name;

--- a/Realm/RLMMongoCollection_Private.h
+++ b/Realm/RLMMongoCollection_Private.h
@@ -18,29 +18,20 @@
 
 #import <Realm/RLMMongoCollection.h>
 
-RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
+RLM_HEADER_AUDIT_BEGIN(nullability)
 
 @class RLMUser;
-@protocol RLMChangeEventDelegate;
-
-@interface RLMChangeStream ()
-- (instancetype)initWithChangeEventSubscriber:(id<RLMChangeEventDelegate>)subscriber
-                                delegateQueue:(nullable dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
-- (instancetype)init NS_UNAVAILABLE;
-- (void)attachURLSession:(NSURLSession *)urlSession;
-@end
 
 @interface RLMMongoCollection ()
-
-@property (nonatomic, strong) RLMUser *user;
-@property (nonatomic, strong) NSString *serviceName;
-@property (nonatomic, strong) NSString *databaseName;
-
 - (instancetype)initWithUser:(RLMUser *)user
                  serviceName:(NSString *)serviceName
                 databaseName:(NSString *)databaseName
               collectionName:(NSString *)collectionName;
 
+- (RLMChangeStream *)watchWithMatchFilter:(nullable id<RLMBSON>)matchFilter
+                                 idFilter:(nullable id<RLMBSON>)idFilter
+                                 delegate:(id<RLMChangeEventDelegate>)delegate
+                                scheduler:(void (^)(dispatch_block_t))scheduler;
 @end
 
-RLM_HEADER_AUDIT_END(nullability, sendability)
+RLM_HEADER_AUDIT_END(nullability)

--- a/Realm/RLMNetworkTransport.h
+++ b/Realm/RLMNetworkTransport.h
@@ -77,15 +77,14 @@ typedef RLM_CLOSED_ENUM(int32_t, RLMHTTPMethod) {
 /// Invoked when a change event has been received.
 /// @param event The change event encoded as NSData
 - (void)didReceiveEvent:(NSData *)event;
-/// A error has occured while subscribing to changes.
-/// @param error The error that has occured.
+/// A error has occurred while subscribing to changes.
+/// @param error The error that has occurred.
 - (void)didReceiveError:(NSError *)error;
 /// The stream was opened.
 - (void)didOpen;
 /// The stream has been closed.
-/// @param error The error that has occured.
-- (void)didCloseWithError:(NSError *)error;
-
+/// @param error The error that has occurred.
+- (void)didCloseWithError:(NSError *_Nullable)error;
 @end
 
 /// A block for receiving an `RLMResponse` from the `RLMNetworkTransport`.

--- a/Realm/RLMNetworkTransport.mm
+++ b/Realm/RLMNetworkTransport.mm
@@ -56,7 +56,7 @@ NSString * const RLMHTTPMethodToNSString[] = {
 @end
 
 @interface RLMEventSessionDelegate <NSURLSessionDelegate> : NSObject
-+ (instancetype)delegateWithEventSubscriber:(RLMEventSubscriber *)subscriber;
++ (instancetype)delegateWithEventSubscriber:(id<RLMEventDelegate>)subscriber;
 @end;
 
 @implementation RLMNetworkTransport
@@ -104,11 +104,11 @@ NSString * const RLMHTTPMethodToNSString[] = {
     return session;
 }
 
-- (RLMRequest *)RLMRequestFromRequest:(const realm::app::Request)request {
+RLMRequest *RLMRequestFromRequest(realm::app::Request const& request) {
     RLMRequest *rlmRequest = [RLMRequest new];
     NSMutableDictionary<NSString *, NSString*> *headersDict = [NSMutableDictionary new];
-    for(auto &[key, value] : request.headers) {
-        [headersDict setValue:@(value.c_str()) forKey:@(key.c_str())];
+    for (auto &[key, value] : request.headers) {
+        headersDict[@(key.c_str())] = @(value.c_str());
     }
     rlmRequest.headers = headersDict;
     rlmRequest.method = static_cast<RLMHTTPMethod>(request.method);
@@ -169,11 +169,11 @@ didCompleteWithError:(NSError *)error
 @end
 
 @implementation RLMEventSessionDelegate {
-    RLMEventSubscriber *_subscriber;
+    id<RLMEventDelegate> _subscriber;
     bool _hasOpened;
 }
 
-+ (instancetype)delegateWithEventSubscriber:(RLMEventSubscriber *)subscriber {
++ (instancetype)delegateWithEventSubscriber:(id<RLMEventDelegate>)subscriber {
     RLMEventSessionDelegate *delegate = [RLMEventSessionDelegate new];
     delegate->_subscriber = subscriber;
     return delegate;

--- a/Realm/RLMNetworkTransport_Private.hpp
+++ b/Realm/RLMNetworkTransport_Private.hpp
@@ -18,24 +18,8 @@
 
 #import "RLMNetworkTransport.h"
 
-namespace realm {
-namespace app {
-struct GenericEventSubscriber;
+namespace realm::app {
 struct Request;
 }
-}
 
-@interface RLMEventSubscriber : NSObject<RLMEventDelegate>
-- (void)didReceiveEvent:(NSData *)event;
-- (void)didReceiveError:(NSError *)error;
-- (void)didOpen;
-- (void)didCloseWithError:(NSError *)error;
-
-@end
-
-@interface RLMNetworkTransport()
-
-- (RLMRequest *)RLMRequestFromRequest:(realm::app::Request)request;
-
-@end
-
+RLMRequest *RLMRequestFromRequest(realm::app::Request const& request);

--- a/Realm/RLMSyncSubscription.h
+++ b/Realm/RLMSyncSubscription.h
@@ -125,9 +125,13 @@ RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
  @param onComplete The block called upon synchronization of subscriptions to the server. Otherwise
                    an `Error`describing what went wrong will be returned by the block
  */
-- (void)update:(__attribute__((noescape)) void(^)(void))block onComplete:(void(^)(NSError * _Nullable))onComplete;
+- (void)update:(__attribute__((noescape)) void(^)(void))block
+    onComplete:(void(^)(NSError * _Nullable))onComplete
+    __attribute__((swift_async(not_swift_private, 2)))
+    __attribute__((swift_attr("@_unsafeInheritExecutor")));
 /// :nodoc:
-- (void)write:(__attribute__((noescape)) void(^)(void))block onComplete:(void(^)(NSError * _Nullable))onComplete __attribute__((unavailable("Renamed to -update:onComplete.")));
+- (void)write:(__attribute__((noescape)) void(^)(void))block
+   onComplete:(void(^)(NSError * _Nullable))onComplete __attribute__((unavailable("Renamed to -update:onComplete.")));
 
 #pragma mark - Find subscription
 

--- a/Realm/Realm.modulemap
+++ b/Realm/Realm.modulemap
@@ -11,6 +11,7 @@ framework module Realm {
         header "RLMCollection_Private.h"
         header "RLMDictionary_Private.h"
         header "RLMEvent.h"
+        header "RLMMongoCollection_Private.h"
         header "RLMObjectBase_Dynamic.h"
         header "RLMObjectBase_Private.h"
         header "RLMObjectSchema_Private.h"

--- a/RealmSwift/Combine.swift
+++ b/RealmSwift/Combine.swift
@@ -69,7 +69,7 @@ extension ObjectKeyIdentifiable where Self: ProjectionObservable {
 // MARK: - Combine
 
 /// A type which can be passed to `valuePublisher()` or `changesetPublisher()`.
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public protocol RealmSubscribable {
     /// :nodoc:
     func _observe<S>(_ keyPaths: [String]?, on queue: DispatchQueue?, _ subscriber: S)
@@ -79,7 +79,7 @@ public protocol RealmSubscribable {
         -> NotificationToken where S: Subscriber, S.Input == Void
 }
 
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Publisher {
     /// Freezes all Realm objects and collections emitted by the upstream publisher
     ///
@@ -281,7 +281,7 @@ extension Publisher {
     }
 }
 
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Publisher where Output: ThreadConfined {
     /// Enables passing thread-confined objects to a different dispatch queue.
     ///
@@ -313,7 +313,7 @@ extension Publisher where Output: ThreadConfined {
     }
 }
 
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Publisher {
     /// Enables passing object changesets to a different dispatch queue.
     ///
@@ -451,7 +451,7 @@ extension Publisher {
     }
 }
 
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension RealmCollection where Self: RealmSubscribable {
     /// A publisher that emits Void each time the collection changes.
     ///
@@ -487,7 +487,7 @@ extension RealmCollection where Self: RealmSubscribable {
     }
 }
 
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension RealmKeyedCollection where Self: RealmSubscribable {
     /// A publisher that emits Void each time the collection changes.
     ///
@@ -529,7 +529,7 @@ extension RealmKeyedCollection where Self: RealmSubscribable {
 /// - parameter object: A managed object to observe.
 /// - parameter keyPaths: The publisher emits changes on these property keyPaths. If `nil` the publisher emits changes for every property.
 /// - returns: A publisher that emits the object each time it changes.
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public func valuePublisher<T: Object>(_ object: T, keyPaths: [String]? = nil) -> RealmPublishers.Value<T> {
     RealmPublishers.Value<T>(object, keyPaths: keyPaths)
 }
@@ -540,7 +540,7 @@ public func valuePublisher<T: Object>(_ object: T, keyPaths: [String]? = nil) ->
 /// - parameter object: A managed collection to observe.
 /// - parameter keyPaths: The publisher emits changes on these property keyPaths. If `nil` the publisher emits changes for every property.
 /// - returns: A publisher that emits the collection each time it changes.
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public func valuePublisher<T: RealmCollection>(_ collection: T, keyPaths: [String]? = nil) -> RealmPublishers.Value<T> {
     RealmPublishers.Value<T>(collection, keyPaths: keyPaths)
 }
@@ -551,7 +551,7 @@ public func valuePublisher<T: RealmCollection>(_ collection: T, keyPaths: [Strin
 /// - parameter object: A managed object to observe.
 /// - parameter keyPaths: The publisher emits changes on these property keyPaths. If `nil` the publisher emits changes for every property.
 /// - returns: A publisher that emits the object each time it changes.
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public func valuePublisher<T: ProjectionObservable>(_ projection: T, keyPaths: [String]? = nil) -> RealmPublishers.Value<T> {
     RealmPublishers.Value<T>(projection, keyPaths: keyPaths)
 }
@@ -562,7 +562,7 @@ public func valuePublisher<T: ProjectionObservable>(_ projection: T, keyPaths: [
 /// - parameter object: A managed object to observe.
 /// - parameter keyPaths: The publisher emits changes on these property keyPaths. If `nil` the publisher emits changes for every property.
 /// - returns: A publisher that emits an object changeset each time the object changes.
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public func changesetPublisher<T: Object>(_ object: T, keyPaths: [String]? = nil) -> RealmPublishers.ObjectChangeset<T> {
     precondition(object.realm != nil, "Only managed objects can be published")
     precondition(!object.isInvalidated, "Object is invalidated or deleted")
@@ -578,7 +578,7 @@ public func changesetPublisher<T: Object>(_ object: T, keyPaths: [String]? = nil
 /// - parameter projection: A projection of Realm Object to observe.
 /// - parameter keyPaths: The publisher emits changes on these property keyPaths. If `nil` the publisher emits changes for every property.
 /// - returns: A publisher that emits an object changeset each time the projection changes.
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public func changesetPublisher<T: ProjectionObservable>(_ projection: T, keyPaths: [String]? = nil) -> RealmPublishers.ObjectChangeset<T> {
     precondition(projection.realm != nil, "Only managed objects can be published")
     precondition(!projection.isInvalidated, "Object is invalidated or deleted")
@@ -593,14 +593,14 @@ public func changesetPublisher<T: ProjectionObservable>(_ projection: T, keyPath
 /// - parameter object: A managed collection to observe.
 /// - parameter keyPaths: The publisher emits changes on these property keyPaths. If `nil` the publisher emits changes for every property.
 /// - returns: A publisher that emits a collection changeset each time the collection changes.
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public func changesetPublisher<T: RealmCollection>(_ collection: T, keyPaths: [String]? = nil) -> RealmPublishers.CollectionChangeset<T> {
     RealmPublishers.CollectionChangeset<T>(collection, keyPaths: keyPaths)
 }
 
 // MARK: - Realm
 
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Realm {
     /// A publisher that emits Void each time the object changes.
     ///
@@ -612,7 +612,7 @@ extension Realm {
 
 // MARK: - Object
 
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Object: ObservableObject {
     /// A publisher that emits Void each time the object changes.
     ///
@@ -621,7 +621,7 @@ extension Object: ObservableObject {
         return RealmPublishers.WillChange(self)
     }
 }
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension EmbeddedObject: ObservableObject {
     /// A publisher that emits Void each time the object changes.
     ///
@@ -630,7 +630,7 @@ extension EmbeddedObject: ObservableObject {
         return RealmPublishers.WillChange(self)
     }
 }
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension ObjectBase: RealmSubscribable {
     /// :nodoc:
     public func _observe<S: Subscriber>(_ keyPaths: [String]?, on queue: DispatchQueue?, _ subscriber: S) -> NotificationToken where S.Input: ObjectBase {
@@ -650,7 +650,7 @@ extension ObjectBase: RealmSubscribable {
 
 // MARK: - List
 
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension List: ObservableObject, RealmSubscribable {
     /// A publisher that emits Void each time the collection changes.
     ///
@@ -662,7 +662,7 @@ extension List: ObservableObject, RealmSubscribable {
 
 // MARK: - MutableSet
 
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension MutableSet: ObservableObject, RealmSubscribable {
     /// A publisher that emits Void each time the collection changes.
     ///
@@ -674,7 +674,7 @@ extension MutableSet: ObservableObject, RealmSubscribable {
 
 // MARK: - Map
 
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Map: ObservableObject, RealmSubscribable {
     /// A publisher that emits Void each time the collection changes.
     ///
@@ -686,7 +686,7 @@ extension Map: ObservableObject, RealmSubscribable {
 
 // MARK: - LinkingObjects
 
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension LinkingObjects: RealmSubscribable {
     /// A publisher that emits Void each time the collection changes.
     ///
@@ -698,7 +698,7 @@ extension LinkingObjects: RealmSubscribable {
 
 // MARK: - Results
 
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Results: RealmSubscribable {
     /// A publisher that emits Void each time the collection changes.
     ///
@@ -710,7 +710,7 @@ extension Results: RealmSubscribable {
 
 // MARK: - Sectioned Results
 
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension SectionedResults: RealmSubscribable {
     /// :nodoc:
     public func _observe<S>(_ keyPaths: [String]? = nil, on queue: DispatchQueue? = nil, _ subscriber: S)
@@ -758,7 +758,7 @@ extension SectionedResults: RealmSubscribable {
     }
 }
 
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension ResultsSection: RealmSubscribable {
     /// :nodoc:
     public func _observe<S>(_ keyPaths: [String]? = nil, on queue: DispatchQueue? = nil, _ subscriber: S)
@@ -808,7 +808,7 @@ extension ResultsSection: RealmSubscribable {
 
 // MARK: RealmCollection
 
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension RealmCollectionImpl {
     /// :nodoc:
     public func _observe<S>(_ keyPaths: [String]? = nil, on queue: DispatchQueue? = nil, _ subscriber: S)
@@ -831,12 +831,12 @@ extension RealmCollectionImpl {
     }
 }
 
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension AnyRealmCollection: RealmSubscribable {}
 
 // MARK: RealmKeyedCollection
 
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension RealmKeyedCollection {
     /// :nodoc:
     public func _observe<S>(_ keyPaths: [String]?, on queue: DispatchQueue? = nil, _ subscriber: S)
@@ -866,7 +866,7 @@ extension RealmKeyedCollection {
 // MARK: Subscriptions
 
 /// A subscription which wraps a Realm notification.
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 @frozen public struct ObservationSubscription: Subscription {
     private var token: NotificationToken
     internal init(token: NotificationToken) {
@@ -891,7 +891,7 @@ extension RealmKeyedCollection {
 }
 
 /// A subscription which wraps a Realm AsyncOpenTask.
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 @frozen public struct AsyncOpenSubscription: Subscription {
     private let task: Realm.AsyncOpenTask
 
@@ -927,7 +927,7 @@ extension RealmKeyedCollection {
 ///
 /// You normally should not create any of these types directly, and should
 /// instead use the extension methods which create them.
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public enum RealmPublishers {
     static private func realm<S: Scheduler>(_ config: RLMRealmConfiguration, _ scheduler: S) -> Realm? {
         try? Realm(RLMRealm(configuration: config, queue: scheduler as? DispatchQueue))

--- a/RealmSwift/Projection.swift
+++ b/RealmSwift/Projection.swift
@@ -471,7 +471,7 @@ extension ProjectionObservable {
 }
 
 // MARK: Notifications
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public extension Projection {
     /// :nodoc:
     func addObserver(_ observer: NSObject,
@@ -547,7 +547,7 @@ extension Projection: ThreadConfined where Root: ThreadConfined {
 
 #if canImport(Combine)
 // MARK: - RealmSubscribable
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension ProjectionObservable {
     /// :nodoc:
     public func _observe<S>(_ keyPaths: [String]?, on queue: DispatchQueue?, _ subscriber: S) -> NotificationToken where S: Subscriber, S.Input == Self {
@@ -569,7 +569,7 @@ extension ProjectionObservable {
     }
 }
 #if !(os(iOS) && (arch(i386) || arch(arm)))
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Projection: ObservableObject, RealmSubscribable where Root: ThreadConfined {
     /// A publisher that emits Void each time the projection changes.
     ///

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -160,7 +160,7 @@ public typealias AsyncTransactionId = RLMAsyncTransactionId
      - returns: A publisher. If the Realm was successfully opened, it will be received by the subscribers.
                 Otherwise, a `Swift.Error` describing what went wrong will be passed upstream instead.
      */
-    @available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     public static func asyncOpen(configuration: Realm.Configuration = .defaultConfiguration) -> RealmPublishers.AsyncOpenPublisher {
         return RealmPublishers.AsyncOpenPublisher(configuration: configuration)
     }
@@ -1162,7 +1162,8 @@ extension Realm {
 public typealias NotificationBlock = (_ notification: Realm.Notification, _ realm: Realm) -> Void
 
 #if canImport(_Concurrency)
-@available(macOS 10.15, tvOS 13.0, iOS 13.0, watchOS 6.0, *)
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Realm {
     /// Options for when to download all data from the server before opening
     /// a synchronized Realm.

--- a/RealmSwift/SyncSubscription.swift
+++ b/RealmSwift/SyncSubscription.swift
@@ -453,7 +453,7 @@ extension SyncSubscriptionSet: Sequence {
 }
 
 #if canImport(_Concurrency)
-@available(macOS 10.15, tvOS 13.0, iOS 13.0, watchOS 6.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension SyncSubscriptionSet {
     /**
      Creates and commits a transaction, updating the subscription set,
@@ -466,15 +466,7 @@ extension SyncSubscriptionSet {
      */
     @MainActor
     public func update(_ block: (() -> Void)) async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            update(block) { error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume()
-                }
-            }
-        }
+        try await rlmSyncSubscriptionSet.update(block)
     }
 
     /// :nodoc:

--- a/include/Realm/RLMMongoCollection_Private.h
+++ b/include/Realm/RLMMongoCollection_Private.h
@@ -1,0 +1,1 @@
+../../Realm/RLMMongoCollection_Private.h

--- a/include/module.modulemap
+++ b/include/module.modulemap
@@ -13,6 +13,7 @@ module Realm {
         header "Realm/RLMCollection_Private.h"
         header "Realm/RLMDictionary_Private.h"
         header "Realm/RLMEvent.h"
+        header "Realm/RLMMongoCollection_Private.h"
         header "Realm/RLMObjectBase_Dynamic.h"
         header "Realm/RLMObjectBase_Private.h"
         header "Realm/RLMObjectSchema_Private.h"


### PR DESCRIPTION
The actual wrapper is trivial, but this includes some refactoring to let it use `ImmediateScheduler` rather than a pointless extra scheduler hop for each event and a bit of incidental general cleanup.

`withCheckedThrowingContinuation()` is broken on macOS 12 (and presumably iOS 15): it's supposed to inherit the caller's actor, but that doesn't actually work. Using the automatic async bridging for obj-c functions instead of it sidesteps this problem. It turned out to usually simply the code as well, so I updated everything to use that instead of just the places where this bug was a problem.