### PR TITLE
Update docstrings

### DIFF
--- a/Realm/RLMUser.h
+++ b/Realm/RLMUser.h
@@ -69,7 +69,7 @@ RLM_SWIFT_SENDABLE RLM_FINAL // internally thread-safe
 
 /**
  The unique Atlas App Services string identifying this user.
- Note this is different from an identitiy: A user may have multiple identities but has a single indentifier. See RLMUserIdentity.
+ Note this is different from an identity: A user may have multiple identities but has a single identifier. See RLMUserIdentity.
  */
 @property (nonatomic, readonly) NSString *identifier NS_SWIFT_NAME(id);
 
@@ -77,18 +77,25 @@ RLM_SWIFT_SENDABLE RLM_FINAL // internally thread-safe
 @property (nonatomic, readonly) NSArray<RLMUserIdentity *> *identities;
 
 /**
- The user's refresh token used to access the Realm Applcation.
+ The user's refresh token used to access App Services.
 
- This is required to make HTTP requests to the Realm App's REST API
- for functionality not exposed natively. It should be treated as sensitive data.
- */
+ By default, refresh tokens expire 60 days after they are issued.
+ You can configure this time for your App's refresh tokens to be
+ anywhere between 30 minutes and 180 days.
+
+ You can configure the refresh token expiration time for all sessions in
+ an App from the Admin UI or Admin API.
+*/
 @property (nullable, nonatomic, readonly) NSString *refreshToken;
 
 /**
- The user's refresh token used to access the Realm Application.
+ The user's access token used to access App Services.
 
- This is required to make HTTP requests to Atlas App Services' REST API
- for functionality not exposed natively. It should be treated as sensitive data.
+ This is required to make HTTP requests to Atlas App Services like the Data API or GraphQL.
+ It should be treated as sensitive data.
+
+ The Realm SDK automatically manages access tokens and refreshes them
+ when they expire.
  */
 @property (nullable, nonatomic, readonly) NSString *accessToken;
 

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -30,8 +30,7 @@ import Realm
  enumerate over the linking objects that were present when the enumeration is begun, even if some of them are deleted or
  modified to no longer link to the target object during the enumeration.
 
- `LinkingObjects` can only be used as a property on `Object` models. Properties of this type must be declared as `let`
- and cannot be `dynamic`.
+ `LinkingObjects` can only be used as a property on `Object` models.
  */
 @frozen public struct LinkingObjects<Element: ObjectBase & RealmCollectionValue>: RealmCollectionImpl {
     // MARK: Initializers

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -31,9 +31,7 @@ import Realm.Private
  is opened as read-only.
 
  Lists can be filtered and sorted with the same predicates as `Results<Element>`.
-
- Properties of `List` type defined on `Object` subclasses must be declared as `let` and cannot be `dynamic`.
- */
+*/
 public final class List<Element: RealmCollectionValue>: RLMSwiftCollectionBase, RealmCollectionImpl {
     internal var lastAccessedNames: NSMutableArray?
 

--- a/RealmSwift/Map.swift
+++ b/RealmSwift/Map.swift
@@ -41,8 +41,6 @@ extension String: _MapKey { }
  is opened as read-only.
  
  A Map can be filtered and sorted with the same predicates as `Results<Value>`.
- 
- Properties of `Map` type defined on `Object` subclasses must be declared as `let` and cannot be `dynamic`.
 */
 public final class Map<Key: _MapKey, Value: RealmCollectionValue>: RLMSwiftCollectionBase {
 

--- a/RealmSwift/MutableSet.swift
+++ b/RealmSwift/MutableSet.swift
@@ -31,9 +31,7 @@ import Realm.Private
  is opened as read-only.
 
  MutableSet's can be filtered and sorted with the same predicates as `Results<Element>`.
-
- Properties of `MutableSet` type defined on `Object` subclasses must be declared as `let` and cannot be `dynamic`.
- */
+*/
 public final class MutableSet<Element: RealmCollectionValue>: RLMSwiftCollectionBase, RealmCollectionImpl {
     internal var lastAccessedNames: NSMutableArray?
 


### PR DESCRIPTION
Just a few updates to some docstrings
* Updated List, MutableSet, Map and LinkingObjects to be aligned with the new model declaration syntax.
* Updated `accessToken` and `refreshToken` to a more descriptive and accurate docstrings.
This can be merged by anyone if approved.