### PR TITLE
Allow support for implicit boolean queries on Swift's Type Safe Queries API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ Replace Xcode 14.3 binaries with 14.3.1, which has important bug fixes for Swift
   that it's impossible. ([#5662](https://github.com/realm/realm-cocoa/issues/5662)).
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
-* None.
+* Allow support for implicit boolean queries on Swift's Type Safe Queries API
+  ([#8212](https://github.com/realm/realm-swift/issues/8212)).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/RealmSwift/Query.swift
+++ b/RealmSwift/Query.swift
@@ -912,9 +912,9 @@ private func buildPredicate(_ root: QueryNode, subqueryCount: Int = 0) -> (Strin
             formatStr.append(prefix)
         }
         formatStr.append("(")
-        build(lhs)
+        build(lhs, isNewNode: true)
         formatStr.append(" \(op) ")
-        build(rhs)
+        build(rhs, isNewNode: true)
         formatStr.append(")")
     }
 
@@ -926,6 +926,13 @@ private func buildPredicate(_ root: QueryNode, subqueryCount: Int = 0) -> (Strin
         formatStr.append("}")
     }
 
+    func buildBool(_ node: QueryNode, isNot: Bool = false) {
+        if case let .keyPath(kp, _) = node {
+            formatStr.append(kp.joined(separator: "."))
+            formatStr.append(" == \(isNot ? "false" : "true")")
+        }
+    }
+
     func strOptions(_ options: StringOptions) -> String {
         if options == [] {
             return ""
@@ -933,17 +940,26 @@ private func buildPredicate(_ root: QueryNode, subqueryCount: Int = 0) -> (Strin
         return "[\(options.contains(.caseInsensitive) ? "c" : "")\(options.contains(.diacriticInsensitive) ? "d" : "")]"
     }
 
-    func build(_ node: QueryNode, prefix: String? = nil) {
+    func build(_ node: QueryNode, prefix: String? = nil, isNewNode: Bool = false) {
         switch node {
         case .constant(let value):
             formatStr.append("%@")
             arguments.add(value ?? NSNull())
         case .keyPath(let kp, let options):
+            if isNewNode {
+                buildBool(node)
+                return
+            }
             if options.contains(.requiresAny) {
                 formatStr.append("ANY ")
             }
             formatStr.append(kp.joined(separator: "."))
         case .not(let child):
+            if case .keyPath = child,
+               isNewNode {
+                buildBool(child, isNot: true)
+                return
+            }
             build(child, prefix: "NOT ")
         case .comparison(operator: let op, let lhs, let rhs, let options):
             switch op {
@@ -969,7 +985,7 @@ private func buildPredicate(_ root: QueryNode, subqueryCount: Int = 0) -> (Strin
             arguments.add(key)
         }
     }
-    build(root)
+    build(root, isNewNode: true)
     return (formatStr as String, (arguments as! [Any]))
 }
 

--- a/RealmSwift/Tests/ModernTestObjects.swift
+++ b/RealmSwift/Tests/ModernTestObjects.swift
@@ -356,6 +356,7 @@ protocol ModernEmbeddedTreeObject: EmbeddedObject {
 
 class ModernEmbeddedTreeObject1: EmbeddedObject, ModernEmbeddedTreeObject {
     @Persisted var value = 0
+    @Persisted var bool = false
     @Persisted var child: ModernEmbeddedTreeObject2?
     @Persisted var children: List<ModernEmbeddedTreeObject2>
 

--- a/RealmSwift/Tests/QueryTests.swift.gyb
+++ b/RealmSwift/Tests/QueryTests.swift.gyb
@@ -34,8 +34,7 @@ import RealmSwift
     import collections
     import itertools
     import sys
-    reload(sys)
-    sys.setdefaultencoding('utf-8')
+
 
     def lowerFirst(str):
         return str[0].lower() + str[1:]
@@ -434,6 +433,29 @@ class QueryTests: TestCase {
         % for property in optProperties:
         validateEqualsNil("${property.colName}", \Query<${property.className}>.${property.colName})
         % end
+    }
+
+    func testImplicitBooleanOperation() {
+        assertQuery(ModernAllTypesObject.self, "boolCol == true", count: 0, { $0.boolCol })
+        assertQuery(ModernAllTypesObject.self, "boolCol == false", count: 1, { !$0.boolCol })
+
+        initLinkedCollectionAggregatesObject()
+        assertQuery(LinkToModernAllTypesObject.self, "object.boolCol == true", count: 0, { $0.object.boolCol })
+        assertQuery(LinkToModernAllTypesObject.self, "object.boolCol == false", count: 1, { !$0.object.boolCol })
+
+        let object = ModernEmbeddedParentObject()
+        let nestedObject = ModernEmbeddedTreeObject1()
+        object.object = nestedObject
+        try! realm.write {
+            realm.add(object)
+        }
+        assertQuery(ModernEmbeddedParentObject.self, "object.bool == true", count: 0, { $0.object.bool })
+        assertQuery(ModernEmbeddedParentObject.self, "object.bool == false", count: 1, { !$0.object.bool })
+
+        assertQuery(ModernAllTypesObject.self, "((intCol == %@) && boolCol == true)", 0, count: 0, { $0.intCol == 0 && $0.boolCol })
+        assertQuery(ModernAllTypesObject.self, "(boolCol == true && (intCol == %@))", 0, count: 0, { $0.boolCol && $0.intCol == 0 })
+        assertQuery(ModernAllTypesObject.self, "((intCol == %@) || boolCol == false)", 0, count: 1, { $0.intCol == 0 || !$0.boolCol })
+        assertQuery(ModernAllTypesObject.self, "(boolCol == false || (intCol == %@))", 0, count: 1, { !$0.boolCol || $0.intCol == 0 })
     }
 
     func testEqualAnyRealmValue() {


### PR DESCRIPTION
Allow support for implicit boolean queries on Swift's Type Safe Queries API ([#8212](https://github.com/realm/realm-swift/issues/8212)).