### PR TITLE
Don't bounce to main thread to update User's subscriber.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ x.y.z Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
-* None.
-
+* `UserPublisher` incorrectly bounced all notifications to the main thread instead
+ of setting up the Combine publisher to correctly receive on the main thread.
+  ([#8132](https://github.com/realm/realm-swift/issues/8132), since 10.21.0)
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 
 ### Compatibility

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -966,9 +966,7 @@ public class UserPublisher: Publisher {
     /// :nodoc:
     public func receive<S>(subscriber: S) where S: Subscriber, S.Failure == Never, Output == S.Input {
         let token = user.subscribe { _ in
-            DispatchQueue.main.async {
-                _ = subscriber.receive(self.user)
-            }
+            _ = subscriber.receive(self.user)
         }
 
         subscriber.receive(subscription: UserSubscription(user: user, token: token))
@@ -980,8 +978,8 @@ extension User: ObservableObject {
     /// A publisher that emits Void each time the user changes.
     ///
     /// Despite the name, this actually emits *after* the user has changed.
-    public var objectWillChange: UserPublisher {
-        return UserPublisher(self)
+    public var objectWillChange: AnyPublisher<UserPublisher.Output, UserPublisher.Failure> {
+        return UserPublisher(self).receive(on: DispatchQueue.main).eraseToAnyPublisher()
     }
 }
 #endif


### PR DESCRIPTION
`User` incorrectly bounced all notifications to the main thread when being used as an `ObservedObject` in SwiftUI which in turn suppressed sendability warnings. The correct approach is to have the caller which mutates the `User` bounce to the main thread and perform the operation.