### PR TITLE
Add missing fields in `-[RLMRealmConfiguration copy]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ x.y.z Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
-* None.
+* Copying a `RLMRealmConfiguration` failed to copy several fields. This
+  resulted in migrations being passed the incorrect object type in Swift when
+  using the default configuration (since v10.34.0) or async open (since
+  v10.37.0). This also broke using the Events API in those two scenarios (since
+  v10.26.0 for default configuration and v10.37.0 for async open). ([#8190](https://github.com/realm/realm-swift/issues/8190))
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/ObjectServerTests/EventTests.swift
+++ b/Realm/ObjectServerTests/EventTests.swift
@@ -210,6 +210,23 @@ class SwiftEventTests: SwiftSyncTestCase {
                     ["SwiftPerson": ["deletions": [mutatedPersonJson]]])
     }
 
+    func testBasicWithAsyncOpen() throws {
+        let realm = try Realm.asyncOpen(configuration: self.config()).await(self)
+        let events = try XCTUnwrap(realm.events)
+
+        let personJson: NSDictionary = try scope(events, "create object") {
+            try realm.write {
+                let person = SwiftPerson(firstName: "Fred", lastName: "Q", age: 30)
+                realm.add(person)
+                return full(person)
+            }
+        }
+
+        let result = getEvents(expectedCount: 1)
+        assertEvent(result, activity: "create object", event: "write",
+                    ["SwiftPerson": ["insertions": [personJson]]])
+    }
+
     func testCustomEventRepresentation() throws {
         let realm = try openRealm(configuration: self.config())
         let events = realm.events!

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -128,6 +128,8 @@ NSString *RLMRealmPathForFile(NSString *fileName) {
     configuration->_migrationBlock = _migrationBlock;
     configuration->_shouldCompactOnLaunch = _shouldCompactOnLaunch;
     configuration->_customSchema = _customSchema;
+    configuration->_eventConfiguration = _eventConfiguration;
+    configuration->_migrationObjectClass = _migrationObjectClass;
     configuration->_initialSubscriptions = _initialSubscriptions;
     configuration->_rerunOnOpen = _rerunOnOpen;
     return configuration;


### PR DESCRIPTION
Fixes #8190.

Most of the changes here are just refactoring the migration tests to perform each test with four different ways to trigger the migration.