### PR TITLE
Fix undefined symbol error for `UIKit` when linking Realm to a framework using SPM.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,15 @@ x.y.z Release notes (yyyy-MM-dd)
   Swift Package Manager or by using a XCFramework as CocoaPods and Carthage do
   not yet support it.
 * Zips compatible with SPM's `.binaryTarget()` are now published as part of the
-  reases on Github.
   releases on Github.
-* Prebuilt XCFrameworks are now built with LTO enabled. This has insignificant
-  performance benefits, but cuts the size of the library by ~15%.
-* Prebuilt XCFrameworks are now built with LTO enabled. This has insgificant
-* performance benefits, but cuts the size of the library by ~15%.
 * Prebuilt XCFrameworks are now built with LTO enabled. This has insignificant
   performance benefits, but cuts the size of the library by ~15%.
 
 ### Fixed
 * Fix nested properties observation on a `Projections` not notifying when there is a property change.
     ([#8276](https://github.com/realm/realm-swift/issues/8276), since v10.34.0).
+* Fix undefined symbol error for `UIKit` when linking Realm to a framework using SPM.
+  ([#8308](https://github.com/realm/realm-swift/issues/8308), since v10.41.0)
 
 ### Breaking Changes
 * Legacy non-xcframework Carthage installations are no longer supported. Please

--- a/Package.swift
+++ b/Package.swift
@@ -249,7 +249,10 @@ let package = Package(
                 "Realm/RLMUserAPIKey.mm"
             ],
             publicHeadersPath: "include",
-            cxxSettings: cxxSettings
+            cxxSettings: cxxSettings,
+            linkerSettings: [
+                .linkedFramework("UIKit", .when(platforms: [.iOS, .macCatalyst, .tvOS, .watchOS]))
+            ]
         ),
         .target(
             name: "RealmSwift",

--- a/build.sh
+++ b/build.sh
@@ -59,7 +59,7 @@ command:
   test-swiftpm:         tests ObjC and Swift macOS frameworks via SwiftPM
   test-swiftui-ios:         tests SwiftUI framework UI tests
   test-swiftui-server-osx:  tests Server Sync in SwiftUI
-  verify:               verifies docs, osx, osx-swift, ios-static, ios-dynamic, ios-swift, ios-device, swiftui-ios in both Debug and Release configurations, swiftlint
+  verify:               verifies docs, osx, osx-swift, ios-static, ios-dynamic, ios-swift, ios-device, swiftui-ios in both Debug and Release configurations, swiftlint, ios-xcode-spm
   verify-osx-object-server:  downloads the Realm Object Server and runs the Objective-C and Swift integration tests
 
   docs:                 builds docs in docs/output
@@ -668,6 +668,7 @@ case "$COMMAND" in
         ;;
 
     verify-cocoapods-ios-dynamic)
+        cd examples/installation
         REALM_TEST_BRANCH="$sha" ./build.rb ios cocoapods
         ;;
 
@@ -768,6 +769,11 @@ case "$COMMAND" in
 
     "verify-xcframework")
         sh build.sh xcframework osx
+        exit 0
+        ;;
+
+    "verify-ios-xcode-spm")
+        REALM_TEST_BRANCH="$sha" sh build.sh test-ios-xcode-spm
         exit 0
         ;;
 


### PR DESCRIPTION
Fix undefined symbol error for `UIKit` when linking Realm to a framework using SPM. ([#8308](https://github.com/realm/realm-swift/issues/8308), since v10.41.0)

This branches changes will be merged to `tg/spm-dynamic` where there is a test for this.