### PR TITLE
Import as `RLMRealm_Private.h` as a module would cause issues when using Realm as a subdependency

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -34,6 +34,7 @@ target:
  - cocoapods-osx
  - cocoapods-ios
  - cocoapods-ios-dynamic
+ - cocoapods-ios-subdependency
  - cocoapods-watchos
  - swiftui-ios
  - swiftui-server-osx
@@ -131,6 +132,12 @@ exclude:
 
   - xcode_version: 14.2
     target: cocoapods-ios-dynamic
+
+  - xcode_version: 14.1
+    target: cocoapods-ios-subdependency
+
+  - xcode_version: 14.2
+    target: cocoapods-ios-subdependency
 
   - xcode_version: 14.2
     target: cocoapods-watchos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ x.y.z Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
+* Import as `RLMRealm_Private.h` as a module would cause issues when using Realm as a subdependency.
+  ([#8164](https://github.com/realm/realm-swift/issues/8164), since 10.37.0)
 * None.
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->

--- a/Realm/RLMAsyncTask_Private.h
+++ b/Realm/RLMAsyncTask_Private.h
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMAsyncTask.h>
 
-#import <Realm/RLMRealm_Private.h>
+#import "RLMRealm_Private.h"
 
 RLM_HEADER_AUDIT_BEGIN(nullability)
 

--- a/build.sh
+++ b/build.sh
@@ -674,6 +674,7 @@ case "$COMMAND" in
 
         sh build.sh verify-cocoapods-ios
         sh build.sh verify-cocoapods-ios-dynamic
+        sh build.sh verify-cocoapods-ios-subdependency
         sh build.sh verify-cocoapods-osx
         sh build.sh verify-cocoapods-watchos
 
@@ -683,6 +684,7 @@ case "$COMMAND" in
         sh build.sh test-ios-objc-cocoapods
         sh build.sh test-ios-objc-cocoapods-dynamic
         sh build.sh test-ios-swift-cocoapods
+        sh build.sh test-ios-swift-cocoapods-subdependency
         sh build.sh test-osx-objc-cocoapods
         sh build.sh test-osx-swift-cocoapods
         sh build.sh test-catalyst-objc-cocoapods
@@ -698,6 +700,14 @@ case "$COMMAND" in
         export EXPANDED_CODE_SIGN_IDENTITY=''
         cd examples/installation
         sh build.sh test-ios-objc-cocoapods-dynamic
+        ;;
+
+    verify-cocoapods-ios-subdependency)
+        PLATFORM=$(echo "$COMMAND" | cut -d - -f 3)
+        # https://github.com/CocoaPods/CocoaPods/issues/7708
+        export EXPANDED_CODE_SIGN_IDENTITY=''
+        cd examples/installation
+        sh build.sh test-ios-swift-cocoapods-subdependency
         ;;
 
     verify-cocoapods-*)

--- a/examples/installation/build.sh
+++ b/examples/installation/build.sh
@@ -19,6 +19,7 @@ command:
   test-ios-swift-dynamic:          tests iOS Swift dynamic example.
   test-ios-swift-xcframework:      tests iOS Swift xcframework example.
   test-ios-swift-cocoapods:        tests iOS Swift CocoaPods example.
+  test-ios-swift-cocoapods-subdependency: tests RealmSwift as a subdependency.
   test-ios-swift-carthage:         tests iOS Swift Carthage example.
   test-ios-spm:                    tests iOS Swift Package Manager example.
 
@@ -188,6 +189,10 @@ case "$COMMAND" in
 
     test-*-*-cocoapods-dynamic)
         xctest "$PLATFORM" "$LANGUAGE" CocoaPodsDynamicExample
+        ;;
+
+    test-*-*-cocoapods-subdependency)
+        xctest "$PLATFORM" "$LANGUAGE" CocoaPodsSubdependency
         ;;
 
     test-*-*-static)

