### PR TITLE
Add carthage binary specs (#8326)

### DIFF
--- a/carthage_specs/Realm.json
+++ b/carthage_specs/Realm.json
@@ -1,0 +1,3 @@
+{
+    "10.42.0": "https://github.com/realm/realm-swift/releases/download/v10.42.0/Carthage.xcframework.zip"
+}

--- a/carthage_specs/RealmSwift.json
+++ b/carthage_specs/RealmSwift.json
@@ -1,0 +1,3 @@
+{
+    "10.42.0": "https://github.com/realm/realm-swift/releases/download/v10.42.0/Carthage.xcframework.zip"
+}


### PR DESCRIPTION
Since there's now a bunch of different archives attached to the releases, it makes sense to me to add a [Carthage binary specification files](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#binary-project-specification) in order to avoid issues like #8326

This change, obviously, should affect some of the scripts which manage bumping lib version and probably some other project flows. 
I'm new here and will be grateful, if somebody point me in the right direction to change that as well.
(In case this proposal will be accepted)