### PR TITLE
Overhaul SDK Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ x.y.z Release notes (yyyy-MM-dd)
 
 ### Internal
 * Upgraded realm-core from ? to ?
+* Overhauled SDK metrics collection to better drive future development efforts.
 
 10.40.0 Release notes (2023-05-26)
 =============================================================
@@ -259,8 +260,6 @@ supported version.
 ### Internal
 
 * Upgraded realm-core from v13.9.4 to v13.10.0.
-* Upgraded realm-core from ? to ?
-* Overhauled SDK metrics collection to better drive future development effort.
 
 10.38.3 Release notes (2023-04-28)
 =============================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,6 +259,8 @@ supported version.
 ### Internal
 
 * Upgraded realm-core from v13.9.4 to v13.10.0.
+* Upgraded realm-core from ? to ?
+* Overhauled SDK metrics collection to better drive future development effort.
 
 10.38.3 Release notes (2023-04-28)
 =============================================================

--- a/Configuration/Realm/Realm.xcconfig
+++ b/Configuration/Realm/Realm.xcconfig
@@ -22,3 +22,5 @@ LD_RUNPATH_SEARCH_PATHS[sdk=macosx*] = $(inherited) @executable_path/../Framewor
 LD_RUNPATH_SEARCH_PATHS[sdk=iphone*] = $(inherited) @executable_path/Frameworks @loader_path/Frameworks;
 LD_RUNPATH_SEARCH_PATHS[sdk=watch*] = $(inherited) @executable_path/Frameworks @loader_path/Frameworks;
 LD_RUNPATH_SEARCH_PATHS[sdk=appletv*] = $(inherited) @executable_path/Frameworks @loader_path/Frameworks;
+
+REALM_IOPLATFORMUUID = "";

--- a/Realm/RLMAnalytics.hpp
+++ b/Realm/RLMAnalytics.hpp
@@ -44,12 +44,16 @@
 // we give you.
 //
 // Currently the following information is reported:
-// - What version of Realm is being used, and from which language (obj-c or Swift).
-// - What version of OS X it's running on (in case Xcode aggressively drops
+// - What version of Realm and core is being used, and from which language (obj-c or Swift).
+// - Which platform and version of OS X it's running on (in case Xcode aggressively drops
 //   support for older versions again, we need to know what we need to support).
 // - The minimum iOS/OS X version that the application is targeting (again, to
 //   help us decide what versions we need to support).
 // - An anonymous MAC address and bundle ID to aggregate the other information on.
-// - What version of Swift is being used (if applicable).
+// - The host platform OSX and version.
+// - The XCode version.
+// - Some info about the features been used when opening the realm for the first time.
 
-void RLMSendAnalytics();
+#import <Realm/RLMRealm.h>
+
+void RLMSendAnalytics(RLMRealmConfiguration *configuration, RLMSchema *schema);