--- a/examples/installation/ios/swift/CocoaPodsSubdependency/CocoaPodsSubdependency/CocoaPodsSubdependencyApp.swift
+++ b/examples/installation/ios/swift/CocoaPodsSubdependency/CocoaPodsSubdependency/CocoaPodsSubdependencyApp.swift
@@ -1,0 +1,28 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import SwiftUI
+
+@main
+struct CocoaPodsSubdependencyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/examples/installation/ios/swift/CocoaPodsSubdependency/Podfile
+++ b/examples/installation/ios/swift/CocoaPodsSubdependency/Podfile
@@ -1,0 +1,25 @@
+# Uncomment this line to define a global platform for your project
+platform :ios, '14.0'
+use_modular_headers!
+
+branch = ENV['sha']
+
+target 'CocoaPodsSubdependency' do
+  pod 'Realm', git: 'https://github.com/realm/realm-swift.git', branch: branch
+  pod 'RealmSwift', git: 'https://github.com/realm/realm-swift.git', branch: branch
+  pod 'SubRealm', :path => '../CocoaPodsSubdependency'
+end
+
+target 'CocoaPodsSubdependencyTests' do
+  pod 'Realm', git: 'https://github.com/realm/realm-swift.git', branch: branch
+  pod 'RealmSwift', git: 'https://github.com/realm/realm-swift.git', branch: branch
+  pod 'SubRealm', :path => '../CocoaPodsSubdependency'
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['GCC_GENERATE_DEBUGGING_SYMBOLS'] = 'NO'
+    end
+  end
+end

--- a/examples/installation/ios/swift/CocoaPodsSubdependency/SubRealm.podspec
+++ b/examples/installation/ios/swift/CocoaPodsSubdependency/SubRealm.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name                       = "SubRealm"
+  s.version                    = "1.0.0"
+  s.summary                    = "Test Realm as a Subdependecy"
+  s.description                = <<-DESC
+SubRealm contains a cocoapods which uses RealmSwift as a subpendency.
+                   DESC
+  s.homepage                   = "https://realm.io"
+  s.author                     = { 'Realm' => 'realm-help@mongodb.com' }
+  s.source                     = { :git => 'https://github.com/realm/realm-swift.git', :tag => "v#{s.version}" }
+  s.swift_version              = '5'
+  s.ios.deployment_target      = '14.0'
+  s.source_files               = "Source/*.{swift}"
+
+  s.dependency  'RealmSwift'
+end

