### PR TITLE
Add an installation example which tests dynamic linking with SPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,15 @@ x.y.z Release notes (yyyy-MM-dd)
   Swift Package Manager or by using a XCFramework as CocoaPods and Carthage do
   not yet support it.
 * Zips compatible with SPM's `.binaryTarget()` are now published as part of the
-  reases on Github.
   releases on Github.
-* Prebuilt XCFrameworks are now built with LTO enabled. This has insignificant
-  performance benefits, but cuts the size of the library by ~15%.
-* Prebuilt XCFrameworks are now built with LTO enabled. This has insgificant
-* performance benefits, but cuts the size of the library by ~15%.
 * Prebuilt XCFrameworks are now built with LTO enabled. This has insignificant
   performance benefits, but cuts the size of the library by ~15%.
 
 ### Fixed
 * Fix nested properties observation on a `Projections` not notifying when there is a property change.
     ([#8276](https://github.com/realm/realm-swift/issues/8276), since v10.34.0).
+* Fix undefined symbol error for `UIKit` when linking Realm to a framework using SPM.
+  ([#8308](https://github.com/realm/realm-swift/issues/8308), since v10.41.0)
 
 ### Breaking Changes
 * Legacy non-xcframework Carthage installations are no longer supported. Please

--- a/Jenkinsfile.publish
+++ b/Jenkinsfile.publish
@@ -104,7 +104,7 @@ pipeline {
         }
 
         excludes {
-          // Carthage is always dynamic, while SPM is magic
+          // Carthage is always dynamic
           exclude {
             axis {
               name 'linkage'
@@ -112,7 +112,7 @@ pipeline {
             }
             axis {
               name 'method'
-              values 'carthage', 'spm'
+              values 'carthage'
             }
           }
 

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -197,6 +197,7 @@ def doBuild() {
         }
       }
       parallelBuilds["Installation - ${platformName} CocoaPods static"] = installationTest(platform, 'cocoapods', carthageXcodeVersion, 'swift', 'static')
+      parallelBuilds["Installation - ${platformName} spm static"] = installationTest(platform, 'spm', carthageXcodeVersion, 'swift', 'static')
     }
     parallelBuilds['Installation - iOS Static'] = installationTest('ios', 'xcframework', carthageXcodeVersion, 'objc', 'static')
     parallelBuilds['Installation - XCFramework Evolution'] = xcframeworkEvolutionTest()

--- a/Package.swift
+++ b/Package.swift
@@ -249,7 +249,10 @@ let package = Package(
                 "Realm/RLMUserAPIKey.mm"
             ],
             publicHeadersPath: "include",
-            cxxSettings: cxxSettings
+            cxxSettings: cxxSettings,
+            linkerSettings: [
+                .linkedFramework("UIKit", .when(platforms: [.iOS, .macCatalyst, .tvOS, .watchOS]))
+            ]
         ),
         .target(
             name: "RealmSwift",

--- a/build.sh
+++ b/build.sh
@@ -59,7 +59,7 @@ command:
   test-swiftpm:         tests ObjC and Swift macOS frameworks via SwiftPM
   test-swiftui-ios:         tests SwiftUI framework UI tests
   test-swiftui-server-osx:  tests Server Sync in SwiftUI
-  verify:               verifies docs, osx, osx-swift, ios-static, ios-dynamic, ios-swift, ios-device, swiftui-ios in both Debug and Release configurations, swiftlint
+  verify:               verifies docs, osx, osx-swift, ios-static, ios-dynamic, ios-swift, ios-device, swiftui-ios in both Debug and Release configurations, swiftlint, ios-xcode-spm
   verify-osx-object-server:  downloads the Realm Object Server and runs the Objective-C and Swift integration tests
 
   docs:                 builds docs in docs/output
@@ -668,6 +668,7 @@ case "$COMMAND" in
         ;;
 
     verify-cocoapods-ios-dynamic)
+        cd examples/installation
         REALM_TEST_BRANCH="$sha" ./build.rb ios cocoapods
         ;;
 
@@ -768,6 +769,11 @@ case "$COMMAND" in
 
     "verify-xcframework")
         sh build.sh xcframework osx
+        exit 0
+        ;;
+
+    "verify-ios-xcode-spm")
+        REALM_TEST_BRANCH="$sha" sh build.sh test-ios-xcode-spm
         exit 0
         ;;
 

--- a/examples/installation/.gitignore
+++ b/examples/installation/.gitignore
@@ -6,3 +6,4 @@ CocoaPodsExample.xcworkspace
 CocoaPodsDynamicExample.xcworkspace
 Cartfile.resolved
 SwiftPackageManager.xcodeproj
+SwiftPackageManagerDynamic.xcodeproj

--- a/examples/installation/SwiftPackageManagerDynamic.notxcodeproj/project.pbxproj
+++ b/examples/installation/SwiftPackageManagerDynamic.notxcodeproj/project.pbxproj
@@ -1,0 +1,779 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		3FEC916A2A4D3B140044BFF5 /* SwiftExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC91692A4D3B140044BFF5 /* SwiftExampleApp.swift */; };
+		3FEC916E2A4D3B150044BFF5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3FEC916D2A4D3B150044BFF5 /* Assets.xcassets */; };
+		3FEC91722A4D3B150044BFF5 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3FEC91712A4D3B150044BFF5 /* Preview Assets.xcassets */; };
+		3FEC917A2A4D3DB90044BFF5 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 3FEC91792A4D3DB90044BFF5 /* Realm */; };
+		3FEC917C2A4D3DB90044BFF5 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FEC917B2A4D3DB90044BFF5 /* RealmSwift */; };
+		3FF673252A684E4400500A25 /* Framework1.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF6731F2A684E4400500A25 /* Framework1.framework */; platformFilters = (ios, macos, ); };
+		3FF673262A684E4400500A25 /* Framework1.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF6731F2A684E4400500A25 /* Framework1.framework */; platformFilters = (ios, macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3FF673362A684E4E00500A25 /* Framework2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF673302A684E4E00500A25 /* Framework2.framework */; platformFilters = (ios, maccatalyst, ); };
+		3FF673372A684E4E00500A25 /* Framework2.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF673302A684E4E00500A25 /* Framework2.framework */; platformFilters = (ios, maccatalyst, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3FF6733D2A684E7200500A25 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF6733C2A684E7200500A25 /* Realm */; };
+		3FF6733F2A684E7200500A25 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF6733E2A684E7200500A25 /* RealmSwift */; };
+		3FF673412A684E7700500A25 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF673402A684E7700500A25 /* Realm */; };
+		3FF673432A684E7700500A25 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF673422A684E7700500A25 /* RealmSwift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		3FF673232A684E4400500A25 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3FEC915E2A4D3B140044BFF5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3FF6731E2A684E4400500A25;
+			remoteInfo = Framework1;
+		};
+		3FF673342A684E4E00500A25 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3FEC915E2A4D3B140044BFF5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3FF6732F2A684E4E00500A25;
+			remoteInfo = Framework2;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		3FF673272A684E4400500A25 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				3FF673262A684E4400500A25 /* Framework1.framework in Embed Frameworks */,
+				3FF673372A684E4E00500A25 /* Framework2.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		3FEC91662A4D3B140044BFF5 /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3FEC91692A4D3B140044BFF5 /* SwiftExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExampleApp.swift; sourceTree = "<group>"; };
+		3FEC916D2A4D3B150044BFF5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		3FEC916F2A4D3B150044BFF5 /* SwiftExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SwiftExample.entitlements; sourceTree = "<group>"; };
+		3FEC91712A4D3B150044BFF5 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		3FF6731F2A684E4400500A25 /* Framework1.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework1.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3FF673302A684E4E00500A25 /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		3FEC91632A4D3B140044BFF5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3FF673252A684E4400500A25 /* Framework1.framework in Frameworks */,
+				3FF673362A684E4E00500A25 /* Framework2.framework in Frameworks */,
+				3FEC917A2A4D3DB90044BFF5 /* Realm in Frameworks */,
+				3FEC917C2A4D3DB90044BFF5 /* RealmSwift in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3FF6731C2A684E4400500A25 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3FF6733D2A684E7200500A25 /* Realm in Frameworks */,
+				3FF6733F2A684E7200500A25 /* RealmSwift in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3FF6732D2A684E4E00500A25 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3FF673412A684E7700500A25 /* Realm in Frameworks */,
+				3FF673432A684E7700500A25 /* RealmSwift in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		3FEC915D2A4D3B140044BFF5 = {
+			isa = PBXGroup;
+			children = (
+				3FEC91682A4D3B140044BFF5 /* Source */,
+				3FEC91672A4D3B140044BFF5 /* Products */,
+				3FF6733B2A684E7200500A25 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		3FEC91672A4D3B140044BFF5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3FEC91662A4D3B140044BFF5 /* App.app */,
+				3FF6731F2A684E4400500A25 /* Framework1.framework */,
+				3FF673302A684E4E00500A25 /* Framework2.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3FEC91682A4D3B140044BFF5 /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				3FEC91702A4D3B150044BFF5 /* Preview Content */,
+				3FEC916D2A4D3B150044BFF5 /* Assets.xcassets */,
+				3FEC916F2A4D3B150044BFF5 /* SwiftExample.entitlements */,
+				3FEC91692A4D3B140044BFF5 /* SwiftExampleApp.swift */,
+			);
+			path = Source;
+			sourceTree = "<group>";
+		};
+		3FEC91702A4D3B150044BFF5 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				3FEC91712A4D3B150044BFF5 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		3FF6733B2A684E7200500A25 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		3FF6731A2A684E4400500A25 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3FF6732B2A684E4E00500A25 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		3FEC91652A4D3B140044BFF5 /* App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3FEC91752A4D3B150044BFF5 /* Build configuration list for PBXNativeTarget "App" */;
+			buildPhases = (
+				3FEC91622A4D3B140044BFF5 /* Sources */,
+				3FEC91632A4D3B140044BFF5 /* Frameworks */,
+				3FEC91642A4D3B140044BFF5 /* Resources */,
+				3FF673272A684E4400500A25 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3FF673242A684E4400500A25 /* PBXTargetDependency */,
+				3FF673352A684E4E00500A25 /* PBXTargetDependency */,
+			);
+			name = App;
+			packageProductDependencies = (
+				3FEC91792A4D3DB90044BFF5 /* Realm */,
+				3FEC917B2A4D3DB90044BFF5 /* RealmSwift */,
+			);
+			productName = SwiftPM;
+			productReference = 3FEC91662A4D3B140044BFF5 /* App.app */;
+			productType = "com.apple.product-type.application";
+		};
+		3FF6731E2A684E4400500A25 /* Framework1 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3FF6732A2A684E4400500A25 /* Build configuration list for PBXNativeTarget "Framework1" */;
+			buildPhases = (
+				3FF6731A2A684E4400500A25 /* Headers */,
+				3FF6731B2A684E4400500A25 /* Sources */,
+				3FF6731C2A684E4400500A25 /* Frameworks */,
+				3FF6731D2A684E4400500A25 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Framework1;
+			packageProductDependencies = (
+				3FF6733C2A684E7200500A25 /* Realm */,
+				3FF6733E2A684E7200500A25 /* RealmSwift */,
+			);
+			productName = Framework1;
+			productReference = 3FF6731F2A684E4400500A25 /* Framework1.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		3FF6732F2A684E4E00500A25 /* Framework2 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3FF673382A684E4E00500A25 /* Build configuration list for PBXNativeTarget "Framework2" */;
+			buildPhases = (
+				3FF6732B2A684E4E00500A25 /* Headers */,
+				3FF6732C2A684E4E00500A25 /* Sources */,
+				3FF6732D2A684E4E00500A25 /* Frameworks */,
+				3FF6732E2A684E4E00500A25 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Framework2;
+			packageProductDependencies = (
+				3FF673402A684E7700500A25 /* Realm */,
+				3FF673422A684E7700500A25 /* RealmSwift */,
+			);
+			productName = Framework2;
+			productReference = 3FF673302A684E4E00500A25 /* Framework2.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		3FEC915E2A4D3B140044BFF5 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					3FEC91652A4D3B140044BFF5 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+					3FF6731E2A684E4400500A25 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+					3FF6732F2A684E4E00500A25 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
+			};
+			buildConfigurationList = 3FEC91612A4D3B140044BFF5 /* Build configuration list for PBXProject "SwiftPackageManagerDynamic" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 3FEC915D2A4D3B140044BFF5;
+			packageReferences = (
+				3FEC91782A4D3DB90044BFF5 /* XCRemoteSwiftPackageReference "realm-swift" */,
+			);
+			productRefGroup = 3FEC91672A4D3B140044BFF5 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				3FEC91652A4D3B140044BFF5 /* App */,
+				3FF6731E2A684E4400500A25 /* Framework1 */,
+				3FF6732F2A684E4E00500A25 /* Framework2 */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		3FEC91642A4D3B140044BFF5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3FEC916E2A4D3B150044BFF5 /* Assets.xcassets in Resources */,
+				3FEC91722A4D3B150044BFF5 /* Preview Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3FF6731D2A684E4400500A25 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3FF6732E2A684E4E00500A25 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		3FEC91622A4D3B140044BFF5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3FEC916A2A4D3B140044BFF5 /* SwiftExampleApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3FF6731B2A684E4400500A25 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3FF6732C2A684E4E00500A25 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		3FF673242A684E4400500A25 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3FF6731E2A684E4400500A25 /* Framework1 */;
+			targetProxy = 3FF673232A684E4400500A25 /* PBXContainerItemProxy */;
+		};
+		3FF673352A684E4E00500A25 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3FF6732F2A684E4E00500A25 /* Framework2 */;
+			targetProxy = 3FF673342A684E4E00500A25 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		3FEC91732A4D3B150044BFF5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		3FEC91742A4D3B150044BFF5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		3FEC91762A4D3B150044BFF5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Source/SwiftExample.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Source/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.Realm.App;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "xrsimulator xros watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,7";
+			};
+			name = Debug;
+		};
+		3FEC91772A4D3B150044BFF5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Source/SwiftExample.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Source/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.Realm.App;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "xrsimulator xros watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,7";
+			};
+			name = Release;
+		};
+		3FF673282A684E4400500A25 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = io.Realm.Framework1;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "$(AVAILABLE_PLATFORMS)";
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,6,7";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		3FF673292A684E4400500A25 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = io.Realm.Framework1;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "$(AVAILABLE_PLATFORMS)";
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,6,7";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		3FF673392A684E4E00500A25 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = io.Realm.Framework2;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "$(AVAILABLE_PLATFORMS)";
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,6,7";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		3FF6733A2A684E4E00500A25 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = io.Realm.Framework2;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "$(AVAILABLE_PLATFORMS)";
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,6,7";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		3FEC91612A4D3B140044BFF5 /* Build configuration list for PBXProject "SwiftPackageManagerDynamic" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3FEC91732A4D3B150044BFF5 /* Debug */,
+				3FEC91742A4D3B150044BFF5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3FEC91752A4D3B150044BFF5 /* Build configuration list for PBXNativeTarget "App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3FEC91762A4D3B150044BFF5 /* Debug */,
+				3FEC91772A4D3B150044BFF5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3FF6732A2A684E4400500A25 /* Build configuration list for PBXNativeTarget "Framework1" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3FF673282A684E4400500A25 /* Debug */,
+				3FF673292A684E4400500A25 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3FF673382A684E4E00500A25 /* Build configuration list for PBXNativeTarget "Framework2" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3FF673392A684E4E00500A25 /* Debug */,
+				3FF6733A2A684E4E00500A25 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		3FEC91782A4D3DB90044BFF5 /* XCRemoteSwiftPackageReference "realm-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/realm-swift.git";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		3FEC91792A4D3DB90044BFF5 /* Realm */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FEC91782A4D3DB90044BFF5 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = Realm;
+		};
+		3FEC917B2A4D3DB90044BFF5 /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FEC91782A4D3DB90044BFF5 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = RealmSwift;
+		};
+		3FF6733C2A684E7200500A25 /* Realm */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FEC91782A4D3DB90044BFF5 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = Realm;
+		};
+		3FF6733E2A684E7200500A25 /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FEC91782A4D3DB90044BFF5 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = RealmSwift;
+		};
+		3FF673402A684E7700500A25 /* Realm */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FEC91782A4D3DB90044BFF5 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = Realm;
+		};
+		3FF673422A684E7700500A25 /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FEC91782A4D3DB90044BFF5 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = RealmSwift;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 3FEC915E2A4D3B140044BFF5 /* Project object */;
+}

