### PR TITLE
Fix retain cycle in SwiftUI asyncOpen

### DIFF
--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -1549,7 +1549,8 @@ private class ObservableAsyncOpenStorage: ObservableObject {
         // Cancel any current subscriptions to asyncOpen if there is one
         cancelAsyncOpen()
         Realm.asyncOpen(configuration: config)
-            .onProgressNotification { asyncProgress in
+            .onProgressNotification { [weak self] asyncProgress in
+                guard let self = self else { return }
                 // Do not change state to progress if the realm file is already opened or there is an error
                 switch self.asyncOpenState {
                 case .connecting, .waitingForUser, .progress:
@@ -1559,7 +1560,8 @@ private class ObservableAsyncOpenStorage: ObservableObject {
                 default: break
                 }
             }
-            .sink { completion in
+            .sink { [weak self] completion in
+                guard let self = self else { return }
                 if case .failure(let error) = completion {
                     switch self.asyncOpenKind {
                     case .asyncOpen:
@@ -1572,8 +1574,8 @@ private class ObservableAsyncOpenStorage: ObservableObject {
                         }
                     }
                 }
-            } receiveValue: { realm in
-                self.asyncOpenState = .open(realm)
+            } receiveValue: { [weak self] realm in
+                self?.asyncOpenState = .open(realm)
             }.store(in: &self.asyncOpenCancellable)
     }
 


### PR DESCRIPTION
This pull request fixes a memory leak issue in the code by adding weak references to self in the closure blocks that are passed to the Realm.asyncOpen() method. The previous implementation did not use weak references, which could lead to retain cycles and memory leaks.

In the new implementation, we use [weak self] in the closure blocks to capture a weak reference to self. This ensures that the closure blocks do not create strong references to self, which could cause a memory leak.

By making this change, the code now properly manages memory and ensures that any references to self are released when they are no longer needed. This should help to prevent any memory-related issues that could occur due to the previous implementation.