--- a/examples/installation/ios/swift/CocoapodsSubdependency/CocoaPodsSubdependency.xcodeproj/project.pbxproj
+++ b/examples/installation/ios/swift/CocoapodsSubdependency/CocoaPodsSubdependency.xcodeproj/project.pbxproj
@@ -1,0 +1,577 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		2CC35ABC0CFE6C4CC1BCE0EA /* libPods-CocoaPodsSubdependency.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC796545555469E7E39A73A /* libPods-CocoaPodsSubdependency.a */; };
+		94EBDAEF1EC24ECD7882342D /* libPods-CocoaPodsSubdependencyTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A0AD105ED829751BABE99216 /* libPods-CocoaPodsSubdependencyTests.a */; };
+		ACA22F032A405B42002A1C08 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA22F022A405B42002A1C08 /* ContentView.swift */; };
+		ACA22F052A405B43002A1C08 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ACA22F042A405B43002A1C08 /* Assets.xcassets */; };
+		ACA22F082A405B43002A1C08 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ACA22F072A405B43002A1C08 /* Preview Assets.xcassets */; };
+		ACA22F122A405B44002A1C08 /* CocoaPodsSubdependencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA22F112A405B44002A1C08 /* CocoaPodsSubdependencyTests.swift */; };
+		ACFD9BBE2A40A56A0035F160 /* CocoaPodsSubdependencyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACFD9BBD2A40A56A0035F160 /* CocoaPodsSubdependencyApp.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		ACA22F0E2A405B44002A1C08 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ACA22EF52A405B42002A1C08 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ACA22EFC2A405B42002A1C08;
+			remoteInfo = CocoapodsSubdependency;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		32C25947BC93E79218FFB150 /* Pods-CocoaPodsSubdependencyTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPodsSubdependencyTests.debug.xcconfig"; path = "Target Support Files/Pods-CocoaPodsSubdependencyTests/Pods-CocoaPodsSubdependencyTests.debug.xcconfig"; sourceTree = "<group>"; };
+		4CA90B1884A48D6EAF06391C /* Pods-CocoaPodsSubdependency.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPodsSubdependency.release.xcconfig"; path = "Target Support Files/Pods-CocoaPodsSubdependency/Pods-CocoaPodsSubdependency.release.xcconfig"; sourceTree = "<group>"; };
+		8DC796545555469E7E39A73A /* libPods-CocoaPodsSubdependency.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-CocoaPodsSubdependency.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A09B8B0F4586CD7441580005 /* Pods-CocoaPodsSubdependency.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPodsSubdependency.debug.xcconfig"; path = "Target Support Files/Pods-CocoaPodsSubdependency/Pods-CocoaPodsSubdependency.debug.xcconfig"; sourceTree = "<group>"; };
+		A0AD105ED829751BABE99216 /* libPods-CocoaPodsSubdependencyTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-CocoaPodsSubdependencyTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		ACA22EFD2A405B42002A1C08 /* CocoaPodsSubdependency.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CocoaPodsSubdependency.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		ACA22F022A405B42002A1C08 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		ACA22F042A405B43002A1C08 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		ACA22F072A405B43002A1C08 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		ACA22F0D2A405B44002A1C08 /* CocoaPodsSubdependencyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CocoaPodsSubdependencyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		ACA22F112A405B44002A1C08 /* CocoaPodsSubdependencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CocoaPodsSubdependencyTests.swift; sourceTree = "<group>"; };
+		ACFD9BBD2A40A56A0035F160 /* CocoaPodsSubdependencyApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CocoaPodsSubdependencyApp.swift; sourceTree = "<group>"; };
+		E86F8EAF64F151620F280C3E /* Pods-CocoaPodsSubdependencyTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPodsSubdependencyTests.release.xcconfig"; path = "Target Support Files/Pods-CocoaPodsSubdependencyTests/Pods-CocoaPodsSubdependencyTests.release.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		ACA22EFA2A405B42002A1C08 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2CC35ABC0CFE6C4CC1BCE0EA /* libPods-CocoaPodsSubdependency.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ACA22F0A2A405B44002A1C08 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				94EBDAEF1EC24ECD7882342D /* libPods-CocoaPodsSubdependencyTests.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		23F4C7C8AA9EC05AD639174B /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				A09B8B0F4586CD7441580005 /* Pods-CocoaPodsSubdependency.debug.xcconfig */,
+				4CA90B1884A48D6EAF06391C /* Pods-CocoaPodsSubdependency.release.xcconfig */,
+				32C25947BC93E79218FFB150 /* Pods-CocoaPodsSubdependencyTests.debug.xcconfig */,
+				E86F8EAF64F151620F280C3E /* Pods-CocoaPodsSubdependencyTests.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		A0E65FF9591F1A3049274E7F /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				8DC796545555469E7E39A73A /* libPods-CocoaPodsSubdependency.a */,
+				A0AD105ED829751BABE99216 /* libPods-CocoaPodsSubdependencyTests.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		ACA22EF42A405B42002A1C08 = {
+			isa = PBXGroup;
+			children = (
+				ACA22EFF2A405B42002A1C08 /* CocoaPodsSubdependency */,
+				ACA22F102A405B44002A1C08 /* CocoaPodsSubdependencyTests */,
+				ACA22EFE2A405B42002A1C08 /* Products */,
+				23F4C7C8AA9EC05AD639174B /* Pods */,
+				A0E65FF9591F1A3049274E7F /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		ACA22EFE2A405B42002A1C08 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				ACA22EFD2A405B42002A1C08 /* CocoaPodsSubdependency.app */,
+				ACA22F0D2A405B44002A1C08 /* CocoaPodsSubdependencyTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		ACA22EFF2A405B42002A1C08 /* CocoaPodsSubdependency */ = {
+			isa = PBXGroup;
+			children = (
+				ACFD9BBD2A40A56A0035F160 /* CocoaPodsSubdependencyApp.swift */,
+				ACA22F022A405B42002A1C08 /* ContentView.swift */,
+				ACA22F042A405B43002A1C08 /* Assets.xcassets */,
+				ACA22F062A405B43002A1C08 /* Preview Content */,
+			);
+			path = CocoaPodsSubdependency;
+			sourceTree = "<group>";
+		};
+		ACA22F062A405B43002A1C08 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				ACA22F072A405B43002A1C08 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		ACA22F102A405B44002A1C08 /* CocoaPodsSubdependencyTests */ = {
+			isa = PBXGroup;
+			children = (
+				ACA22F112A405B44002A1C08 /* CocoaPodsSubdependencyTests.swift */,
+			);
+			path = CocoaPodsSubdependencyTests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		ACA22EFC2A405B42002A1C08 /* CocoaPodsSubdependency */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = ACA22F212A405B44002A1C08 /* Build configuration list for PBXNativeTarget "CocoaPodsSubdependency" */;
+			buildPhases = (
+				6FB34B3720A387119AD57658 /* [CP] Check Pods Manifest.lock */,
+				ACA22EF92A405B42002A1C08 /* Sources */,
+				ACA22EFA2A405B42002A1C08 /* Frameworks */,
+				ACA22EFB2A405B42002A1C08 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CocoaPodsSubdependency;
+			productName = CocoapodsSubdependency;
+			productReference = ACA22EFD2A405B42002A1C08 /* CocoaPodsSubdependency.app */;
+			productType = "com.apple.product-type.application";
+		};
+		ACA22F0C2A405B44002A1C08 /* CocoaPodsSubdependencyTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = ACA22F242A405B44002A1C08 /* Build configuration list for PBXNativeTarget "CocoaPodsSubdependencyTests" */;
+			buildPhases = (
+				6427C5B7E8BDF5E38A517F39 /* [CP] Check Pods Manifest.lock */,
+				ACA22F092A405B44002A1C08 /* Sources */,
+				ACA22F0A2A405B44002A1C08 /* Frameworks */,
+				ACA22F0B2A405B44002A1C08 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				ACA22F0F2A405B44002A1C08 /* PBXTargetDependency */,
+			);
+			name = CocoaPodsSubdependencyTests;
+			productName = CocoapodsSubdependencyTests;
+			productReference = ACA22F0D2A405B44002A1C08 /* CocoaPodsSubdependencyTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		ACA22EF52A405B42002A1C08 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					ACA22EFC2A405B42002A1C08 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+					ACA22F0C2A405B44002A1C08 = {
+						CreatedOnToolsVersion = 15.0;
+						TestTargetID = ACA22EFC2A405B42002A1C08;
+					};
+				};
+			};
+			buildConfigurationList = ACA22EF82A405B42002A1C08 /* Build configuration list for PBXProject "CocoaPodsSubdependency" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = ACA22EF42A405B42002A1C08;
+			productRefGroup = ACA22EFE2A405B42002A1C08 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				ACA22EFC2A405B42002A1C08 /* CocoaPodsSubdependency */,
+				ACA22F0C2A405B44002A1C08 /* CocoaPodsSubdependencyTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		ACA22EFB2A405B42002A1C08 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ACA22F082A405B43002A1C08 /* Preview Assets.xcassets in Resources */,
+				ACA22F052A405B43002A1C08 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ACA22F0B2A405B44002A1C08 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		6427C5B7E8BDF5E38A517F39 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-CocoaPodsSubdependencyTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6FB34B3720A387119AD57658 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-CocoaPodsSubdependency-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		ACA22EF92A405B42002A1C08 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ACA22F032A405B42002A1C08 /* ContentView.swift in Sources */,
+				ACFD9BBE2A40A56A0035F160 /* CocoaPodsSubdependencyApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ACA22F092A405B44002A1C08 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ACA22F122A405B44002A1C08 /* CocoaPodsSubdependencyTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		ACA22F0F2A405B44002A1C08 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = ACA22EFC2A405B42002A1C08 /* CocoaPodsSubdependency */;
+			targetProxy = ACA22F0E2A405B44002A1C08 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		ACA22F1F2A405B44002A1C08 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		ACA22F202A405B44002A1C08 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		ACA22F222A405B44002A1C08 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A09B8B0F4586CD7441580005 /* Pods-CocoaPodsSubdependency.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"CocoapodsSubdependency/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		ACA22F232A405B44002A1C08 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4CA90B1884A48D6EAF06391C /* Pods-CocoaPodsSubdependency.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"CocoapodsSubdependency/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+		ACA22F252A405B44002A1C08 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 32C25947BC93E79218FFB150 /* Pods-CocoaPodsSubdependencyTests.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CocoaPodsSubdependency.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/CocoaPodsSubdependency";
+			};
+			name = Debug;
+		};
+		ACA22F262A405B44002A1C08 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E86F8EAF64F151620F280C3E /* Pods-CocoaPodsSubdependencyTests.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CocoaPodsSubdependency.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/CocoaPodsSubdependency";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		ACA22EF82A405B42002A1C08 /* Build configuration list for PBXProject "CocoaPodsSubdependency" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ACA22F1F2A405B44002A1C08 /* Debug */,
+				ACA22F202A405B44002A1C08 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		ACA22F212A405B44002A1C08 /* Build configuration list for PBXNativeTarget "CocoaPodsSubdependency" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ACA22F222A405B44002A1C08 /* Debug */,
+				ACA22F232A405B44002A1C08 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		ACA22F242A405B44002A1C08 /* Build configuration list for PBXNativeTarget "CocoaPodsSubdependencyTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ACA22F252A405B44002A1C08 /* Debug */,
+				ACA22F262A405B44002A1C08 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = ACA22EF52A405B42002A1C08 /* Project object */;
+}