--- a/examples/installation/build.rb
+++ b/examples/installation/build.rb
@@ -131,26 +131,27 @@ def download_realm(platform, method, static)
     sh 'carthage', 'update', '--use-xcframeworks', '--platform', platformName
 
   when 'spm'
+    project = static ? 'SwiftPackageManager' : 'SwiftPackageManagerDynamic'
     # We have to hide the spm example from carthage because otherwise
     # it'll fetch the example's package dependencies as part of deciding
     # what to build from this repo.
-    unless File.symlink? 'SwiftPackageManager.xcodeproj/project.pbxproj'
-      FileUtils.mkdir_p 'SwiftPackageManager.xcodeproj'
-      File.symlink '../SwiftPackageManager.notxcodeproj/project.pbxproj',
-                   'SwiftPackageManager.xcodeproj/project.pbxproj'
+    unless File.symlink? "#{project}.xcodeproj/project.pbxproj"
+      FileUtils.mkdir_p "#{project}.xcodeproj"
+      File.symlink "../#{project}.notxcodeproj/project.pbxproj",
+                   "#{project}.xcodeproj/project.pbxproj"
     end
 
     # Update the XcodeProj to reference the requested branch or version
     if TEST_RELEASE
-      replace_in_file 'SwiftPackageManager.xcodeproj/project.pbxproj',
+      replace_in_file "#{project}.xcodeproj/project.pbxproj",
         /(branch|version) = .*;/, "version = #{TEST_RELEASE};",
         /kind = .*;/, "kind = exactVersion;"
     elsif TEST_BRANCH