--- a/Realm/RLMAnalytics.mm
+++ b/Realm/RLMAnalytics.mm
@@ -326,14 +326,14 @@ static NSDictionary *RLMBaseMetrics() {
 static NSDictionary *RLMSchemaMetrics(RLMSchema *schema) {
     NSMutableDictionary *featuresDictionary = [@{@"Embedded_Object": @0,
                                                  @"Asymmetric_Object": @0,
-                                                 @"Reference_Link": @0,
+                                                 @"Object_Link": @0,
                                                  @"Mixed": @0,
                                                  @"Primitive_List": @0,
                                                  @"Primitive_Set": @0,
                                                  @"Primitive_Dictionary": @0,
-                                                 @"Reference_List": @0,
-                                                 @"Reference_Set": @0,
-                                                 @"Reference_Dictionary": @0,
+                                                 @"Object_List": @0,
+                                                 @"Object_Set": @0,
+                                                 @"Object_Dictionary": @0,
                                                } mutableCopy];
 
     for (RLMObjectSchema *objectSchema in schema.objectSchema) {
@@ -347,7 +347,7 @@ static NSDictionary *RLMSchemaMetrics(RLMSchema *schema) {
         for (RLMProperty *property in objectSchema.properties) {
             if (property.array) {
                 if (property.type == RLMPropertyTypeObject) {
-                    featuresDictionary[@"Reference_List"] = @1;
+                    featuresDictionary[@"Object_List"] = @1;
                 } else {
                     featuresDictionary[@"Primitive_List"] = @1;
                 }
@@ -355,7 +355,7 @@ static NSDictionary *RLMSchemaMetrics(RLMSchema *schema) {
             }
             if (property.set) {
                 if (property.type == RLMPropertyTypeObject) {
-                    featuresDictionary[@"Reference_Set"] = @1;
+                    featuresDictionary[@"Object_Set"] = @1;
                 } else {
                     featuresDictionary[@"Primitive_Set"] = @1;
                 }
@@ -363,7 +363,7 @@ static NSDictionary *RLMSchemaMetrics(RLMSchema *schema) {
             }
             if (property.dictionary) {
                 if (property.type == RLMPropertyTypeObject) {
-                    featuresDictionary[@"Reference_Dictionary"] = @1;
+                    featuresDictionary[@"Object_Dictionary"] = @1;
                 } else {
                     featuresDictionary[@"Primitive_Dictionary"] = @1;
                 }
@@ -375,7 +375,7 @@ static NSDictionary *RLMSchemaMetrics(RLMSchema *schema) {
                     featuresDictionary[@"Mixed"] = @1;
                   break;
                case RLMPropertyTypeObject:
-                    featuresDictionary[@"Reference_Link"] = @1;
+                    featuresDictionary[@"Object_Link"] = @1;
                   break;
                 case RLMPropertyTypeLinkingObjects:
                     featuresDictionary[@"Backlink"] = @1;
@@ -401,14 +401,14 @@ static NSDictionary *RLMConfigurationMetrics(RLMRealmConfiguration *configuratio
     return @{
         // Sync
         @"Sync Enabled": isSync ? @"true" : @"false",
-        @"Flexible_Sync": isFlexibleSync ? @1 : @0,
+        @"Flx_Sync": isFlexibleSync ? @1 : @0,
         @"Pbs_Sync": isPBSSync ? @1 : @0,
 
         // Client Reset
-        @"Client_Reset_Recover_Or_Discard": (isSync && resetMode == RLMClientResetModeRecoverOrDiscardUnsyncedChanges) ? @1 : @0,
-        @"Client_Reset_Recover": (isSync && resetMode == RLMClientResetModeRecoverUnsyncedChanges) ? @1 : @0,
-        @"Client_Reset_Discard": (isSync && resetMode == RLMClientResetModeDiscardUnsyncedChanges) ? @1 : @0,
-        @"Client_Reset_Manual": (isSync && resetMode == RLMClientResetModeManual) ? @1 : @0,
+        @"CR_Recover_Discard": (isSync && resetMode == RLMClientResetModeRecoverOrDiscardUnsyncedChanges) ? @1 : @0,
+        @"CR_Recover": (isSync && resetMode == RLMClientResetModeRecoverUnsyncedChanges) ? @1 : @0,
+        @"CR_Discard": (isSync && resetMode == RLMClientResetModeDiscardUnsyncedChanges) ? @1 : @0,
+        @"CR_Manual": (isSync && resetMode == RLMClientResetModeManual) ? @1 : @0,
 
         // Configuration
         @"Compact_On_Launch": isCompactOnLaunch ? @1 : @0,

--- a/Realm/RLMAnalytics.mm
+++ b/Realm/RLMAnalytics.mm
@@ -403,8 +403,6 @@ void RLMSendAnalytics(RLMRealmConfiguration *configuration, RLMSchema *schema) {
 
     id config = [configuration copy];
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        NSArray *urlStrings = @[@"https://data.mongodb-api.com/app/realmsdkmetrics-zmhtm/endpoint/metric_webhook/metric?data=%@"];
-
         NSDictionary *baseMetrics = RLMBaseMetrics();
         NSDictionary *schemaMetrics = RLMSchemaMetrics(schema);
         NSDictionary *configurationMetrics = RLMConfigurationMetrics(config);
@@ -417,12 +415,11 @@ void RLMSendAnalytics(RLMRealmConfiguration *configuration, RLMSchema *schema) {
         NSDictionary *payloadN = @{@"event": @"Run", @"properties": metrics};
         NSData *payload = [NSJSONSerialization dataWithJSONObject:payloadN options:0 error:nil];
 
-        for (NSString *urlString in urlStrings) {
-            NSString *formatted = [NSString stringWithFormat:urlString, [payload base64EncodedStringWithOptions:0]];
-            // No error handling or anything because logging errors annoyed people for no
-            // real benefit, and it's not clear what else we could do
-            [[NSURLSession.sharedSession dataTaskWithURL:[NSURL URLWithString:formatted]] resume];
-        }
+        NSString *url = @"https://data.mongodb-api.com/app/realmsdkmetrics-zmhtm/endpoint/metric_webhook/metric?data=%@";
+        NSString *formatted = [NSString stringWithFormat:url, [payload base64EncodedStringWithOptions:0]];
+        // No error handling or anything because logging errors annoyed people for no
+        // real benefit, and it's not clear what else we could do
+        [[NSURLSession.sharedSession dataTaskWithURL:[NSURL URLWithString:formatted]] resume];
     });
 }
 

--- a/Realm/RLMDecimal128.mm
+++ b/Realm/RLMDecimal128.mm
@@ -26,7 +26,7 @@
 // to Decodable, so we need a Swift-defined subclass for that. This means that
 // when Realm Swift is being used, we need to produce objects of that type rather
 // than our obj-c defined type. objc_runtime_visible marks the type as being
-// visbile only to the obj-c runtime and not the linker, which means that it'll
+// visible only to the obj-c runtime and not the linker, which means that it'll
 // be `nil` at runtime rather than being a linker error if it's not defined, and
 // valid if it happens to be defined by some other library (i.e. Realm Swift).
 //

--- a/Realm/RLMPlatform.h.in
+++ b/Realm/RLMPlatform.h.in
@@ -45,3 +45,5 @@
 #error Attempting to use Realm''s watchOS framework in a non-watchOS target.
 #endif
 #endif
+
+#define REALM_IOPLATFORMUUID @""

--- a/Realm/RLMPlatform.h.in
+++ b/Realm/RLMPlatform.h.in
@@ -45,5 +45,3 @@
 #error Attempting to use Realm''s watchOS framework in a non-watchOS target.
 #endif
 #endif
-
-#define REALM_IOPLATFORMUUID @""

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -18,7 +18,9 @@
 
 #import "RLMRealm_Private.hpp"
 
+#if DEBUG
 #import "RLMAnalytics.hpp"
+#endif
 #import "RLMAsyncTask_Private.h"
 #import "RLMArray_Private.hpp"
 #import "RLMDictionary_Private.hpp"
@@ -239,18 +241,21 @@ bool copySeedFile(RLMRealmConfiguration *configuration, NSError **error) {
 }
 
 + (void)initialize {
+    // In cases where we are not using a synced Realm, we initialise the default logger
+    // before opening any realm.
+    [RLMLogger class];
+}
+
++ (void)runFirstCheckForConfiguration:(RLMRealmConfiguration *)configuration schema:(RLMSchema *)schema {
     static bool initialized;
     if (initialized) {
         return;
     }
     initialized = true;
 
+    // Run Analytics on the very first any Realm open.
+    RLMSendAnalytics(configuration, schema);
     RLMCheckForUpdates();
-    RLMSendAnalytics();
-
-    // In cases where we are not using a synced Realm, we initialise the default logger
-    // before opening any realm.
-    [RLMLogger class];
 }
 
 - (instancetype)initPrivate {
@@ -476,6 +481,9 @@ bool copySeedFile(RLMRealmConfiguration *configuration, NSError **error) {
         }];
     }
 #endif
+
+    // Run Analytics and Update checker, this will be run only the first any realm open
+    [self runFirstCheckForConfiguration:configuration schema:realm.schema];
 
     return realm;
 }

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -18,9 +18,7 @@
 
 #import "RLMRealm_Private.hpp"
 
-#if DEBUG
 #import "RLMAnalytics.hpp"
-#endif
 #import "RLMAsyncTask_Private.h"
 #import "RLMArray_Private.hpp"
 #import "RLMDictionary_Private.hpp"

--- a/Realm/RLMSyncConfiguration.mm
+++ b/Realm/RLMSyncConfiguration.mm
@@ -227,10 +227,6 @@ void RLMSetConfigInfoForClientResetCallbacks(realm::SyncConfig& syncConfig, RLMR
     _config->cancel_waits_on_nonfatal_error = cancelAsyncOpenOnNonFatalErrors;
 }
 
-- (BOOL)enableFlexibleSync {
-    return _config->flx_sync_requested;
-}
-
 - (void)assignConfigErrorHandler:(RLMUser *)user {
     RLMSyncManager *manager = [user.app syncManager];
     __weak RLMSyncManager *weakManager = manager;

--- a/Realm/RLMSyncConfiguration_Private.h
+++ b/Realm/RLMSyncConfiguration_Private.h
@@ -41,7 +41,6 @@ typedef RLM_CLOSED_ENUM(NSUInteger, RLMSyncStopPolicy) {
 
 // Internal-only APIs
 @property (nonatomic, readwrite) RLMSyncStopPolicy stopPolicy;
-@property (nonatomic, readonly) BOOL enableFlexibleSync;
 
 @end
 

--- a/build.sh
+++ b/build.sh
@@ -75,6 +75,7 @@ command:
   examples-ios-swift:   builds all Swift iOS examples
   examples-osx:         builds all macOS examples
   get-version:          get the current version
+  get-ioplatformuuid:   get io platform uuid
   set-version version:  set the version
   cocoapods-setup:      download realm-core and create a stub RLMPlatform.h file to enable building via CocoaPods
 
@@ -953,6 +954,11 @@ case "$COMMAND" in
     ######################################
     "get-version")
         plist_get 'Realm/Realm-Info.plist' 'CFBundleShortVersionString'
+        exit 0
+        ;;
+
+    "get-ioplatformuuid")
+        ioreg -d2 -c IOPlatformExpertDevice | awk -F\" '/IOPlatformUUID/{print $(NF-1)}'
         exit 0
         ;;
 

--- a/scripts/generate-rlmplatform.sh
+++ b/scripts/generate-rlmplatform.sh
@@ -12,7 +12,8 @@ if [ "$IS_MACCATALYST" = "YES" ]; then
 fi
 
 unifdef -B -DREALM_BUILDING_FOR_$(echo ${PLATFORM_SUFFIX} | tr "[:lower:]" "[:upper:]") < "${SOURCE_FILE}" | sed -e "s/''/'/" > "${TEMPORARY_FILE}"
-echo "#define REALM_IOPLATFORMUUID @\"$(sh build.sh get-ioplatformuuid)\"" >> ${TEMPORARY_FILE}
+echo "#define REALM_IOPLATFORMUUID @\"\"" >> ${TEMPORARY_FILE}
+
 
 if ! cmp -s "${TEMPORARY_FILE}" "${DESTINATION_FILE}"; then
   echo "Updating ${DESTINATION_FILE}"

--- a/scripts/generate-rlmplatform.sh
+++ b/scripts/generate-rlmplatform.sh
@@ -12,6 +12,7 @@ if [ "$IS_MACCATALYST" = "YES" ]; then
 fi
 
 unifdef -B -DREALM_BUILDING_FOR_$(echo ${PLATFORM_SUFFIX} | tr "[:lower:]" "[:upper:]") < "${SOURCE_FILE}" | sed -e "s/''/'/" > "${TEMPORARY_FILE}"
+echo "#define REALM_IOPLATFORMUUID @\"$(sh build.sh get-ioplatformuuid)\"" >> ${TEMPORARY_FILE}
 
 if ! cmp -s "${TEMPORARY_FILE}" "${DESTINATION_FILE}"; then
   echo "Updating ${DESTINATION_FILE}"

--- a/scripts/setup-cocoapods.sh
+++ b/scripts/setup-cocoapods.sh
@@ -13,5 +13,5 @@ mkdir -p "$source_root/include"
 cp -R "$source_root/core/realm-monorepo.xcframework/ios-arm64_armv7/Headers" "$source_root/include/core"
 
 mkdir -p "$source_root/include"
-echo '' > "$source_root/Realm/RLMPlatform.h"
+echo "#define REALM_IOPLATFORMUUID @\"$(sh $source_root/build.sh get-ioplatformuuid)\"" > "$source_root/Realm/RLMPlatform.h"
 cp "$source_root/Realm/"*.h "$source_root/Realm/"*.hpp "$source_root/include"


### PR DESCRIPTION
Overhauled SDK metrics collection to better drive future development effort.
After the PR we still send the metrics the first time a realm is opened in the life time of and App on Debug, but we now do it after we have the schema, so we can get some features metrics.

Here is a list of the metrics, and info about if is tracked or not.
Field Name | isTracked
-- | --
distinct_id | ✅
builder_id | ✅
Anonymized Bundle ID | ✅
Binding | ✅
Language | ✅
Host OS Type | ✅
Host OS Version | ✅
Host CPU Arch | ✅
Target CPU Arch | ✅
Target OS Type | ✅
Target OS Minimum Version | ✅
Target OS Version | ✅
Realm Version | ✅
Core Version | ✅
Sync Enabled | ✅
Language Version |  
Framework | ✅
Framework Version |  
Installation Method | ✅
Installation Method Version |  
IDE |  
IDE Version | 
Runtime Engine |  
Compiler | ✅
Embedded_Object | ✅
Asymmetric_Object | ✅
Reference_Link | ✅
Mixed | ✅
Primitive_List | ✅
Primitive_Set | ✅
Primitive_Dictionary | ✅
Reference_List | ✅
Reference_Set | ✅
Reference_Dictionary | ✅
Backlink | ✅
Realm_Integer |  
Asynchronous_Realm_Open |  
Synchronous_Realm_Open |  
Query_Async |  
Query_Primary_Key |  
Write_Async |  
Thread_Safe_Reference |  
Insert_Modified |  
Compact_On_Launch | ✅
Schema_Migration_Block | ✅
Realm_Change_Listener |  
List_Change_Listener |  
Set_Change_Listener |  
Dictionary_Change_Listener |  
Result_Change_Listener |  
Object_Change_Listener |  
Client_Reset_Recover_Or_Discard | ✅
Client_Reset_Recover | ✅
Client_Reset_Discard | ✅
Client_Reset_Manual | ✅
Progress_Notification |  
Connection_Notification |  
Pbs_Sync | ✅
Flexible_Sync | ✅
Auth_Anonymous |  
Auth_Email_Password |  
Auth_Facebook |  
Auth_Google |  
Auth_Custom_JWT |  
Auth_API_Key |  
Auth_Server_API_Key |  
Auth_Apple |  
Auth_Function |  
Remote_Function |  
MongoDB_Data_Access |  
Dynamic_API |  
String_FTS |  