--- a/examples/installation/ios/swift/CocoapodsSubdependency/CocoaPodsSubdependency/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/examples/installation/ios/swift/CocoapodsSubdependency/CocoaPodsSubdependency/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/installation/ios/swift/CocoapodsSubdependency/CocoaPodsSubdependency/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/installation/ios/swift/CocoapodsSubdependency/CocoaPodsSubdependency/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/installation/ios/swift/CocoapodsSubdependency/CocoaPodsSubdependency/Assets.xcassets/Contents.json
+++ b/examples/installation/ios/swift/CocoapodsSubdependency/CocoaPodsSubdependency/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/installation/ios/swift/CocoapodsSubdependency/CocoaPodsSubdependency/ContentView.swift
+++ b/examples/installation/ios/swift/CocoapodsSubdependency/CocoaPodsSubdependency/ContentView.swift
@@ -1,0 +1,47 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import SwiftUI
+import SubRealm
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+            Text("Hello, world!")
+        }
+        .padding()
+        .onAppear {
+            print(Test.test() ?? "")
+        }
+    }
+}
+
+public class Test {
+    public static func test() -> TestObject? {
+        do {
+            try SubRealm.storeTestModel()
+            let model = try SubRealm.findTestModel()
+            return model ?? nil
+        } catch {
+            print(error)
+            return nil
+        }
+    }
+}

