### PR TITLE
Add SortDescriptor API for Mongo Client sorting options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,11 @@ x.y.z Release notes (yyyy-MM-dd)
 
 * Improve performance of equality queries on a non-indexed AnyRealmValue
   property by about 30%. ([Core #6506](https://github.com/realm/realm-core/issues/6506))
+* Now you can use sortDescriptors parameter to set an array of `SortDescriptor`s 
+  which can be use to set the order of the matching documents when used within MongoCollection. 
+  This new API fixes the issue where the resulting documents when using more than 
+  one sort parameter were not consistent between calls. 
+  ([#7188](https://github.com/realm/realm-swift/issues/7188), since v10.0.0). 
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ x.y.z Release notes (yyyy-MM-dd)
   runtime actor data race detection (`OTHER_SWIFT_FLAGS=-Xfrontend
   -enable-actor-data-race-checks`) is strongly recommended when using
   actor-isolated Realms.
+* Now you can use an array `[["_id": 1], ["breed": 0]]` as sorting option for a MongoCollection. 
+  This new API fixes the issue where the resulting documents when using more than 
+  one sort parameter were not consistent between calls. 
+  ([#7188](https://github.com/realm/realm-swift/issues/7188), since v10.0.0). 
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
@@ -141,11 +145,6 @@ x.y.z Release notes (yyyy-MM-dd)
 
 * Improve performance of equality queries on a non-indexed AnyRealmValue
   property by about 30%. ([Core #6506](https://github.com/realm/realm-core/issues/6506))
-* Now you can use sortDescriptors parameter to set an array of `SortDescriptor`s 
-  which can be use to set the order of the matching documents when used within MongoCollection. 
-  This new API fixes the issue where the resulting documents when using more than 
-  one sort parameter were not consistent between calls. 
-  ([#7188](https://github.com/realm/realm-swift/issues/7188), since v10.0.0). 
 
 ### Fixed
 

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -2171,94 +2171,100 @@ static const NSInteger NUMBER_OF_BIG_OBJECTS = 2;
 
 - (void)testFindOneAndModifyOptions {
     NSDictionary<NSString *, id<RLMBSON>> *projection = @{@"name": @1, @"breed": @1};
-    NSArray<RLMSortDescriptor *> *sortDescriptors = @[[RLMSortDescriptor sortDescriptorWithKeyPath:@"age" ascending:true], [RLMSortDescriptor sortDescriptorWithKeyPath:@"coat" ascending:true]];
+    NSArray<id<RLMBSON>> *sorting = @[@{@"age": @1}, @{@"coat": @1}];
 
     RLMFindOneAndModifyOptions *findOneAndModifyOptions1 = [[RLMFindOneAndModifyOptions alloc] init];
     XCTAssertNil(findOneAndModifyOptions1.projection);
-    XCTAssertEqual(findOneAndModifyOptions1.sortDescriptors.count, 0U);
+    XCTAssertEqual(findOneAndModifyOptions1.sorting.count, 0U);
     XCTAssertFalse(findOneAndModifyOptions1.shouldReturnNewDocument);
     XCTAssertFalse(findOneAndModifyOptions1.upsert);
 
     RLMFindOneAndModifyOptions *findOneAndModifyOptions2 = [[RLMFindOneAndModifyOptions alloc] init];
     findOneAndModifyOptions2.projection = projection;
-    findOneAndModifyOptions2.sortDescriptors = sortDescriptors;
+    findOneAndModifyOptions2.sorting = sorting;
     findOneAndModifyOptions2.shouldReturnNewDocument = YES;
     findOneAndModifyOptions2.upsert = YES;
     XCTAssertNotNil(findOneAndModifyOptions2.projection);
-    XCTAssertEqual(findOneAndModifyOptions2.sortDescriptors.count, 2U);
+    XCTAssertEqual(findOneAndModifyOptions2.sorting.count, 2U);
     XCTAssertTrue(findOneAndModifyOptions2.shouldReturnNewDocument);
     XCTAssertTrue(findOneAndModifyOptions2.upsert);
     XCTAssertFalse([findOneAndModifyOptions2.projection isEqual:@{}]);
     XCTAssertTrue([findOneAndModifyOptions2.projection isEqual:projection]);
-    XCTAssertFalse([findOneAndModifyOptions2.sortDescriptors isEqual:sortDescriptors]);
+    XCTAssertFalse([findOneAndModifyOptions2.sorting isEqual:@{}]);
+    XCTAssertTrue([findOneAndModifyOptions2.sorting isEqual:sorting]);
 
     RLMFindOneAndModifyOptions *findOneAndModifyOptions3 = [[RLMFindOneAndModifyOptions alloc]
                                                             initWithProjection:projection
-                                                            sortDescriptors:sortDescriptors
+                                                            sorting:sorting
                                                             upsert:YES
                                                             shouldReturnNewDocument:YES];
     XCTAssertNotNil(findOneAndModifyOptions3.projection);
-    XCTAssertEqual(findOneAndModifyOptions3.sortDescriptors.count, 2U);
+    XCTAssertEqual(findOneAndModifyOptions3.sorting.count, 2U);
     XCTAssertTrue(findOneAndModifyOptions3.shouldReturnNewDocument);
     XCTAssertTrue(findOneAndModifyOptions3.upsert);
     XCTAssertFalse([findOneAndModifyOptions3.projection isEqual:@{}]);
     XCTAssertTrue([findOneAndModifyOptions3.projection isEqual:projection]);
-    XCTAssertFalse([findOneAndModifyOptions3.sortDescriptors isEqual:sortDescriptors]);
+    XCTAssertFalse([findOneAndModifyOptions3.sorting isEqual:@{}]);
+    XCTAssertTrue([findOneAndModifyOptions3.sorting isEqual:sorting]);
 
     findOneAndModifyOptions3.projection = nil;
-    findOneAndModifyOptions3.sortDescriptors = @[];
+    findOneAndModifyOptions3.sorting = @[];
     XCTAssertNil(findOneAndModifyOptions3.projection);
-    XCTAssertEqual(findOneAndModifyOptions3.sortDescriptors.count, 0U);
+    XCTAssertEqual(findOneAndModifyOptions3.sorting.count, 0U);
+    XCTAssertTrue([findOneAndModifyOptions3.sorting isEqual:@[]]);
 
     RLMFindOneAndModifyOptions *findOneAndModifyOptions4 = [[RLMFindOneAndModifyOptions alloc]
                                                             initWithProjection:nil
-                                                            sortDescriptors:@[]
+                                                            sorting:@[]
                                                             upsert:NO
                                                             shouldReturnNewDocument:NO];
     XCTAssertNil(findOneAndModifyOptions4.projection);
-    XCTAssertEqual(findOneAndModifyOptions4.sortDescriptors.count, 0U);
+    XCTAssertEqual(findOneAndModifyOptions4.sorting.count, 0U);
     XCTAssertFalse(findOneAndModifyOptions4.upsert);
     XCTAssertFalse(findOneAndModifyOptions4.shouldReturnNewDocument);
 }
 
 - (void)testFindOptions {
     NSDictionary<NSString *, id<RLMBSON>> *projection = @{@"name": @1, @"breed": @1};
-    NSArray<RLMSortDescriptor *> *sortDescriptors = @[[RLMSortDescriptor sortDescriptorWithKeyPath:@"age" ascending:true], [RLMSortDescriptor sortDescriptorWithKeyPath:@"coat" ascending:true]];
+    NSArray<id<RLMBSON>> *sorting = @[@{@"age": @1}, @{@"coat": @1}];
 
     RLMFindOptions *findOptions1 = [[RLMFindOptions alloc] init];
     XCTAssertNil(findOptions1.projection);
-    XCTAssertEqual(findOptions1.sortDescriptors.count, 0U);
+    XCTAssertEqual(findOptions1.sorting.count, 0U);
     XCTAssertEqual(findOptions1.limit, 0);
 
     findOptions1.limit = 37;
     findOptions1.projection = projection;
-    findOptions1.sortDescriptors = sortDescriptors;
+    findOptions1.sorting = sorting;
     XCTAssertEqual(findOptions1.limit, 37);
     XCTAssertTrue([findOptions1.projection isEqual:projection]);
-    XCTAssertEqual(findOptions1.sortDescriptors.count, 2U);
+    XCTAssertEqual(findOptions1.sorting.count, 2U);
+    XCTAssertTrue([findOptions1.sorting isEqual:sorting]);
 
     RLMFindOptions *findOptions2 = [[RLMFindOptions alloc] initWithProjection:projection
-                                                              sortDescriptors:sortDescriptors];
+                                                                      sorting:sorting];
     XCTAssertTrue([findOptions2.projection isEqual:projection]);
-    XCTAssertEqual(findOptions1.sortDescriptors.count, 2U);
+    XCTAssertEqual(findOptions2.sorting.count, 2U);
     XCTAssertEqual(findOptions2.limit, 0);
+    XCTAssertTrue([findOptions2.sorting isEqual:sorting]);
 
     RLMFindOptions *findOptions3 = [[RLMFindOptions alloc] initWithLimit:37
                                                               projection:projection
-                                                         sortDescriptors:sortDescriptors];
+                                                                 sorting:sorting];
     XCTAssertTrue([findOptions3.projection isEqual:projection]);
-    XCTAssertEqual(findOptions1.sortDescriptors.count, 2U);
+    XCTAssertEqual(findOptions3.sorting.count, 2U);
     XCTAssertEqual(findOptions3.limit, 37);
+    XCTAssertTrue([findOptions3.sorting isEqual:sorting]);
 
     findOptions3.projection = nil;
-    findOptions3.sortDescriptors = @[];
+    findOptions3.sorting = @[];
     XCTAssertNil(findOptions3.projection);
-    XCTAssertEqual(findOptions3.sortDescriptors.count, 0U);
+    XCTAssertEqual(findOptions3.sorting.count, 0U);
 
     RLMFindOptions *findOptions4 = [[RLMFindOptions alloc] initWithProjection:nil
-                                                              sortDescriptors:@[]];
+                                                                      sorting:@[]];
     XCTAssertNil(findOptions4.projection);
-    XCTAssertEqual(findOptions4.sortDescriptors.count, 0U);
+    XCTAssertEqual(findOptions4.sorting.count, 0U);
     XCTAssertEqual(findOptions4.limit, 0);
 }
 
@@ -2289,7 +2295,7 @@ static const NSInteger NUMBER_OF_BIG_OBJECTS = 2;
     [self waitForExpectationsWithTimeout:60.0 handler:nil];
 
     XCTestExpectation *findExpectation = [self expectationWithDescription:@"should find documents"];
-    RLMFindOptions *options = [[RLMFindOptions alloc] initWithLimit:0 projection:nil sortDescriptors:@[]];
+    RLMFindOptions *options = [[RLMFindOptions alloc] initWithLimit:0 projection:nil sorting:@[]];
     [collection findWhere:@{@"name": @"fido", @"breed": @"cane corso"}
                   options:options
                completion:^(NSArray<NSDictionary *> *documents, NSError *error) {
@@ -2318,7 +2324,7 @@ static const NSInteger NUMBER_OF_BIG_OBJECTS = 2;
     [self waitForExpectationsWithTimeout:60.0 handler:nil];
 
     XCTestExpectation *findExpectation = [self expectationWithDescription:@"should find documents"];
-    RLMFindOptions *options = [[RLMFindOptions alloc] initWithLimit:0 projection:nil sortDescriptors:@[]];
+    RLMFindOptions *options = [[RLMFindOptions alloc] initWithLimit:0 projection:nil sorting:@[]];
     [collection findWhere:@{@"name": @"fido", @"breed": @"cane corso"}
                   options:options
                completion:^(NSArray<NSDictionary *> *documents, NSError *error) {
@@ -2513,10 +2519,10 @@ static const NSInteger NUMBER_OF_BIG_OBJECTS = 2;
     RLMMongoDatabase *database = [client databaseWithName:@"test_data"];
     RLMMongoCollection *collection = [database collectionWithName:@"Dog"];
 
-    NSArray<RLMSortDescriptor *> *sortDescriptors = @[[RLMSortDescriptor sortDescriptorWithKeyPath:@"name" ascending:true], [RLMSortDescriptor sortDescriptorWithKeyPath:@"breed" ascending:true]];
+    NSArray<id<RLMBSON>> *sorting = @[@{@"name": @1}, @{@"breed": @1}];
     RLMFindOneAndModifyOptions *findAndModifyOptions = [[RLMFindOneAndModifyOptions alloc]
                                                         initWithProjection:@{@"name" : @1, @"breed" : @1}
-                                                        sortDescriptors:sortDescriptors
+                                                        sorting:sorting
                                                         upsert:YES
                                                         shouldReturnNewDocument:YES];
 
@@ -2621,10 +2627,10 @@ static const NSInteger NUMBER_OF_BIG_OBJECTS = 2;
 
     XCTestExpectation *findOneAndDeleteExpectation2 = [self expectationWithDescription:@"should find one and delete"];
     NSDictionary<NSString *, id<RLMBSON>> *projection = @{@"name": @1, @"breed": @1};
-    NSArray<RLMSortDescriptor *> *sortDescriptors = @[[RLMSortDescriptor sortDescriptorWithKeyPath:@"_id" ascending:true], [RLMSortDescriptor sortDescriptorWithKeyPath:@"breed" ascending:true]];
+    NSArray<id<RLMBSON>> *sortDescriptors = @[@{@"_id": @1}, @{@"breed": @1}];
     RLMFindOneAndModifyOptions *findOneAndModifyOptions = [[RLMFindOneAndModifyOptions alloc]
                                                            initWithProjection:projection
-                                                           sortDescriptors:sortDescriptors
+                                                           sorting:sortDescriptors
                                                            upsert:YES
                                                            shouldReturnNewDocument:YES];
 

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -2171,97 +2171,94 @@ static const NSInteger NUMBER_OF_BIG_OBJECTS = 2;
 
 - (void)testFindOneAndModifyOptions {
     NSDictionary<NSString *, id<RLMBSON>> *projection = @{@"name": @1, @"breed": @1};
-    NSDictionary<NSString *, id<RLMBSON>> *sort = @{@"age" : @1, @"coat" : @1};
+    NSArray<RLMSortDescriptor *> *sortDescriptors = @[[RLMSortDescriptor sortDescriptorWithKeyPath:@"age" ascending:true], [RLMSortDescriptor sortDescriptorWithKeyPath:@"coat" ascending:true]];
 
     RLMFindOneAndModifyOptions *findOneAndModifyOptions1 = [[RLMFindOneAndModifyOptions alloc] init];
     XCTAssertNil(findOneAndModifyOptions1.projection);
-    XCTAssertNil(findOneAndModifyOptions1.sort);
+    XCTAssertEqual(findOneAndModifyOptions1.sortDescriptors.count, 0U);
     XCTAssertFalse(findOneAndModifyOptions1.shouldReturnNewDocument);
     XCTAssertFalse(findOneAndModifyOptions1.upsert);
 
     RLMFindOneAndModifyOptions *findOneAndModifyOptions2 = [[RLMFindOneAndModifyOptions alloc] init];
     findOneAndModifyOptions2.projection = projection;
-    findOneAndModifyOptions2.sort = sort;
-    XCTAssertNotNil(findOneAndModifyOptions2.projection);
-    XCTAssertNotNil(findOneAndModifyOptions2.sort);
+    findOneAndModifyOptions2.sortDescriptors = sortDescriptors;
     findOneAndModifyOptions2.shouldReturnNewDocument = YES;
     findOneAndModifyOptions2.upsert = YES;
+    XCTAssertNotNil(findOneAndModifyOptions2.projection);
+    XCTAssertEqual(findOneAndModifyOptions2.sortDescriptors.count, 2U);
     XCTAssertTrue(findOneAndModifyOptions2.shouldReturnNewDocument);
     XCTAssertTrue(findOneAndModifyOptions2.upsert);
-
     XCTAssertFalse([findOneAndModifyOptions2.projection isEqual:@{}]);
     XCTAssertTrue([findOneAndModifyOptions2.projection isEqual:projection]);
-    XCTAssertFalse([findOneAndModifyOptions2.sort isEqual:@{}]);
-    XCTAssertTrue([findOneAndModifyOptions2.sort isEqual:sort]);
+    XCTAssertFalse([findOneAndModifyOptions2.sortDescriptors isEqual:sortDescriptors]);
 
     RLMFindOneAndModifyOptions *findOneAndModifyOptions3 = [[RLMFindOneAndModifyOptions alloc]
                                                             initWithProjection:projection
-                                                            sort:sort
+                                                            sortDescriptors:sortDescriptors
                                                             upsert:YES
                                                             shouldReturnNewDocument:YES];
-
     XCTAssertNotNil(findOneAndModifyOptions3.projection);
-    XCTAssertNotNil(findOneAndModifyOptions3.sort);
+    XCTAssertEqual(findOneAndModifyOptions3.sortDescriptors.count, 2U);
     XCTAssertTrue(findOneAndModifyOptions3.shouldReturnNewDocument);
     XCTAssertTrue(findOneAndModifyOptions3.upsert);
     XCTAssertFalse([findOneAndModifyOptions3.projection isEqual:@{}]);
     XCTAssertTrue([findOneAndModifyOptions3.projection isEqual:projection]);
-    XCTAssertFalse([findOneAndModifyOptions3.sort isEqual:@{}]);
-    XCTAssertTrue([findOneAndModifyOptions3.sort isEqual:sort]);
+    XCTAssertFalse([findOneAndModifyOptions3.sortDescriptors isEqual:sortDescriptors]);
 
     findOneAndModifyOptions3.projection = nil;
-    findOneAndModifyOptions3.sort = nil;
+    findOneAndModifyOptions3.sortDescriptors = @[];
     XCTAssertNil(findOneAndModifyOptions3.projection);
-    XCTAssertNil(findOneAndModifyOptions3.sort);
+    XCTAssertEqual(findOneAndModifyOptions3.sortDescriptors.count, 0U);
 
     RLMFindOneAndModifyOptions *findOneAndModifyOptions4 = [[RLMFindOneAndModifyOptions alloc]
                                                             initWithProjection:nil
-                                                            sort:nil
+                                                            sortDescriptors:@[]
                                                             upsert:NO
                                                             shouldReturnNewDocument:NO];
-
     XCTAssertNil(findOneAndModifyOptions4.projection);
-    XCTAssertNil(findOneAndModifyOptions4.sort);
+    XCTAssertEqual(findOneAndModifyOptions4.sortDescriptors.count, 0U);
     XCTAssertFalse(findOneAndModifyOptions4.upsert);
     XCTAssertFalse(findOneAndModifyOptions4.shouldReturnNewDocument);
 }
 
 - (void)testFindOptions {
     NSDictionary<NSString *, id<RLMBSON>> *projection = @{@"name": @1, @"breed": @1};
-    NSDictionary<NSString *, id<RLMBSON>> *sort = @{@"age" : @1, @"coat" : @1};
+    NSArray<RLMSortDescriptor *> *sortDescriptors = @[[RLMSortDescriptor sortDescriptorWithKeyPath:@"age" ascending:true], [RLMSortDescriptor sortDescriptorWithKeyPath:@"coat" ascending:true]];
 
     RLMFindOptions *findOptions1 = [[RLMFindOptions alloc] init];
-    findOptions1.limit = 37;
     XCTAssertNil(findOptions1.projection);
+    XCTAssertEqual(findOptions1.sortDescriptors.count, 0U);
+    XCTAssertEqual(findOptions1.limit, 0);
+
+    findOptions1.limit = 37;
     findOptions1.projection = projection;
-    XCTAssertTrue([findOptions1.projection isEqual:projection]);
-    XCTAssertNil(findOptions1.sort);
-    findOptions1.sort = sort;
-    XCTAssertTrue([findOptions1.sort isEqual:sort]);
+    findOptions1.sortDescriptors = sortDescriptors;
     XCTAssertEqual(findOptions1.limit, 37);
+    XCTAssertTrue([findOptions1.projection isEqual:projection]);
+    XCTAssertEqual(findOptions1.sortDescriptors.count, 2U);
 
     RLMFindOptions *findOptions2 = [[RLMFindOptions alloc] initWithProjection:projection
-                                                                         sort:sort];
+                                                              sortDescriptors:sortDescriptors];
     XCTAssertTrue([findOptions2.projection isEqual:projection]);
-    XCTAssertTrue([findOptions2.sort isEqual:sort]);
+    XCTAssertEqual(findOptions1.sortDescriptors.count, 2U);
     XCTAssertEqual(findOptions2.limit, 0);
 
     RLMFindOptions *findOptions3 = [[RLMFindOptions alloc] initWithLimit:37
                                                               projection:projection
-                                                                    sort:sort];
+                                                         sortDescriptors:sortDescriptors];
     XCTAssertTrue([findOptions3.projection isEqual:projection]);
-    XCTAssertTrue([findOptions3.sort isEqual:sort]);
+    XCTAssertEqual(findOptions1.sortDescriptors.count, 2U);
     XCTAssertEqual(findOptions3.limit, 37);
 
     findOptions3.projection = nil;
-    findOptions3.sort = nil;
+    findOptions3.sortDescriptors = @[];
     XCTAssertNil(findOptions3.projection);
-    XCTAssertNil(findOptions3.sort);
+    XCTAssertEqual(findOptions3.sortDescriptors.count, 0U);
 
     RLMFindOptions *findOptions4 = [[RLMFindOptions alloc] initWithProjection:nil
-                                                                         sort:nil];
+                                                              sortDescriptors:@[]];
     XCTAssertNil(findOptions4.projection);
-    XCTAssertNil(findOptions4.sort);
+    XCTAssertEqual(findOptions4.sortDescriptors.count, 0U);
     XCTAssertEqual(findOptions4.limit, 0);
 }
 
@@ -2292,7 +2289,7 @@ static const NSInteger NUMBER_OF_BIG_OBJECTS = 2;
     [self waitForExpectationsWithTimeout:60.0 handler:nil];
 
     XCTestExpectation *findExpectation = [self expectationWithDescription:@"should find documents"];
-    RLMFindOptions *options = [[RLMFindOptions alloc] initWithLimit:0 projection:nil sort:nil];
+    RLMFindOptions *options = [[RLMFindOptions alloc] initWithLimit:0 projection:nil sortDescriptors:@[]];
     [collection findWhere:@{@"name": @"fido", @"breed": @"cane corso"}
                   options:options
                completion:^(NSArray<NSDictionary *> *documents, NSError *error) {
@@ -2321,7 +2318,7 @@ static const NSInteger NUMBER_OF_BIG_OBJECTS = 2;
     [self waitForExpectationsWithTimeout:60.0 handler:nil];
 
     XCTestExpectation *findExpectation = [self expectationWithDescription:@"should find documents"];
-    RLMFindOptions *options = [[RLMFindOptions alloc] initWithLimit:0 projection:nil sort:nil];
+    RLMFindOptions *options = [[RLMFindOptions alloc] initWithLimit:0 projection:nil sortDescriptors:@[]];
     [collection findWhere:@{@"name": @"fido", @"breed": @"cane corso"}
                   options:options
                completion:^(NSArray<NSDictionary *> *documents, NSError *error) {
@@ -2516,9 +2513,10 @@ static const NSInteger NUMBER_OF_BIG_OBJECTS = 2;
     RLMMongoDatabase *database = [client databaseWithName:@"test_data"];
     RLMMongoCollection *collection = [database collectionWithName:@"Dog"];
 
+    NSArray<RLMSortDescriptor *> *sortDescriptors = @[[RLMSortDescriptor sortDescriptorWithKeyPath:@"name" ascending:true], [RLMSortDescriptor sortDescriptorWithKeyPath:@"breed" ascending:true]];
     RLMFindOneAndModifyOptions *findAndModifyOptions = [[RLMFindOneAndModifyOptions alloc]
                                                         initWithProjection:@{@"name" : @1, @"breed" : @1}
-                                                        sort:@{@"name" : @1, @"breed" : @1}
+                                                        sortDescriptors:sortDescriptors
                                                         upsert:YES
                                                         shouldReturnNewDocument:YES];
 
@@ -2623,10 +2621,10 @@ static const NSInteger NUMBER_OF_BIG_OBJECTS = 2;
 
     XCTestExpectation *findOneAndDeleteExpectation2 = [self expectationWithDescription:@"should find one and delete"];
     NSDictionary<NSString *, id<RLMBSON>> *projection = @{@"name": @1, @"breed": @1};
-    NSDictionary<NSString *, id<RLMBSON>> *sort = @{@"_id" : @1, @"breed" : @1};
+    NSArray<RLMSortDescriptor *> *sortDescriptors = @[[RLMSortDescriptor sortDescriptorWithKeyPath:@"_id" ascending:true], [RLMSortDescriptor sortDescriptorWithKeyPath:@"breed" ascending:true]];
     RLMFindOneAndModifyOptions *findOneAndModifyOptions = [[RLMFindOneAndModifyOptions alloc]
                                                            initWithProjection:projection
-                                                           sort:sort
+                                                           sortDescriptors:sortDescriptors
                                                            upsert:YES
                                                            shouldReturnNewDocument:YES];
 

--- a/Realm/ObjectServerTests/SwiftMongoClientTests.swift
+++ b/Realm/ObjectServerTests/SwiftMongoClientTests.swift
@@ -56,22 +56,43 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
     }
 
     func testMongoOptions() {
-        let findOptions = FindOptions(1, nil, nil)
-        let findOptions1 = FindOptions(5, ["name": 1], ["_id": 1])
-        let findOptions2 = FindOptions(5, ["names": ["fido", "bob", "rex"]], ["_id": 1])
+        let findOptions = FindOptions(1, nil)
+        let findOptions1 = FindOptions(5, ["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)])
+        let findOptions2 = FindOptions(5, ["names": ["fido", "bob", "rex"]], [SortDescriptor(keyPath: "_id", ascending: true)])
 
         XCTAssertEqual(findOptions.limit, 1)
         XCTAssertEqual(findOptions.projection, nil)
-        XCTAssertEqual(findOptions.sort, nil)
+        XCTAssertEqual(findOptions.sortDescriptors, [])
 
         XCTAssertEqual(findOptions1.limit, 5)
         XCTAssertEqual(findOptions1.projection, ["name": 1])
-        XCTAssertEqual(findOptions1.sort, ["_id": 1])
+        XCTAssertEqual(findOptions1.sortDescriptors, [SortDescriptor(keyPath: "_id", ascending: true)])
         XCTAssertEqual(findOptions2.projection, ["names": ["fido", "bob", "rex"]])
 
-        let findModifyOptions = FindOneAndModifyOptions(["name": 1], ["_id": 1], true, true)
+        let findModifyOptions = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
         XCTAssertEqual(findModifyOptions.projection, ["name": 1])
-        XCTAssertEqual(findModifyOptions.sort, ["_id": 1])
+        XCTAssertEqual(findModifyOptions.sortDescriptors, [SortDescriptor(keyPath: "_id", ascending: true)])
+        XCTAssertTrue(findModifyOptions.upsert)
+        XCTAssertTrue(findModifyOptions.shouldReturnNewDocument)
+    }
+
+    func testMongoOptionsWithSortDescriptor() {
+        let findOptions = FindOptions(1, nil)
+        let findOptions1 = FindOptions(5, ["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)])
+        let findOptions2 = FindOptions(5, ["names": ["fido", "bob", "rex"]], [SortDescriptor(keyPath: "_id", ascending: true)])
+
+        XCTAssertEqual(findOptions.limit, 1)
+        XCTAssertEqual(findOptions.projection, nil)
+        XCTAssertEqual(findOptions.sortDescriptors, [])
+
+        XCTAssertEqual(findOptions1.limit, 5)
+        XCTAssertEqual(findOptions1.projection, ["name": 1])
+        XCTAssertEqual(findOptions1.sortDescriptors, [SortDescriptor(keyPath: "_id", ascending: true)])
+        XCTAssertEqual(findOptions2.projection, ["names": ["fido", "bob", "rex"]])
+
+        let findModifyOptions = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
+        XCTAssertEqual(findModifyOptions.projection, ["name": 1])
+        XCTAssertEqual(findModifyOptions.sortDescriptors, [SortDescriptor(keyPath: "_id", ascending: true)])
         XCTAssertTrue(findModifyOptions.upsert)
         XCTAssertTrue(findModifyOptions.shouldReturnNewDocument)
     }
@@ -124,7 +145,7 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
         let document: Document = ["name": "fido", "breed": "cane corso"]
         let document2: Document = ["name": "rex", "breed": "tibetan mastiff"]
         let document3: Document = ["name": "rex", "breed": "tibetan mastiff", "coat": ["fawn", "brown", "white"]]
-        let findOptions = FindOptions(1, nil, nil)
+        let findOptions = FindOptions(1, nil)
 
         let insertManyEx1 = expectation(description: "Insert many documents")
         collection.insertMany([document, document2, document3]) { result in
@@ -222,7 +243,7 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
         }
         wait(for: [findOneReplaceEx1], timeout: 20.0)
 
-        let options1 = FindOneAndModifyOptions(["name": 1], ["_id": 1], true, true)
+        let options1 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
         let findOneReplaceEx2 = expectation(description: "Find one document and replace")
         collection.findOneAndReplace(filter: document2, replacement: document3, options: options1) { result in
             switch result {
@@ -235,7 +256,7 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
         }
         wait(for: [findOneReplaceEx2], timeout: 20.0)
 
-        let options2 = FindOneAndModifyOptions(["name": 1], ["_id": 1], true, false)
+        let options2 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, false)
         let findOneReplaceEx3 = expectation(description: "Find one document and replace")
         collection.findOneAndReplace(filter: document, replacement: document2, options: options2) { result in
             switch result {
@@ -269,7 +290,7 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
         }
         wait(for: [findOneUpdateEx1], timeout: 20.0)
 
-        let options1 = FindOneAndModifyOptions(["name": 1], ["_id": 1], true, true)
+        let options1 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
         let findOneUpdateEx2 = expectation(description: "Find one document and update")
         collection.findOneAndUpdate(filter: document2, update: document3, options: options1) { result in
             switch result {
@@ -283,7 +304,7 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
         }
         wait(for: [findOneUpdateEx2], timeout: 20.0)
 
-        let options2 = FindOneAndModifyOptions(["name": 1], ["_id": 1], true, true)
+        let options2 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
         let findOneUpdateEx3 = expectation(description: "Find one document and update")
         collection.findOneAndUpdate(filter: document, update: document2, options: options2) { result in
             switch result {
@@ -327,7 +348,7 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
         }
         wait(for: [findOneDeleteEx1], timeout: 20.0)
 
-        let options1 = FindOneAndModifyOptions(["name": 1], ["_id": 1], false, false)
+        let options1 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], false, false)
         let findOneDeleteEx2 = expectation(description: "Find one document and delete")
         collection.findOneAndDelete(filter: document, options: options1) { result in
             switch result {
@@ -341,7 +362,7 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
         }
         wait(for: [findOneDeleteEx2], timeout: 20.0)
 
-        let options2 = FindOneAndModifyOptions(["name": 1], ["_id": 1])
+        let options2 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)])
         let findOneDeleteEx3 = expectation(description: "Find one document and delete")
         collection.findOneAndDelete(filter: document, options: options2) { result in
             switch result {
@@ -884,6 +905,52 @@ class AsyncAwaitMongoClientTests: SwiftSyncTestCase {
         return collection
     }
 
+    func testMongoFindSortOptions() async throws {
+        let collection = try await setupMongoCollection()
+
+        let document: Document = ["name": "fido", "breed": "cane corso"]
+        let document2: Document = ["name": "rex", "breed": "tibetan mastiff"]
+        let document3: Document = ["name": "rex", "breed": "cane corso"]
+        let document4: Document = ["name": "fido", "breed": "cane corso"]
+
+        let objectIds = try await collection.insertMany([document, document2, document3, document4])
+        XCTAssertNotNil(objectIds)
+        XCTAssertEqual(objectIds.count, 4)
+
+        let findOptions = FindOptions(0, nil, [SortDescriptor(keyPath: "name", ascending: true), SortDescriptor(keyPath: "breed", ascending: false)])
+        let fetchedDocuments = try await collection.find(filter: [:], options: findOptions)
+        XCTAssertEqual(fetchedDocuments.count, 4)
+        XCTAssertEqual(fetchedDocuments[0]["name"]??.stringValue, "fido")
+        XCTAssertEqual(fetchedDocuments[0]["breed"]??.stringValue, "cane corso")
+        XCTAssertEqual(fetchedDocuments[1]["name"]??.stringValue, "fido")
+        XCTAssertEqual(fetchedDocuments[1]["breed"]??.stringValue, "cane corso")
+        XCTAssertEqual(fetchedDocuments[2]["name"]??.stringValue, "rex")
+        XCTAssertEqual(fetchedDocuments[2]["breed"]??.stringValue, "tibetan mastiff")
+        XCTAssertEqual(fetchedDocuments[3]["name"]??.stringValue, "rex")
+        XCTAssertEqual(fetchedDocuments[3]["breed"]??.stringValue, "cane corso")
+
+        for try _ in 0...10 {
+            let findOptions2 = FindOptions(0, nil, [SortDescriptor(keyPath: "name", ascending: true), SortDescriptor(keyPath: "breed", ascending: false)])
+            let fetchedDocuments2 = try await collection.find(filter: [:], options: findOptions2)
+            XCTAssertEqual(fetchedDocuments[0]["name"], fetchedDocuments2[0]["name"])
+            XCTAssertEqual(fetchedDocuments[0]["breed"], fetchedDocuments2[0]["breed"])
+            XCTAssertEqual(fetchedDocuments[1]["name"], fetchedDocuments2[1]["name"])
+            XCTAssertEqual(fetchedDocuments[1]["breed"], fetchedDocuments2[1]["breed"])
+            XCTAssertEqual(fetchedDocuments[2]["name"], fetchedDocuments2[2]["name"])
+            XCTAssertEqual(fetchedDocuments[2]["breed"], fetchedDocuments2[2]["breed"])
+            XCTAssertEqual(fetchedDocuments[3]["name"], fetchedDocuments2[3]["name"])
+            XCTAssertEqual(fetchedDocuments[3]["breed"], fetchedDocuments2[3]["breed"])
+        }
+
+        let findOptions3 = FindOptions(0, nil, [SortDescriptor(keyPath: "breed", ascending: true), SortDescriptor(keyPath: "name", ascending: false)])
+        let fetchedDocuments3 = try await collection.find(filter: [:], options: findOptions3)
+        XCTAssertEqual(fetchedDocuments3.count, 4)
+        XCTAssertEqual(fetchedDocuments3[0]["name"]??.stringValue, "rex")
+        XCTAssertEqual(fetchedDocuments3[1]["breed"]??.stringValue, "cane corso")
+        XCTAssertEqual(fetchedDocuments3[3]["name"]??.stringValue, "rex")
+        XCTAssertEqual(fetchedDocuments3[3]["breed"]??.stringValue, "tibetan mastiff")
+    }
+
     func testMongoCollectionInsertOneAsyncAwait() async throws {
         let collection = try await setupMongoCollection()
 
@@ -928,7 +995,7 @@ class AsyncAwaitMongoClientTests: SwiftSyncTestCase {
         XCTAssertEqual(fetchedDocuments[3]["breed"]??.stringValue, "labradoodle")
 
         // Test filter all with option limit to one
-        let findOptions = FindOptions(1, nil, nil)
+        let findOptions = FindOptions(1, nil)
         let fetchedDocuments2 = try await collection.find(filter: [:], options: findOptions)
         XCTAssertEqual(fetchedDocuments2.count, 1)
         XCTAssertEqual(fetchedDocuments2[0]["name"]??.stringValue, "tomas")
@@ -961,7 +1028,7 @@ class AsyncAwaitMongoClientTests: SwiftSyncTestCase {
         XCTAssertEqual(fetchedOneDocument?["breed"]??.stringValue, "jack rusell")
 
         // Test findOne all with option limit
-        let findOptions = FindOptions(1, nil, nil)
+        let findOptions = FindOptions(1, nil)
         let fetchedOneDocument2 = try await collection.findOneDocument(filter: [:], options: findOptions)
         XCTAssertNotNil(fetchedOneDocument2)
 
@@ -989,12 +1056,12 @@ class AsyncAwaitMongoClientTests: SwiftSyncTestCase {
         XCTAssertNotNil(resultReplacedDocument)
         XCTAssertEqual(resultReplacedDocument?["name"]??.stringValue, "tomas") // shouldReturnNewDocument is false that is why returns old document
 
-        let options1 = FindOneAndModifyOptions(["name": 1], ["_id": 1], true, true)
+        let options1 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
         let resultReplacedDocument2 = try await collection.findOneAndReplace(filter: document1, replacement: document2, options: options1)
         XCTAssertNotNil(resultReplacedDocument2)
         XCTAssertEqual(resultReplacedDocument2?["name"]??.stringValue, "fito")
 
-        let options2 = FindOneAndModifyOptions(["name": 1], ["_id": 1], true, false)
+        let options2 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, false)
         let resultReplacedDocument3 = try await collection.findOneAndReplace(filter: document, replacement: document1, options: options2)
         XCTAssertNil(resultReplacedDocument3)
     }
@@ -1018,12 +1085,12 @@ class AsyncAwaitMongoClientTests: SwiftSyncTestCase {
         XCTAssertNotNil(resultUpdatedDocument)
         XCTAssertEqual(resultUpdatedDocument?["name"]??.stringValue, "tomas") // shouldReturnNewDocument is false that is why returns old document
 
-        let options1 = FindOneAndModifyOptions(["name": 1], ["_id": 1], true, true)
+        let options1 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
         let resultUpdatedDocument2 = try await collection.findOneAndUpdate(filter: document1, update: document2, options: options1)
         XCTAssertNotNil(resultUpdatedDocument2)
         XCTAssertEqual(resultUpdatedDocument2?["name"]??.stringValue, "fito")
 
-        let options2 = FindOneAndModifyOptions(["name": 1], ["_id": 1], true, false)
+        let options2 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, false)
         let resultUpdatedDocument3 = try await collection.findOneAndUpdate(filter: document, update: document1, options: options2)
         XCTAssertNil(resultUpdatedDocument3)
     }
@@ -1046,7 +1113,7 @@ class AsyncAwaitMongoClientTests: SwiftSyncTestCase {
         XCTAssertEqual(deletedDocument?["name"]??.stringValue, "tomas")
 
         // Document already deleted, should return nil
-        let options2 = FindOneAndModifyOptions(["name": 1], ["_id": 1])
+        let options2 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)])
         let deletedDocument3 = try await collection.findOneAndDelete(filter: document, options: options2)
         XCTAssertNil(deletedDocument3)
 

--- a/Realm/ObjectServerTests/SwiftMongoClientTests.swift
+++ b/Realm/ObjectServerTests/SwiftMongoClientTests.swift
@@ -56,43 +56,30 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
     }
 
     func testMongoOptions() {
-        let findOptions = FindOptions(1, nil)
-        let findOptions1 = FindOptions(5, ["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)])
-        let findOptions2 = FindOptions(5, ["names": ["fido", "bob", "rex"]], [SortDescriptor(keyPath: "_id", ascending: true)])
+        let findOptions = FindOptions(1)
+        let findOptions1 = FindOptions(5, ["name": 1], [["_id": 1]])
+        let findOptions2 = FindOptions(5, ["names": ["fido", "bob", "rex"]], [["_id": 1]])
+        let findOptions3 = FindOptions(5, ["names": ["fido", "bob", "rex"]], [["_id": 1], ["breed": 0]])
 
         XCTAssertEqual(findOptions.limit, 1)
         XCTAssertEqual(findOptions.projection, nil)
-        XCTAssertEqual(findOptions.sortDescriptors, [])
+        XCTAssertTrue(findOptions.sorting.isEmpty)
 
         XCTAssertEqual(findOptions1.limit, 5)
         XCTAssertEqual(findOptions1.projection, ["name": 1])
-        XCTAssertEqual(findOptions1.sortDescriptors, [SortDescriptor(keyPath: "_id", ascending: true)])
+        XCTAssertTrue(findOptions1.sorting == [["_id": 1]])
+
+        XCTAssertEqual(findOptions2.limit, 5)
         XCTAssertEqual(findOptions2.projection, ["names": ["fido", "bob", "rex"]])
+        XCTAssertTrue(findOptions2.sorting == [["_id": 1]])
 
-        let findModifyOptions = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
+        XCTAssertEqual(findOptions3.limit, 5)
+        XCTAssertEqual(findOptions3.projection, ["names": ["fido", "bob", "rex"]])
+        XCTAssertTrue(findOptions3.sorting == [["_id": 1], ["breed": 0]])
+
+        let findModifyOptions = FindOneAndModifyOptions(["name": 1], [["_id": 1], ["breed": 0]], true, true)
         XCTAssertEqual(findModifyOptions.projection, ["name": 1])
-        XCTAssertEqual(findModifyOptions.sortDescriptors, [SortDescriptor(keyPath: "_id", ascending: true)])
-        XCTAssertTrue(findModifyOptions.upsert)
-        XCTAssertTrue(findModifyOptions.shouldReturnNewDocument)
-    }
-
-    func testMongoOptionsWithSortDescriptor() {
-        let findOptions = FindOptions(1, nil)
-        let findOptions1 = FindOptions(5, ["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)])
-        let findOptions2 = FindOptions(5, ["names": ["fido", "bob", "rex"]], [SortDescriptor(keyPath: "_id", ascending: true)])
-
-        XCTAssertEqual(findOptions.limit, 1)
-        XCTAssertEqual(findOptions.projection, nil)
-        XCTAssertEqual(findOptions.sortDescriptors, [])
-
-        XCTAssertEqual(findOptions1.limit, 5)
-        XCTAssertEqual(findOptions1.projection, ["name": 1])
-        XCTAssertEqual(findOptions1.sortDescriptors, [SortDescriptor(keyPath: "_id", ascending: true)])
-        XCTAssertEqual(findOptions2.projection, ["names": ["fido", "bob", "rex"]])
-
-        let findModifyOptions = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
-        XCTAssertEqual(findModifyOptions.projection, ["name": 1])
-        XCTAssertEqual(findModifyOptions.sortDescriptors, [SortDescriptor(keyPath: "_id", ascending: true)])
+        XCTAssertEqual(findModifyOptions.sorting, [["_id": 1], ["breed": 0]])
         XCTAssertTrue(findModifyOptions.upsert)
         XCTAssertTrue(findModifyOptions.shouldReturnNewDocument)
     }
@@ -243,7 +230,7 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
         }
         wait(for: [findOneReplaceEx1], timeout: 20.0)
 
-        let options1 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
+        let options1 = FindOneAndModifyOptions(["name": 1], [["_id": 1]], true, true)
         let findOneReplaceEx2 = expectation(description: "Find one document and replace")
         collection.findOneAndReplace(filter: document2, replacement: document3, options: options1) { result in
             switch result {
@@ -256,7 +243,7 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
         }
         wait(for: [findOneReplaceEx2], timeout: 20.0)
 
-        let options2 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, false)
+        let options2 = FindOneAndModifyOptions(["name": 1], [["_id": 1]], true, false)
         let findOneReplaceEx3 = expectation(description: "Find one document and replace")
         collection.findOneAndReplace(filter: document, replacement: document2, options: options2) { result in
             switch result {
@@ -290,7 +277,7 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
         }
         wait(for: [findOneUpdateEx1], timeout: 20.0)
 
-        let options1 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
+        let options1 = FindOneAndModifyOptions(["name": 1], [["_id": 1]], true, true)
         let findOneUpdateEx2 = expectation(description: "Find one document and update")
         collection.findOneAndUpdate(filter: document2, update: document3, options: options1) { result in
             switch result {
@@ -304,7 +291,7 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
         }
         wait(for: [findOneUpdateEx2], timeout: 20.0)
 
-        let options2 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
+        let options2 = FindOneAndModifyOptions(["name": 1], [["_id": 1]], true, true)
         let findOneUpdateEx3 = expectation(description: "Find one document and update")
         collection.findOneAndUpdate(filter: document, update: document2, options: options2) { result in
             switch result {
@@ -348,7 +335,7 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
         }
         wait(for: [findOneDeleteEx1], timeout: 20.0)
 
-        let options1 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], false, false)
+        let options1 = FindOneAndModifyOptions(["name": 1], [["_id": 1]], false, false)
         let findOneDeleteEx2 = expectation(description: "Find one document and delete")
         collection.findOneAndDelete(filter: document, options: options1) { result in
             switch result {
@@ -362,7 +349,7 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
         }
         wait(for: [findOneDeleteEx2], timeout: 20.0)
 
-        let options2 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)])
+        let options2 = FindOneAndModifyOptions(["name": 1], [["_id": 1]])
         let findOneDeleteEx3 = expectation(description: "Find one document and delete")
         collection.findOneAndDelete(filter: document, options: options2) { result in
             switch result {
@@ -911,26 +898,27 @@ class AsyncAwaitMongoClientTests: SwiftSyncTestCase {
         let document: Document = ["name": "fido", "breed": "cane corso"]
         let document2: Document = ["name": "rex", "breed": "tibetan mastiff"]
         let document3: Document = ["name": "rex", "breed": "cane corso"]
-        let document4: Document = ["name": "fido", "breed": "cane corso"]
+        let document4: Document = ["name": "fido", "breed": "tibetan mastiff"]
 
         let objectIds = try await collection.insertMany([document, document2, document3, document4])
         XCTAssertNotNil(objectIds)
         XCTAssertEqual(objectIds.count, 4)
 
-        let findOptions = FindOptions(0, nil, [SortDescriptor(keyPath: "name", ascending: true), SortDescriptor(keyPath: "breed", ascending: false)])
+        let findOptions = FindOptions(0, nil, [["name": 1], ["breed": 1]])
         let fetchedDocuments = try await collection.find(filter: [:], options: findOptions)
         XCTAssertEqual(fetchedDocuments.count, 4)
         XCTAssertEqual(fetchedDocuments[0]["name"]??.stringValue, "fido")
         XCTAssertEqual(fetchedDocuments[0]["breed"]??.stringValue, "cane corso")
         XCTAssertEqual(fetchedDocuments[1]["name"]??.stringValue, "fido")
-        XCTAssertEqual(fetchedDocuments[1]["breed"]??.stringValue, "cane corso")
+        XCTAssertEqual(fetchedDocuments[1]["breed"]??.stringValue, "tibetan mastiff")
         XCTAssertEqual(fetchedDocuments[2]["name"]??.stringValue, "rex")
-        XCTAssertEqual(fetchedDocuments[2]["breed"]??.stringValue, "tibetan mastiff")
+        XCTAssertEqual(fetchedDocuments[2]["breed"]??.stringValue, "cane corso")
         XCTAssertEqual(fetchedDocuments[3]["name"]??.stringValue, "rex")
-        XCTAssertEqual(fetchedDocuments[3]["breed"]??.stringValue, "cane corso")
+        XCTAssertEqual(fetchedDocuments[3]["breed"]??.stringValue, "tibetan mastiff")
+
 
         for try _ in 0...10 {
-            let findOptions2 = FindOptions(0, nil, [SortDescriptor(keyPath: "name", ascending: true), SortDescriptor(keyPath: "breed", ascending: false)])
+            let findOptions2 = FindOptions(0, nil, [["name": 1], ["breed": 1]])
             let fetchedDocuments2 = try await collection.find(filter: [:], options: findOptions2)
             XCTAssertEqual(fetchedDocuments[0]["name"], fetchedDocuments2[0]["name"])
             XCTAssertEqual(fetchedDocuments[0]["breed"], fetchedDocuments2[0]["breed"])
@@ -942,11 +930,11 @@ class AsyncAwaitMongoClientTests: SwiftSyncTestCase {
             XCTAssertEqual(fetchedDocuments[3]["breed"], fetchedDocuments2[3]["breed"])
         }
 
-        let findOptions3 = FindOptions(0, nil, [SortDescriptor(keyPath: "breed", ascending: true), SortDescriptor(keyPath: "name", ascending: false)])
+        let findOptions3 = FindOptions(0, nil, [["breed": 1], ["name": 1]])
         let fetchedDocuments3 = try await collection.find(filter: [:], options: findOptions3)
         XCTAssertEqual(fetchedDocuments3.count, 4)
-        XCTAssertEqual(fetchedDocuments3[0]["name"]??.stringValue, "rex")
-        XCTAssertEqual(fetchedDocuments3[1]["breed"]??.stringValue, "cane corso")
+        XCTAssertEqual(fetchedDocuments3[0]["name"]??.stringValue, "fido")
+        XCTAssertEqual(fetchedDocuments3[0]["breed"]??.stringValue, "cane corso")
         XCTAssertEqual(fetchedDocuments3[3]["name"]??.stringValue, "rex")
         XCTAssertEqual(fetchedDocuments3[3]["breed"]??.stringValue, "tibetan mastiff")
     }
@@ -1056,12 +1044,12 @@ class AsyncAwaitMongoClientTests: SwiftSyncTestCase {
         XCTAssertNotNil(resultReplacedDocument)
         XCTAssertEqual(resultReplacedDocument?["name"]??.stringValue, "tomas") // shouldReturnNewDocument is false that is why returns old document
 
-        let options1 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
+        let options1 = FindOneAndModifyOptions(["name": 1], [["_id": 1]], true, true)
         let resultReplacedDocument2 = try await collection.findOneAndReplace(filter: document1, replacement: document2, options: options1)
         XCTAssertNotNil(resultReplacedDocument2)
         XCTAssertEqual(resultReplacedDocument2?["name"]??.stringValue, "fito")
 
-        let options2 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, false)
+        let options2 = FindOneAndModifyOptions(["name": 1], [["_id": 1]], true, false)
         let resultReplacedDocument3 = try await collection.findOneAndReplace(filter: document, replacement: document1, options: options2)
         XCTAssertNil(resultReplacedDocument3)
     }
@@ -1085,12 +1073,12 @@ class AsyncAwaitMongoClientTests: SwiftSyncTestCase {
         XCTAssertNotNil(resultUpdatedDocument)
         XCTAssertEqual(resultUpdatedDocument?["name"]??.stringValue, "tomas") // shouldReturnNewDocument is false that is why returns old document
 
-        let options1 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
+        let options1 = FindOneAndModifyOptions(["name": 1], [["_id": 1]], true, true)
         let resultUpdatedDocument2 = try await collection.findOneAndUpdate(filter: document1, update: document2, options: options1)
         XCTAssertNotNil(resultUpdatedDocument2)
         XCTAssertEqual(resultUpdatedDocument2?["name"]??.stringValue, "fito")
 
-        let options2 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, false)
+        let options2 = FindOneAndModifyOptions(["name": 1], [["_id": 1]], true, false)
         let resultUpdatedDocument3 = try await collection.findOneAndUpdate(filter: document, update: document1, options: options2)
         XCTAssertNil(resultUpdatedDocument3)
     }
@@ -1113,7 +1101,7 @@ class AsyncAwaitMongoClientTests: SwiftSyncTestCase {
         XCTAssertEqual(deletedDocument?["name"]??.stringValue, "tomas")
 
         // Document already deleted, should return nil
-        let options2 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)])
+        let options2 = FindOneAndModifyOptions(["name": 1], [["_id": 1]])
         let deletedDocument3 = try await collection.findOneAndDelete(filter: document, options: options2)
         XCTAssertNil(deletedDocument3)
 

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -2669,7 +2669,7 @@ class CombineObjectServerTests: SwiftSyncTestCase {
         let document: Document = ["name": "fido", "breed": "cane corso"]
         let document2: Document = ["name": "rex", "breed": "tibetan mastiff"]
         let document3: Document = ["name": "rex", "breed": "tibetan mastiff", "coat": ["fawn", "brown", "white"]]
-        let findOptions = FindOptions(1, nil, nil)
+        let findOptions = FindOptions(1, nil)
 
         collection.find(filter: [:], options: findOptions)
             .await(self) { findResult in
@@ -2788,7 +2788,7 @@ class CombineObjectServerTests: SwiftSyncTestCase {
 
         collection.findOneAndUpdate(filter: document, update: document2).await(self)
 
-        let options1 = FindOneAndModifyOptions(["name": 1], ["_id": 1], true, true)
+        let options1 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
         collection.findOneAndUpdate(filter: document2, update: document3, options: options1).await(self) { updateResult in
             guard let updateResult = updateResult else {
                 XCTFail("Should find")
@@ -2797,7 +2797,7 @@ class CombineObjectServerTests: SwiftSyncTestCase {
             XCTAssertEqual(updateResult["name"]??.stringValue, "john")
         }
 
-        let options2 = FindOneAndModifyOptions(["name": 1], ["_id": 1], true, true)
+        let options2 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
         collection.findOneAndUpdate(filter: document, update: document2, options: options2).await(self) { updateResult in
             guard let updateResult = updateResult else {
                 XCTFail("Should find")
@@ -2817,7 +2817,7 @@ class CombineObjectServerTests: SwiftSyncTestCase {
             XCTAssertNil(updateResult)
         }
 
-        let options1 = FindOneAndModifyOptions(["name": 1], ["_id": 1], true, true)
+        let options1 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
         collection.findOneAndReplace(filter: document2, replacement: document3, options: options1).await(self) { updateResult in
             guard let updateResult = updateResult else {
                 XCTFail("Should find")
@@ -2826,7 +2826,7 @@ class CombineObjectServerTests: SwiftSyncTestCase {
             XCTAssertEqual(updateResult["name"]??.stringValue, "john")
         }
 
-        let options2 = FindOneAndModifyOptions(["name": 1], ["_id": 1], true, false)
+        let options2 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, false)
         collection.findOneAndReplace(filter: document, replacement: document2, options: options2).await(self) { updateResult in
             XCTAssertNil(updateResult)
         }
@@ -2845,7 +2845,7 @@ class CombineObjectServerTests: SwiftSyncTestCase {
         }
 
         collection.insertMany([document]).await(self)
-        let options1 = FindOneAndModifyOptions(projection: ["name": 1], sort: ["_id": 1], upsert: false, shouldReturnNewDocument: false)
+        let options1 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], false, false)
         collection.findOneAndDelete(filter: document, options: options1).await(self) { deleteResult in
             XCTAssertNotNil(deleteResult)
         }
@@ -2854,7 +2854,7 @@ class CombineObjectServerTests: SwiftSyncTestCase {
         }
 
         collection.insertMany([document]).await(self)
-        let options2 = FindOneAndModifyOptions(["name": 1], ["_id": 1])
+        let options2 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)])
         collection.findOneAndDelete(filter: document, options: options2).await(self) { deleteResult in
             XCTAssertNotNil(deleteResult)
         }

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -2788,7 +2788,7 @@ class CombineObjectServerTests: SwiftSyncTestCase {
 
         collection.findOneAndUpdate(filter: document, update: document2).await(self)
 
-        let options1 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
+        let options1 = FindOneAndModifyOptions(["name": 1], [["_id": 1]], true, true)
         collection.findOneAndUpdate(filter: document2, update: document3, options: options1).await(self) { updateResult in
             guard let updateResult = updateResult else {
                 XCTFail("Should find")
@@ -2797,7 +2797,7 @@ class CombineObjectServerTests: SwiftSyncTestCase {
             XCTAssertEqual(updateResult["name"]??.stringValue, "john")
         }
 
-        let options2 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
+        let options2 = FindOneAndModifyOptions(["name": 1], [["_id": 1]], true, true)
         collection.findOneAndUpdate(filter: document, update: document2, options: options2).await(self) { updateResult in
             guard let updateResult = updateResult else {
                 XCTFail("Should find")
@@ -2817,7 +2817,7 @@ class CombineObjectServerTests: SwiftSyncTestCase {
             XCTAssertNil(updateResult)
         }
 
-        let options1 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, true)
+        let options1 = FindOneAndModifyOptions(["name": 1], [["_id": 1]], true, true)
         collection.findOneAndReplace(filter: document2, replacement: document3, options: options1).await(self) { updateResult in
             guard let updateResult = updateResult else {
                 XCTFail("Should find")
@@ -2826,7 +2826,7 @@ class CombineObjectServerTests: SwiftSyncTestCase {
             XCTAssertEqual(updateResult["name"]??.stringValue, "john")
         }
 
-        let options2 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], true, false)
+        let options2 = FindOneAndModifyOptions(["name": 1], [["_id": 1]], true, false)
         collection.findOneAndReplace(filter: document, replacement: document2, options: options2).await(self) { updateResult in
             XCTAssertNil(updateResult)
         }
@@ -2845,7 +2845,7 @@ class CombineObjectServerTests: SwiftSyncTestCase {
         }
 
         collection.insertMany([document]).await(self)
-        let options1 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)], false, false)
+        let options1 = FindOneAndModifyOptions(["name": 1], [["_id": 1]], false, false)
         collection.findOneAndDelete(filter: document, options: options1).await(self) { deleteResult in
             XCTAssertNotNil(deleteResult)
         }
@@ -2854,7 +2854,7 @@ class CombineObjectServerTests: SwiftSyncTestCase {
         }
 
         collection.insertMany([document]).await(self)
-        let options2 = FindOneAndModifyOptions(["name": 1], [SortDescriptor(keyPath: "_id", ascending: true)])
+        let options2 = FindOneAndModifyOptions(["name": 1], [["_id": 1]])
         collection.findOneAndDelete(filter: document, options: options2).await(self) { deleteResult in
             XCTAssertNotNil(deleteResult)
         }

--- a/Realm/RLMBSON.mm
+++ b/Realm/RLMBSON.mm
@@ -355,6 +355,16 @@ Bson RLMConvertRLMBSONToBson(id<RLMBSON> b) {
     }
 }
 
+BsonDocument RLMConvertRLMBSONArrayToBsonDocument(NSArray<id<RLMBSON>> *array) {
+    BsonDocument bsonDocument = BsonDocument{};
+    for (NSDictionary<NSString *, id<RLMBSON>> *item in array) {
+        [item enumerateKeysAndObjectsUsingBlock:[&](NSString *key, id<RLMBSON> bson, BOOL *) {
+            bsonDocument[key.UTF8String] = RLMConvertRLMBSONToBson(bson);
+        }];
+    }
+    return bsonDocument;
+}
+
 #pragma mark BsonToRLMBSON
 
 id<RLMBSON> RLMConvertBsonToRLMBSON(const Bson& b) {
@@ -399,4 +409,15 @@ id<RLMBSON> RLMConvertBsonToRLMBSON(const Bson& b) {
 
 id<RLMBSON> RLMConvertBsonDocumentToRLMBSON(std::optional<BsonDocument> b) {
     return b ? RLMConvertBsonToRLMBSON(*b) : nil;
+}
+
+NSArray<id<RLMBSON>> *RLMConvertBsonDocumentToRLMBSONArray(std::optional<BsonDocument> b) {
+    if (!b) {
+        return @[];
+    }
+    NSMutableArray<id<RLMBSON>> *array = [[NSMutableArray alloc] init];
+    for (const auto& [key, value] : *b) {
+        [array addObject:@{@(key.c_str()): RLMConvertBsonToRLMBSON(value)}];
+    }
+    return array;
 }

--- a/Realm/RLMBSON_Private.hpp
+++ b/Realm/RLMBSON_Private.hpp
@@ -26,5 +26,7 @@ using BsonDocument = IndexedMap<Bson>;
 }
 
 realm::bson::Bson RLMConvertRLMBSONToBson(id<RLMBSON> b);
+realm::bson::BsonDocument RLMConvertRLMBSONArrayToBsonDocument(NSArray<id<RLMBSON>> *array);
 id<RLMBSON> RLMConvertBsonToRLMBSON(const realm::bson::Bson& b);
 id<RLMBSON> RLMConvertBsonDocumentToRLMBSON(std::optional<realm::bson::BsonDocument> b);
+NSArray<id<RLMBSON>> *RLMConvertBsonDocumentToRLMBSONArray(std::optional<realm::bson::BsonDocument> b);

--- a/Realm/RLMFindOneAndModifyOptions.h
+++ b/Realm/RLMFindOneAndModifyOptions.h
@@ -20,6 +20,7 @@
 
 RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 @protocol RLMBSON;
+@class RLMSortDescriptor;
 
 /// Options to use when executing a `findOneAndUpdate`, `findOneAndReplace`,
 /// or `findOneAndDelete` command on a `RLMMongoCollection`.
@@ -29,7 +30,13 @@ RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 @property (nonatomic, nullable) id<RLMBSON> projection NS_REFINED_FOR_SWIFT;
 
 /// The order in which to return matching documents.
-@property (nonatomic, nullable) id<RLMBSON> sort NS_REFINED_FOR_SWIFT;
+@property (nonatomic, nullable) id<RLMBSON> sort NS_REFINED_FOR_SWIFT
+__attribute__((deprecated("Use `sortDescriptors` instead, which correctly sort more than one sort attribute", "sortDescriptors")));
+
+/// The order in which to return matching documents.
+/// - seeAlso ``RLMSortDescriptor``
+@property (nonatomic) NSArray<RLMSortDescriptor *>* sortDescriptors NS_REFINED_FOR_SWIFT;
+
 
 /// Whether or not to perform an upsert, default is false
 /// (only available for find_one_and_replace and find_one_and_update)
@@ -52,8 +59,22 @@ RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 - (instancetype)initWithProjection:(id<RLMBSON> _Nullable)projection
                               sort:(id<RLMBSON> _Nullable)sort
                             upsert:(BOOL)upsert
-           shouldReturnNewDocument:(BOOL)shouldReturnNewDocument NS_SWIFT_UNAVAILABLE("Please see FindOneAndModifyOptions");
+           shouldReturnNewDocument:(BOOL)shouldReturnNewDocument __deprecated
+     NS_SWIFT_UNAVAILABLE("Please see FindOneAndModifyOptions");
 
+/// Options to use when executing a `findOneAndUpdate`, `findOneAndReplace`,
+/// or `findOneAndDelete` command on a `RLMMongoCollection`.
+/// @param projection Limits the fields to return for all matching documents.
+/// @param sortDescriptors The order in which to return matching documents.
+/// @param upsert Whether or not to perform an upsert, default is false
+/// (only available for findOneAndReplace and findOneAndUpdate)
+/// @param shouldReturnNewDocument When true then the new document is returned,
+/// Otherwise the old document is returned (default),
+/// (only available for findOneAndReplace and findOneAndUpdate)
+- (instancetype)initWithProjection:(id<RLMBSON> _Nullable)projection
+                   sortDescriptors:(NSArray<RLMSortDescriptor *> *)sortDescriptors
+                            upsert:(BOOL)upsert
+           shouldReturnNewDocument:(BOOL)shouldReturnNewDocument;
 @end
 
 RLM_HEADER_AUDIT_END(nullability, sendability)

--- a/Realm/RLMFindOneAndModifyOptions.h
+++ b/Realm/RLMFindOneAndModifyOptions.h
@@ -31,11 +31,10 @@ RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /// The order in which to return matching documents.
 @property (nonatomic, nullable) id<RLMBSON> sort NS_REFINED_FOR_SWIFT
-__attribute__((deprecated("Use `sortDescriptors` instead, which correctly sort more than one sort attribute", "sortDescriptors")));
+__attribute__((deprecated("Use `sorting` instead, which correctly sort more than one sort attribute", "sorting")));
 
 /// The order in which to return matching documents.
-/// - seeAlso ``RLMSortDescriptor``
-@property (nonatomic) NSArray<RLMSortDescriptor *>* sortDescriptors NS_REFINED_FOR_SWIFT;
+@property (nonatomic) NSArray<id<RLMBSON>> *sorting NS_REFINED_FOR_SWIFT;
 
 
 /// Whether or not to perform an upsert, default is false
@@ -59,20 +58,21 @@ __attribute__((deprecated("Use `sortDescriptors` instead, which correctly sort m
 - (instancetype)initWithProjection:(id<RLMBSON> _Nullable)projection
                               sort:(id<RLMBSON> _Nullable)sort
                             upsert:(BOOL)upsert
-           shouldReturnNewDocument:(BOOL)shouldReturnNewDocument __deprecated
+           shouldReturnNewDocument:(BOOL)shouldReturnNewDocument
+__attribute__((deprecated("Please use `initWithProjection:sorting:upsert:shouldReturnNewDocument:`")))
      NS_SWIFT_UNAVAILABLE("Please see FindOneAndModifyOptions");
 
 /// Options to use when executing a `findOneAndUpdate`, `findOneAndReplace`,
 /// or `findOneAndDelete` command on a `RLMMongoCollection`.
 /// @param projection Limits the fields to return for all matching documents.
-/// @param sortDescriptors The order in which to return matching documents.
+/// @param sorting The order in which to return matching documents.
 /// @param upsert Whether or not to perform an upsert, default is false
 /// (only available for findOneAndReplace and findOneAndUpdate)
 /// @param shouldReturnNewDocument When true then the new document is returned,
 /// Otherwise the old document is returned (default),
 /// (only available for findOneAndReplace and findOneAndUpdate)
 - (instancetype)initWithProjection:(id<RLMBSON> _Nullable)projection
-                   sortDescriptors:(NSArray<RLMSortDescriptor *> *)sortDescriptors
+                           sorting:(NSArray<id<RLMBSON>> *)sorting
                             upsert:(BOOL)upsert
            shouldReturnNewDocument:(BOOL)shouldReturnNewDocument;
 @end

--- a/Realm/RLMFindOneAndModifyOptions.mm
+++ b/Realm/RLMFindOneAndModifyOptions.mm
@@ -41,14 +41,14 @@
 }
 
 - (instancetype)initWithProjection:(id<RLMBSON> _Nullable)projection
-                   sortDescriptors:(NSArray<RLMSortDescriptor *> *)sortDescriptors
+                           sorting:(NSArray<id<RLMBSON>> *)sorting
                             upsert:(BOOL)upsert
            shouldReturnNewDocument:(BOOL)shouldReturnNewDocument {
     if (self = [super init]) {
         self.upsert = upsert;
         self.shouldReturnNewDocument = shouldReturnNewDocument;
         self.projection = projection;
-        self.sortDescriptors = sortDescriptors;
+        self.sorting = sorting;
     }
     return self;
 }
@@ -65,16 +65,8 @@
     return RLMConvertBsonDocumentToRLMBSON(_options.sort_bson);
 }
 
-- (NSArray<RLMSortDescriptor *> *)sortDescriptors {
-    NSMutableArray<RLMSortDescriptor *> *sortDescriptors = [[NSMutableArray alloc] init];
-    for (auto it = _options.sort_bson->begin(); it != _options.sort_bson->end();) {
-        auto entry = *it;
-        RLMSortDescriptor *sortDescriptor = [RLMSortDescriptor sortDescriptorWithKeyPath:@(entry.first.c_str()) ascending:[(NSNumber *)RLMConvertBsonToRLMBSON(entry.second) boolValue]];
-        [sortDescriptors addObject:sortDescriptor];
-        it++;
-    }
-
-    return sortDescriptors;
+- (NSArray<id<RLMBSON>> *)sorting {
+    return RLMConvertBsonDocumentToRLMBSONArray(_options.sort_bson);
 }
 
 - (BOOL)upsert {
@@ -103,13 +95,8 @@
     }
 }
 
-- (void)setSortDescriptors:(NSArray<RLMSortDescriptor *> *)sortDescriptors {
-    auto bsonDocuments = realm::bson::BsonDocument{};
-    for (RLMSortDescriptor *sortDescriptor in sortDescriptors) {
-        NSNumber *ascending = sortDescriptor.ascending == TRUE ? [[NSNumber alloc]initWithInteger:1] :  [[NSNumber alloc]initWithInteger:-1];
-        bsonDocuments[sortDescriptor.keyPath.UTF8String] = RLMConvertRLMBSONToBson(ascending);
-    }
-    _options.sort_bson = bsonDocuments;
+- (void)setSorting:(NSArray<id<RLMBSON>> *)sorting {
+    _options.sort_bson = RLMConvertRLMBSONArrayToBsonDocument(sorting);
 }
 
 - (void)setUpsert:(BOOL)upsert {

--- a/Realm/RLMFindOptions.h
+++ b/Realm/RLMFindOptions.h
@@ -20,8 +20,6 @@
 
 RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
-@class RLMSortDescriptor;
-
 @protocol RLMBSON;
 
 /// Options to use when executing a `find` command on a `RLMMongoCollection`.
@@ -35,11 +33,10 @@ RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /// The order in which to return matching documents.
 @property (nonatomic, nullable) id<RLMBSON> sort NS_REFINED_FOR_SWIFT
-__attribute__((deprecated("Use `sortDescriptors` instead, which correctly sort more than one sort attribute", "sortDescriptors")));
+__attribute__((deprecated("Use `sorting` instead, which correctly sort more than one sort attribute", "sorting")));
 
 /// The order in which to return matching documents.
-/// - seeAlso ``RLMSortDescriptor``
-@property (nonatomic) NSArray<RLMSortDescriptor *> *sortDescriptors NS_REFINED_FOR_SWIFT;
+@property (nonatomic) NSArray<id<RLMBSON>> *sorting NS_REFINED_FOR_SWIFT;
 
 /// Options to use when executing a `find` command on a `RLMMongoCollection`.
 /// @param limit The maximum number of documents to return. Specifying 0 will return all documents.
@@ -47,7 +44,8 @@ __attribute__((deprecated("Use `sortDescriptors` instead, which correctly sort m
 /// @param sort The order in which to return matching documents.
 - (instancetype)initWithLimit:(NSInteger)limit
                    projection:(id<RLMBSON> _Nullable)projection
-                         sort:(id<RLMBSON> _Nullable)sort __deprecated
+                         sort:(id<RLMBSON> _Nullable)sort
+__attribute__((deprecated("Please use `initWithLimit:projection:sorting:`")))
     NS_SWIFT_UNAVAILABLE("Please see FindOption");
 
 
@@ -56,22 +54,23 @@ __attribute__((deprecated("Use `sortDescriptors` instead, which correctly sort m
 /// @param sort The order in which to return matching documents.
 - (instancetype)initWithProjection:(id<RLMBSON> _Nullable)projection
                               sort:(id<RLMBSON> _Nullable)sort __deprecated
+__attribute__((deprecated("Please use `initWithProjection:sorting:`")))
      NS_SWIFT_UNAVAILABLE("Please see FindOption");
 
 
 /// Options to use when executing a `find` command on a `RLMMongoCollection`.
 /// @param limit The maximum number of documents to return. Specifying 0 will return all documents.
 /// @param projection Limits the fields to return for all matching documents.
-/// @param sortDescriptors The order in which to return matching documents.
+/// @param sorting The order in which to return matching documents.
 - (instancetype)initWithLimit:(NSInteger)limit
                    projection:(id<RLMBSON> _Nullable)projection
-              sortDescriptors:(NSArray<RLMSortDescriptor *> *)sortDescriptors;
+                      sorting:(NSArray<id<RLMBSON>> *)sorting;
 
 /// Options to use when executing a `find` command on a `RLMMongoCollection`.
 /// @param projection Limits the fields to return for all matching documents.
-/// @param sortDescriptors The order in which to return matching documents.
+/// @param sorting The order in which to return matching documents.
 - (instancetype)initWithProjection:(id<RLMBSON> _Nullable)projection
-                   sortDescriptors:(NSArray<RLMSortDescriptor *> *)sortDescriptors;
+                           sorting:(NSArray<id<RLMBSON>> *)sorting;
 
 @end
 

--- a/Realm/RLMFindOptions.h
+++ b/Realm/RLMFindOptions.h
@@ -20,6 +20,8 @@
 
 RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 
+@class RLMSortDescriptor;
+
 @protocol RLMBSON;
 
 /// Options to use when executing a `find` command on a `RLMMongoCollection`.
@@ -32,7 +34,12 @@ RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 @property (nonatomic, nullable) id<RLMBSON> projection NS_REFINED_FOR_SWIFT;
 
 /// The order in which to return matching documents.
-@property (nonatomic, nullable) id<RLMBSON> sort NS_REFINED_FOR_SWIFT;
+@property (nonatomic, nullable) id<RLMBSON> sort NS_REFINED_FOR_SWIFT
+__attribute__((deprecated("Use `sortDescriptors` instead, which correctly sort more than one sort attribute", "sortDescriptors")));
+
+/// The order in which to return matching documents.
+/// - seeAlso ``RLMSortDescriptor``
+@property (nonatomic) NSArray<RLMSortDescriptor *> *sortDescriptors NS_REFINED_FOR_SWIFT;
 
 /// Options to use when executing a `find` command on a `RLMMongoCollection`.
 /// @param limit The maximum number of documents to return. Specifying 0 will return all documents.
@@ -40,15 +47,31 @@ RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
 /// @param sort The order in which to return matching documents.
 - (instancetype)initWithLimit:(NSInteger)limit
                    projection:(id<RLMBSON> _Nullable)projection
-                         sort:(id<RLMBSON> _Nullable)sort
-NS_SWIFT_UNAVAILABLE("Please see FindOption");
+                         sort:(id<RLMBSON> _Nullable)sort __deprecated
+    NS_SWIFT_UNAVAILABLE("Please see FindOption");
+
 
 /// Options to use when executing a `find` command on a `RLMMongoCollection`.
 /// @param projection Limits the fields to return for all matching documents.
 /// @param sort The order in which to return matching documents.
 - (instancetype)initWithProjection:(id<RLMBSON> _Nullable)projection
-                              sort:(id<RLMBSON> _Nullable)sort
-NS_SWIFT_UNAVAILABLE("Please see FindOption");
+                              sort:(id<RLMBSON> _Nullable)sort __deprecated
+     NS_SWIFT_UNAVAILABLE("Please see FindOption");
+
+
+/// Options to use when executing a `find` command on a `RLMMongoCollection`.
+/// @param limit The maximum number of documents to return. Specifying 0 will return all documents.
+/// @param projection Limits the fields to return for all matching documents.
+/// @param sortDescriptors The order in which to return matching documents.
+- (instancetype)initWithLimit:(NSInteger)limit
+                   projection:(id<RLMBSON> _Nullable)projection
+              sortDescriptors:(NSArray<RLMSortDescriptor *> *)sortDescriptors;
+
+/// Options to use when executing a `find` command on a `RLMMongoCollection`.
+/// @param projection Limits the fields to return for all matching documents.
+/// @param sortDescriptors The order in which to return matching documents.
+- (instancetype)initWithProjection:(id<RLMBSON> _Nullable)projection
+                   sortDescriptors:(NSArray<RLMSortDescriptor *> *)sortDescriptors;
 
 @end
 

--- a/Realm/RLMFindOptions.mm
+++ b/Realm/RLMFindOptions.mm
@@ -49,20 +49,20 @@
 
 - (instancetype)initWithLimit:(NSInteger)limit
                    projection:(id<RLMBSON> _Nullable)projection
-              sortDescriptors:(NSArray<RLMSortDescriptor *> *)sortDescriptors {
+                      sorting:(NSArray<id<RLMBSON>> *)sorting {
     if (self = [super init]) {
         self.projection = projection;
-        self.sortDescriptors = sortDescriptors;
+        self.sorting = sorting;
         self.limit = limit;
     }
     return self;
 }
 
 - (instancetype)initWithProjection:(id<RLMBSON> _Nullable)projection
-                   sortDescriptors:(NSArray<RLMSortDescriptor *> *)sortDescriptors {
+                           sorting:(NSArray<id<RLMBSON>> *)sorting {
     if (self = [super init]) {
         self.projection = projection;
-        self.sortDescriptors = sortDescriptors;
+        self.sorting = sorting;
     }
     return self;
 }
@@ -79,16 +79,8 @@
     return RLMConvertBsonDocumentToRLMBSON(_options.sort_bson);
 }
 
-- (NSArray<RLMSortDescriptor *> *)sortDescriptors {
-    NSMutableArray<RLMSortDescriptor *> *sortDescriptors = [[NSMutableArray alloc] init];
-    for (auto it = _options.sort_bson->begin(); it != _options.sort_bson->end();) {
-        auto entry = *it;
-        RLMSortDescriptor *sortDescriptor = [RLMSortDescriptor sortDescriptorWithKeyPath:@(entry.first.c_str()) ascending:[(NSNumber *)RLMConvertBsonToRLMBSON(entry.second) boolValue]];
-        [sortDescriptors addObject:sortDescriptor];
-        it++;
-    }
-
-    return sortDescriptors;
+- (NSArray<id<RLMBSON>> *)sorting {
+    return RLMConvertBsonDocumentToRLMBSONArray(_options.sort_bson);
 }
 
 - (void)setProjection:(id<RLMBSON>)projection {
@@ -109,13 +101,8 @@
     }
 }
 
-- (void)setSortDescriptors:(NSArray<RLMSortDescriptor *> *)sortDescriptors {
-    auto bsonDocuments = realm::bson::BsonDocument{};
-    for (RLMSortDescriptor *sortDescriptor in sortDescriptors) {
-        NSNumber *ascending = sortDescriptor.ascending == TRUE ? [[NSNumber alloc]initWithInteger:1] :  [[NSNumber alloc]initWithInteger:-1];
-        bsonDocuments[sortDescriptor.keyPath.UTF8String] = RLMConvertRLMBSONToBson(ascending);
-    }
-    _options.sort_bson = bsonDocuments;
+- (void)setSorting:(NSArray<id<RLMBSON>> *)sorting {
+    _options.sort_bson = RLMConvertRLMBSONArrayToBsonDocument(sorting);
 }
 
 - (NSInteger)limit {

--- a/RealmSwift/MongoClient.swift
+++ b/RealmSwift/MongoClient.swift
@@ -65,7 +65,7 @@ extension FindOptions {
     }
 
     /// The order in which to return matching documents.
-    @available(*, deprecated, message: "Use sortDescriptors")
+    @available(*, deprecated, message: "Use `sorting`")
     public var sort: Document? {
         get {
             return __sort.map(ObjectiveCSupport.convertBson)??.documentValue
@@ -76,12 +76,12 @@ extension FindOptions {
     }
 
     /// The order in which to return matching documents.
-    public var sortDescriptors: [SortDescriptor] {
+    public var sorting: [Document] {
         get {
-            __sortDescriptors.map { SortDescriptor(keyPath: $0.keyPath, ascending: $0.ascending) }
+            return __sorting.map(ObjectiveCSupport.convertBson).map({$0!.documentValue!})
         }
         set {
-            __sortDescriptors = newValue.compactMap { RLMSortDescriptor(keyPath: $0.keyPath, ascending: $0.ascending) }
+            __sorting = newValue.map(AnyBSON.init).map(ObjectiveCSupport.convertBson)
         }
     }
 
@@ -91,7 +91,7 @@ extension FindOptions {
     ///   - limit: The maximum number of documents to return. Specifying 0 will return all documents.
     ///   - projected: Limits the fields to return for all matching documents.
     ///   - sort: The order in which to return matching documents.
-    @available(*, deprecated, message: "Use init(limit:projection:sortDescriptors:)")
+    @available(*, deprecated, message: "Use init(limit:projection:sorting:)")
     public convenience init(_ limit: Int?, _ projection: Document?, _ sort: Document?) {
         self.init()
         self.limit = limit ?? 0
@@ -103,12 +103,12 @@ extension FindOptions {
     /// - Parameters:
     ///   - limit: The maximum number of documents to return. Specifying 0 will return all documents.
     ///   - projected: Limits the fields to return for all matching documents.
-    ///   - sortDescriptors: The order in which to return matching documents.
-    public convenience init(_ limit: Int = 0, _ projection: Document?, _ sortDescriptors: [SortDescriptor] = []) {
+    ///   - sorting: The order in which to return matching documents.
+    public convenience init(_ limit: Int = 0, _ projection: Document? = nil, _ sorting: [Document] = []) {
         self.init()
         self.limit = limit
         self.projection = projection
-        self.sortDescriptors = sortDescriptors
+        self.sorting = sorting
     }
 
     /// Options to use when executing a `find` command on a `MongoCollection`.
@@ -116,7 +116,7 @@ extension FindOptions {
     ///   - limit: The maximum number of documents to return. Specifying 0 will return all documents.
     ///   - projected: Limits the fields to return for all matching documents.
     ///   - sort: The order in which to return matching documents.
-    @available(*, deprecated, message: "Use init(limit:projection:sortDescriptors:)")
+    @available(*, deprecated, message: "Use init(limit:projection:sorting:)")
     public convenience init(limit: Int?, projection: Document?, sort: Document?) {
         self.init(limit, projection, sort)
     }
@@ -139,7 +139,7 @@ extension FindOneAndModifyOptions {
     }
 
     /// The order in which to return matching documents.
-    @available(*, deprecated, message: "Use sortDescriptors")
+    @available(*, deprecated, message: "Use `sorting`")
     public var sort: Document? {
         get {
             return __sort.map(ObjectiveCSupport.convertBson)??.documentValue
@@ -150,12 +150,12 @@ extension FindOneAndModifyOptions {
     }
 
     /// The order in which to return matching documents, defined by `SortDescriptor`
-    public var sortDescriptors: [SortDescriptor] {
+    public var sorting: [Document] {
         get {
-            __sortDescriptors.map { SortDescriptor(keyPath: $0.keyPath, ascending: $0.ascending) }
+            return __sorting.map(ObjectiveCSupport.convertBson).map({$0!.documentValue!})
         }
         set {
-            __sortDescriptors = newValue.compactMap { RLMSortDescriptor(keyPath: $0.keyPath, ascending: $0.ascending) }
+            __sorting = newValue.map(AnyBSON.init).map(ObjectiveCSupport.convertBson)
         }
     }
 
@@ -169,7 +169,7 @@ extension FindOneAndModifyOptions {
     ///   - shouldReturnNewDocument: When true then the new document is returned,
     ///   Otherwise the old document is returned (default)
     ///   (only available for findOneAndReplace and findOneAndUpdate)
-    @available(*, deprecated, message: "Use init(projection:sortDescriptors:upsert:shouldReturnNewDocument:)")
+    @available(*, deprecated, message: "Use init(projection:sorting:upsert:shouldReturnNewDocument:)")
     public convenience init(_ projection: Document?,
                             _ sort: Document?,
                             _ upsert: Bool=false,
@@ -185,19 +185,19 @@ extension FindOneAndModifyOptions {
     /// or `findOneAndDelete` command on a `MongoCollection`
     /// - Parameters:
     ///   - projection: Limits the fields to return for all matching documents.
-    ///   - sortDescriptors: The order in which to return matching documents.
+    ///   - sorting: The order in which to return matching documents.
     ///   - upsert: Whether or not to perform an upsert, default is false
     ///   (only available for findOneAndReplace and findOneAndUpdate)
     ///   - shouldReturnNewDocument: When true then the new document is returned,
     ///   Otherwise the old document is returned (default)
     ///   (only available for findOneAndReplace and findOneAndUpdate)
     public convenience init(_ projection: Document?,
-                            _ sortDescriptors: [SortDescriptor] = [],
+                            _ sorting: [Document] = [],
                             _ upsert: Bool=false,
                             _ shouldReturnNewDocument: Bool=false) {
         self.init()
         self.projection = projection
-        self.sortDescriptors = sortDescriptors
+        self.sorting = sorting
         self.upsert = upsert
         self.shouldReturnNewDocument = shouldReturnNewDocument
     }
@@ -212,7 +212,7 @@ extension FindOneAndModifyOptions {
     ///   - shouldReturnNewDocument: When true then the new document is returned,
     ///   Otherwise the old document is returned (default)
     ///   (only available for findOneAndReplace and findOneAndUpdate)
-    @available(*, deprecated, message: "Use init(projection:sortDescriptors:upsert:shouldReturnNewDocument:)")
+    @available(*, deprecated, message: "Use init(projection:sorting:upsert:shouldReturnNewDocument:)")
     public convenience init(projection: Document?,
                             sort: Document?,
                             upsert: Bool=false,

--- a/RealmSwift/MongoClient.swift
+++ b/RealmSwift/MongoClient.swift
@@ -65,6 +65,7 @@ extension FindOptions {
     }
 
     /// The order in which to return matching documents.
+    @available(*, deprecated, message: "Use sortDescriptors")
     public var sort: Document? {
         get {
             return __sort.map(ObjectiveCSupport.convertBson)??.documentValue
@@ -74,12 +75,23 @@ extension FindOptions {
         }
     }
 
+    /// The order in which to return matching documents.
+    public var sortDescriptors: [SortDescriptor] {
+        get {
+            __sortDescriptors.map { SortDescriptor(keyPath: $0.keyPath, ascending: $0.ascending) }
+        }
+        set {
+            __sortDescriptors = newValue.compactMap { RLMSortDescriptor(keyPath: $0.keyPath, ascending: $0.ascending) }
+        }
+    }
+
     // NEXT-MAJOR: there's no reason for limit to be optional here
     /// Options to use when executing a `find` command on a `MongoCollection`.
     /// - Parameters:
     ///   - limit: The maximum number of documents to return. Specifying 0 will return all documents.
     ///   - projected: Limits the fields to return for all matching documents.
     ///   - sort: The order in which to return matching documents.
+    @available(*, deprecated, message: "Use init(limit:projection:sortDescriptors:)")
     public convenience init(_ limit: Int?, _ projection: Document?, _ sort: Document?) {
         self.init()
         self.limit = limit ?? 0
@@ -91,10 +103,24 @@ extension FindOptions {
     /// - Parameters:
     ///   - limit: The maximum number of documents to return. Specifying 0 will return all documents.
     ///   - projected: Limits the fields to return for all matching documents.
+    ///   - sortDescriptors: The order in which to return matching documents.
+    public convenience init(_ limit: Int = 0, _ projection: Document?, _ sortDescriptors: [SortDescriptor] = []) {
+        self.init()
+        self.limit = limit
+        self.projection = projection
+        self.sortDescriptors = sortDescriptors
+    }
+
+    /// Options to use when executing a `find` command on a `MongoCollection`.
+    /// - Parameters:
+    ///   - limit: The maximum number of documents to return. Specifying 0 will return all documents.
+    ///   - projected: Limits the fields to return for all matching documents.
     ///   - sort: The order in which to return matching documents.
+    @available(*, deprecated, message: "Use init(limit:projection:sortDescriptors:)")
     public convenience init(limit: Int?, projection: Document?, sort: Document?) {
         self.init(limit, projection, sort)
     }
+
 }
 
 /// Options to use when executing a `findOneAndUpdate`, `findOneAndReplace`,
@@ -113,12 +139,23 @@ extension FindOneAndModifyOptions {
     }
 
     /// The order in which to return matching documents.
+    @available(*, deprecated, message: "Use sortDescriptors")
     public var sort: Document? {
         get {
             return __sort.map(ObjectiveCSupport.convertBson)??.documentValue
         }
         set {
             __sort = newValue.map(AnyBSON.init).map(ObjectiveCSupport.convertBson)
+        }
+    }
+
+    /// The order in which to return matching documents, defined by `SortDescriptor`
+    public var sortDescriptors: [SortDescriptor] {
+        get {
+            __sortDescriptors.map { SortDescriptor(keyPath: $0.keyPath, ascending: $0.ascending) }
+        }
+        set {
+            __sortDescriptors = newValue.compactMap { RLMSortDescriptor(keyPath: $0.keyPath, ascending: $0.ascending) }
         }
     }
 
@@ -132,6 +169,7 @@ extension FindOneAndModifyOptions {
     ///   - shouldReturnNewDocument: When true then the new document is returned,
     ///   Otherwise the old document is returned (default)
     ///   (only available for findOneAndReplace and findOneAndUpdate)
+    @available(*, deprecated, message: "Use init(projection:sortDescriptors:upsert:shouldReturnNewDocument:)")
     public convenience init(_ projection: Document?,
                             _ sort: Document?,
                             _ upsert: Bool=false,
@@ -147,12 +185,34 @@ extension FindOneAndModifyOptions {
     /// or `findOneAndDelete` command on a `MongoCollection`
     /// - Parameters:
     ///   - projection: Limits the fields to return for all matching documents.
+    ///   - sortDescriptors: The order in which to return matching documents.
+    ///   - upsert: Whether or not to perform an upsert, default is false
+    ///   (only available for findOneAndReplace and findOneAndUpdate)
+    ///   - shouldReturnNewDocument: When true then the new document is returned,
+    ///   Otherwise the old document is returned (default)
+    ///   (only available for findOneAndReplace and findOneAndUpdate)
+    public convenience init(_ projection: Document?,
+                            _ sortDescriptors: [SortDescriptor] = [],
+                            _ upsert: Bool=false,
+                            _ shouldReturnNewDocument: Bool=false) {
+        self.init()
+        self.projection = projection
+        self.sortDescriptors = sortDescriptors
+        self.upsert = upsert
+        self.shouldReturnNewDocument = shouldReturnNewDocument
+    }
+
+    /// Options to use when executing a `findOneAndUpdate`, `findOneAndReplace`,
+    /// or `findOneAndDelete` command on a `MongoCollection`
+    /// - Parameters:
+    ///   - projection: Limits the fields to return for all matching documents.
     ///   - sort: The order in which to return matching documents.
     ///   - upsert: Whether or not to perform an upsert, default is false
     ///   (only available for findOneAndReplace and findOneAndUpdate)
     ///   - shouldReturnNewDocument: When true then the new document is returned,
     ///   Otherwise the old document is returned (default)
     ///   (only available for findOneAndReplace and findOneAndUpdate)
+    @available(*, deprecated, message: "Use init(projection:sortDescriptors:upsert:shouldReturnNewDocument:)")
     public convenience init(projection: Document?,
                             sort: Document?,
                             upsert: Bool=false,


### PR DESCRIPTION
Added new API which allow using `RLMSortDescriptor` and  `SortDescriptor` to define parameters for sort options in MongoClient
Also deprecated the old API to be eliminated for next major version.