### PR TITLE
Remove incorrect @MainActor annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,10 @@ x.y.z Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
-* None.
+* Several schema initialization functions had incorrect `@MainActor`
+  annotations, resulting in runtime warnings if the first time a Realm was
+  opened was on a background thread
+  ([#8222](https://github.com/realm/realm-swift/issues/8222), since v10.34.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/RealmSwift/AsymmetricObject.swift
+++ b/RealmSwift/AsymmetricObject.swift
@@ -81,7 +81,7 @@ extension AsymmetricObject {
      It is not considered part of the public API.
      :nodoc:
      */
-    @MainActor public override final class func _getProperties() -> [RLMProperty] {
+    public override final class func _getProperties() -> [RLMProperty] {
         return ObjectUtil.getSwiftProperties(self)
     }
 

--- a/RealmSwift/EmbeddedObject.swift
+++ b/RealmSwift/EmbeddedObject.swift
@@ -114,7 +114,7 @@ extension EmbeddedObject: _RealmCollectionValueInsideOptional {
      It is not considered part of the public API.
      :nodoc:
      */
-    @MainActor public override final class func _getProperties() -> [RLMProperty] {
+    public override final class func _getProperties() -> [RLMProperty] {
         return ObjectUtil.getSwiftProperties(self)
     }
 

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -133,7 +133,7 @@ extension Object: _RealmCollectionValueInsideOptional {
      It is not considered part of the public API.
      :nodoc:
      */
-    @MainActor public override final class func _getProperties() -> [RLMProperty] {
+    public override final class func _getProperties() -> [RLMProperty] {
         return ObjectUtil.getSwiftProperties(self)
     }
 


### PR DESCRIPTION
These functions are called on whatever thread a Realm is first opened on, not the main thread.

Fixes #8222.