--- a/examples/installation/ios/swift/CocoapodsSubdependency/CocoaPodsSubdependency/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/examples/installation/ios/swift/CocoapodsSubdependency/CocoaPodsSubdependency/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/installation/ios/swift/CocoapodsSubdependency/CocoaPodsSubdependencyTests/CocoaPodsSubdependencyTests.swift
+++ b/examples/installation/ios/swift/CocoapodsSubdependency/CocoaPodsSubdependencyTests/CocoaPodsSubdependencyTests.swift
@@ -1,0 +1,28 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import XCTest
+@testable import CocoaPodsSubdependency
+
+class CocoaPodsSubdependencyTests: XCTestCase {
+    func testExample() throws {
+        let result = Test.test()
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.name, "Test")
+    }
+}

--- a/examples/installation/ios/swift/CocoapodsSubdependency/Source/SubRealm.swift
+++ b/examples/installation/ios/swift/CocoapodsSubdependency/Source/SubRealm.swift
@@ -1,0 +1,39 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import RealmSwift
+
+public class TestObject: Object {
+    @Persisted public var name: String
+}
+
+public class SubRealm {
+    public static func storeTestModel() throws {
+        let realm = try Realm()
+        let model = TestObject()
+        model.name = "Test"
+        try realm.write {
+            realm.add(model)
+        }
+    }
+
+    public static func findTestModel() throws -> TestObject? {
+        let realm = try Realm()
+        return realm.objects(TestObject.self).first ?? nil
+    }
+}

--- a/scripts/pr-ci-matrix.rb
+++ b/scripts/pr-ci-matrix.rb
@@ -45,6 +45,7 @@ targets = {
   'cocoapods-osx' => all,
   'cocoapods-ios' => oldest_and_latest,
   'cocoapods-ios-dynamic' => oldest_and_latest,
+  'cocoapods-ios-subdependency' => latest_only,
   'cocoapods-watchos' => oldest_and_latest,
   # 'cocoapods-catalyst' => oldest_and_latest,
   'swiftui-ios' => latest_only,


### PR DESCRIPTION
Import as `RLMRealm_Private.h` as a module would cause issues when using Realm as a subdependency.
Because `<Realm/RLMRealm_Private.h>` is part of the Private Realm Module, there seems to be an issue when you use `Realm` as a sub-dependency with Cocopods which doesn't find the file within the headers associated to the module, even if we expose them as private headers. 
Importing the file relative to the directory using quotation marks fixes the issue.