### PR TITLE
RCOCOA-2105 Fix crash when deleting a row from @ObservedSectionedResults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* Add `@ObservedSectionedResults.remove(atOffsets:, section:)` which adds the ability to 
+* Add `@ObservedSectionedResults.remove(atOffsets:section:)` which adds the ability to 
   remove a Realm Object when using `onDelete` on `ForEach` in a SwiftUI `List`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Add `@ObservedSectionedResults.remove(atOffsets:, section:)` which adds the ability to 
+  remove a Realm Object when using `onDelete` on `ForEach` in a SwiftUI `List`.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
-* None.
+* Deleting a Realm Object used in a `@ObservedSectionedResults` collection in `SwiftUI`
+  would cause a crash during the diff on the `View`. ([#8294](https://github.com/realm/realm-swift/issues/8294), since v10.29.0)
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/Tests/SwiftUITestHost/SwiftUITestHostApp.swift
+++ b/Realm/Tests/SwiftUITestHost/SwiftUITestHostApp.swift
@@ -445,10 +445,10 @@ struct ObservedSectionedResultsSearchableTestView: View {
             .navigationTitle("Reminders")
             .navigationBarItems(trailing:
                 Button("add") {
-                let realm = $reminders.wrappedValue.realm?.thaw()
-                try! realm?.write {
-                    realm?.add(ReminderList())
-                }
+                    let realm = $reminders.wrappedValue.realm?.thaw()
+                    try! realm?.write {
+                        realm?.add(ReminderList())
+                    }
                 }.accessibility(identifier: "addList"))
         }
     }
@@ -490,7 +490,7 @@ struct ObservedSectionedResultsConfiguration: View {
             .navigationTitle("Reminders")
             .navigationBarItems(leading:
                 Button("add A") {
-                let realm = $remindersA.wrappedValue.realm?.thaw()
+                    let realm = $remindersA.wrappedValue.realm?.thaw()
                     try! realm?.write {
                         realm?.add(ReminderList())
                     }
@@ -498,7 +498,7 @@ struct ObservedSectionedResultsConfiguration: View {
             )
             .navigationBarItems(trailing:
                 Button("add B") {
-                let realm = $remindersB.wrappedValue.realm?.thaw()
+                    let realm = $remindersB.wrappedValue.realm?.thaw()
                     try! realm?.write {
                         realm?.add(ReminderList())
                     }

--- a/Realm/Tests/SwiftUITestHost/SwiftUITestHostApp.swift
+++ b/Realm/Tests/SwiftUITestHost/SwiftUITestHostApp.swift
@@ -374,6 +374,8 @@ struct ObservedSectionedResultsKeyPathTestView: View {
                     Section(header: Text(section.key)) {
                         ForEach(section) { object in
                             ObservedResultsKeyPathTestRow(list: object)
+                        }.onDelete {
+                            $reminders.remove(atOffsets: $0, section: section)
                         }
                     }
                 }
@@ -443,7 +445,7 @@ struct ObservedSectionedResultsSearchableTestView: View {
             .navigationTitle("Reminders")
             .navigationBarItems(trailing:
                 Button("add") {
-                let realm = $reminders.wrappedValue.realm
+                let realm = $reminders.wrappedValue.realm?.thaw()
                 try! realm?.write {
                     realm?.add(ReminderList())
                 }
@@ -488,7 +490,7 @@ struct ObservedSectionedResultsConfiguration: View {
             .navigationTitle("Reminders")
             .navigationBarItems(leading:
                 Button("add A") {
-                    let realm = $remindersA.wrappedValue.realm
+                let realm = $remindersA.wrappedValue.realm?.thaw()
                     try! realm?.write {
                         realm?.add(ReminderList())
                     }
@@ -496,7 +498,7 @@ struct ObservedSectionedResultsConfiguration: View {
             )
             .navigationBarItems(trailing:
                 Button("add B") {
-                    let realm = $remindersB.wrappedValue.realm
+                let realm = $remindersB.wrappedValue.realm?.thaw()
                     try! realm?.write {
                         realm?.add(ReminderList())
                     }

--- a/Realm/Tests/SwiftUITestHostUITests/SwiftUITestHostUITests.swift
+++ b/Realm/Tests/SwiftUITestHostUITests/SwiftUITestHostUITests.swift
@@ -445,12 +445,12 @@ class SwiftUITests: XCTestCase {
         collectionViewsQuery.children(matching: .other).element(boundBy: 1).tap()
         collectionViewsQuery.children(matching: .cell).element(boundBy: 1).children(matching: .other).element(boundBy: 1).children(matching: .other).element.swipeLeft()
         collectionViewsQuery.buttons["Delete"].tap()
-
         XCTAssertEqual(realm.objects(ReminderList.self).count, 2)
 
         collectionViewsQuery.children(matching: .other).element(boundBy: 2).tap()
         collectionViewsQuery.children(matching: .cell).element(boundBy: 2).children(matching: .other).element(boundBy: 1).children(matching: .other).element.swipeLeft()
         collectionViewsQuery.buttons["Delete"].tap()
+        XCTAssertEqual(realm.objects(ReminderList.self).count, 1)
 
         collectionViewsQuery.children(matching: .other).element(boundBy: 1).tap()
         collectionViewsQuery.children(matching: .cell).element(boundBy: 1).children(matching: .other).element(boundBy: 1).children(matching: .other).element.swipeLeft()

--- a/Realm/Tests/SwiftUITestHostUITests/SwiftUITestHostUITests.swift
+++ b/Realm/Tests/SwiftUITestHostUITests/SwiftUITestHostUITests.swift
@@ -440,6 +440,22 @@ class SwiftUITests: XCTestCase {
             XCTAssertEqual(app.tables.firstMatch.cells.count, 3)
         }
         XCTAssertEqual(realm.objects(ReminderList.self).count, 3)
+
+        let collectionViewsQuery = XCUIApplication().collectionViews
+        collectionViewsQuery.children(matching: .other).element(boundBy: 1).tap()
+        collectionViewsQuery.children(matching: .cell).element(boundBy: 1).children(matching: .other).element(boundBy: 1).children(matching: .other).element.swipeLeft()
+        collectionViewsQuery.buttons["Delete"].tap()
+
+        XCTAssertEqual(realm.objects(ReminderList.self).count, 2)
+
+        collectionViewsQuery.children(matching: .other).element(boundBy: 2).tap()
+        collectionViewsQuery.children(matching: .cell).element(boundBy: 2).children(matching: .other).element(boundBy: 1).children(matching: .other).element.swipeLeft()
+        collectionViewsQuery.buttons["Delete"].tap()
+
+        collectionViewsQuery.children(matching: .other).element(boundBy: 1).tap()
+        collectionViewsQuery.children(matching: .cell).element(boundBy: 1).children(matching: .other).element(boundBy: 1).children(matching: .other).element.swipeLeft()
+        collectionViewsQuery.buttons["Delete"].tap()
+        XCTAssertEqual(realm.objects(ReminderList.self).count, 0)
     }
 
     @MainActor

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -665,7 +665,7 @@ extension Projection: _ObservedResultsValue { }
             value = results
 
             /*
-             Observing the sectioned results directly doesnt allow the SwiftUI diff to work
+             Observing the sectioned results directly doesn't allow the SwiftUI diff to work
              correctly as the previous state of the sectioned results will have the new values.
 
              An example of when this is an issue is when an item is deleted in a List containing sectioned results,

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -676,8 +676,9 @@ extension Projection: _ObservedResultsValue { }
              Each time the results observation callback is invoked and the SwiftUI View is redrawn the sectioned results will be updated.
              */
             sectionedResults = value.sectioned(sortDescriptors: sortDescriptors, sectionBlock).freeze()
-            token = self.objectWillChange.sink { [unowned self] _ in
-                sectionedResults = value.sectioned(sortDescriptors: sortDescriptors, sectionBlock).freeze()
+            token = self.objectWillChange.sink { [weak self] _ in
+                guard let self = self else { return }
+                self.sectionedResults = self.value.sectioned(sortDescriptors: self.sortDescriptors, self.sectionBlock).freeze()
             }
         }
 

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -752,7 +752,7 @@ extension Projection: _ObservedResultsValue { }
     public func remove(atOffsets offsets: IndexSet,
                        section: ResultsSection<Key, ResultType>) where ResultType: ObjectBase & ThreadConfined {
         write(wrappedValue) { collection in
-            collection.realm!.delete(offsets.map { section[$0].thaw()! })
+            collection.realm?.delete(offsets.compactMap { section[$0].thaw() ?? nil })
         }
     }
 

--- a/RealmSwift/Tests/SwiftUITests.swift
+++ b/RealmSwift/Tests/SwiftUITests.swift
@@ -735,6 +735,7 @@ class SwiftUITests: TestCase {
             // add another default inited object for filter comparison
             realm.add(object)
         }
+        realm.refresh()
         XCTAssertEqual(fullResults.wrappedValue.count, 1)
         XCTAssertEqual(fullResults.wrappedValue[0].key, "abc")
 
@@ -780,6 +781,7 @@ class SwiftUITests: TestCase {
             // add another default inited object for filter comparison
             realm.add(object)
         }
+        realm.refresh()
         XCTAssertEqual(fullResults.wrappedValue.count, 1)
         XCTAssertEqual(fullResults.wrappedValue[0].key, "abc")
 


### PR DESCRIPTION
Observing the sectioned results directly doesnt allow the SwiftUI diff to work correctly as the previous state of the sectioned results will have the new values. 

An example of when this is an issue is when an item is deleted in a List containing sectioned results, the diff needs a stable state of the previous transaction but due to the observation callback calling calculate_sections the collection will be brought up to date. 

The solution around this is to store a frozen copy of the sectioned results and observe the parent `Results` instead. Each time the results observation callback is invoked and the SwiftUI View is redrawn the sectioned results will be updated.