-      replace_in_file 'SwiftPackageManager.xcodeproj/project.pbxproj',
+      replace_in_file "#{project}.xcodeproj/project.pbxproj",
         /(branch|version) = .*;/, "branch = #{TEST_BRANCH};",
         /kind = .*;/, "kind = branch;"
     end
-    sh 'xcodebuild', '-project', 'SwiftPackageManager.xcodeproj', '-resolvePackageDependencies'
+    sh 'xcodebuild', '-project', "#{project}.xcodeproj", '-resolvePackageDependencies'
 
   when 'xcframework'
     # If we're testing a branch then we should already have a built zip
@@ -200,7 +201,7 @@ def build_app(platform, method, static)
     sh 'xcodebuild', '-project', 'Carthage.xcodeproj', '-scheme', 'App', *build_args
 
   when 'spm'
-    sh 'xcodebuild', '-project', 'SwiftPackageManager.xcodeproj', '-scheme', 'App', *build_args
+    sh 'xcodebuild', '-project', static ? 'SwiftPackageManager.xcodeproj' : 'SwiftPackageManagerDynamic.xcodeproj', '-scheme', 'App', *build_args
 
   when 'xcframework'
     if static
@@ -221,9 +222,7 @@ def validate_build(static)
 end
 
 def test(platform, method, linkage = 'dynamic')
-  # Because we only have one target Xcode will choose to build us as a static
-  # library when using spm
-  static = linkage == 'static' || method == 'spm'
+  static = linkage == 'static'
   if static
     ENV['REALM_BUILD_STATIC'] = '1'
   else
@@ -251,6 +250,7 @@ if ARGV[0] == 'test-all'
     end
 
     test platform, 'cocoapods', 'static' unless platform == 'visionos'
+    test platform, 'spm', 'static'
   end
 
   test 'ios', 'xcframework', 'static'


### PR DESCRIPTION
SPM builds libraries as static libraries if they're used by one target in the project, and dynamic libraries if they're used by multiple. This means that we can test both variations by adding a project with some frameworks which depend on RealmSwift.