### PR TITLE
Fix some packaging problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ x.y.z Release notes (yyyy-MM-dd)
 * The names of the prebuilt zips for SPM have changed to avoid having Carthage
   download them instead of the intended Carthage zip
   ([#8326](https://github.com/realm/realm-swift/issues/8326), since v10.42.0).
+* The prebuild Realm.xcframework for SwiftPM now has all platforms other than
+  visionOS built with Xcode 14 to comply with app store rules
+  ([#8339](https://github.com/realm/realm-swift/issues/8339), since 10.42.0).
+* Fix visionOS compilation with Xcode beta 7.
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 
@@ -16,7 +20,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * APIs are backwards compatible with all previous releases in the 10.x.y series.
 * Carthage release for Swift is built with Xcode 14.3.1.
 * CocoaPods: 1.10 or later.
-* Xcode: 14.1-15 beta 4.
+* Xcode: 14.1-15 beta 7.
 
 ### Internal
 * Upgraded realm-core from ? to ?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ x.y.z Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
-* None.
+* The names of the prebuilt zips for SPM have changed to avoid having Carthage
+  download them instead of the intended Carthage zip
+  ([#8326](https://github.com/realm/realm-swift/issues/8326), since v10.42.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Jenkinsfile.publish
+++ b/Jenkinsfile.publish
@@ -26,7 +26,7 @@ pipeline {
         // at the same time as this job
         stash name: 'source', includes: 'source.zip'
         stash name: 'docs', includes: 'realm-docs.zip'
-        stash name: 'binary', includes: 'realm-swift-*.zip'
+        stash name: 'binary', includes: 'realm-swift-*.zip,Carthage.xcframework.zip,*.spm.zip'
         sh 'unzip source.zip'
         script {
           env.version = sh(script: "sed -n 's/^VERSION=\\(.*\\)\$/\\1/p' dependencies.list", returnStdout: true).trim()

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -143,8 +143,11 @@ def doBuild() {
       withEnv(['REALM_XCODE_VERSION=15.0']) {
         sh './build.sh package-release'
       }
-      stash includes: 'realm-swift-*.zip', name: 'packaged'
-      archiveArtifacts artifacts: 'realm-swift-*.zip'
+
+      dir("pkg") {
+        stash includes: 'realm-swift-*.zip', name: 'packaged'
+        archiveArtifacts artifacts: '*.zip'
+      }
     }
   }
 

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -2398,7 +2398,7 @@ class AnyRealmValueSyncTests: SwiftSyncTestCase {
 // results in a warning about it being redundant due to the enclosing check, so
 // it needs to be out of line.
 func hasCombine() -> Bool {
-    if #available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *) {
+    if #available(macOS 10.15, watchOS 6.0, iOS 13.0, tvOS 13.0, *) {
         return true
     }
     return false

--- a/Realm/ObjectServerTests/SwiftSyncTestCase.swift
+++ b/Realm/ObjectServerTests/SwiftSyncTestCase.swift
@@ -313,7 +313,7 @@ extension SwiftSyncTestCase {
     }
 }
 
-@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+@available(macOS 10.15, watchOS 6.0, iOS 13.0, tvOS 13.0, *)
 public extension Publisher {
     func expectValue(_ testCase: XCTestCase, _ expectation: XCTestExpectation,
                      receiveValue: (@Sendable (Self.Output) -> Void)? = nil) -> AnyCancellable {

--- a/RealmSwift/Projection.swift
+++ b/RealmSwift/Projection.swift
@@ -789,7 +789,7 @@ private struct ProjectionProperty: @unchecked Sendable {
 }
 
 // An adaptor for os_unfair_lock to make it implement NSLocking
-@available(OSX 10.12, watchOS 3.0, iOS 10.0, iOSApplicationExtension 10.0, OSXApplicationExtension 10.12, tvOS 10.0, *)
+@available(OSX 10.12, watchOS 3.0, iOS 10.0, tvOS 10.0, *)
 private final class UnfairLock: NSLocking, Sendable {
     func lock() {
         os_unfair_lock_lock(impl)
@@ -806,7 +806,7 @@ private final class UnfairLock: NSLocking, Sendable {
 
 // We want to use os_unfair_lock when it's available, but fall back to NSLock otherwise
 private func createLock() -> NSLocking {
-    if #available(OSX 10.12, watchOS 3.0, iOS 10.0, iOSApplicationExtension 10.0, OSXApplicationExtension 10.12, tvOS 10.0, *) {
+    if #available(macOS 10.12, watchOS 3.0, iOS 10.0, tvOS 10.0, *) {
         return UnfairLock()
     }
     return NSLock()

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -1494,7 +1494,7 @@ internal extension Actor {
     }
 
     // A helper to invoke a regular isolated sendable function with this actor
-    func invoke<T>(_ fn: @Sendable (isolated Self) async throws -> T) async rethrows -> T {
+    func invoke<T: Sendable>(_ fn: @Sendable (isolated Self) async throws -> T) async rethrows -> T {
         try await fn(self)
     }
 }

--- a/RealmSwift/Tests/CombineTests.swift
+++ b/RealmSwift/Tests/CombineTests.swift
@@ -41,7 +41,7 @@ extension Publisher {
 // results in a warning about it being redundant due to the enclosing check, so
 // it needs to be out of line.
 func hasCombine() -> Bool {
-    if #available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *) {
+    if #available(macOS 10.15, watchOS 6.0, iOS 13.0, tvOS 13.0, *) {
         return true
     }
     return false

--- a/scripts/create-release-package.rb
+++ b/scripts/create-release-package.rb
@@ -1,0 +1,127 @@
+#!/usr/bin/env ruby
+
+require 'fileutils'
+require 'pathname'
+require 'tmpdir'
+
+raise 'usage: create-release-package.rb destination_path version [xcode_versions]' unless ARGV.length >= 3
+
+DESTINATION = Pathname(ARGV[0])
+VERSION = ARGV[1]
+XCODE_VERSIONS = ARGV[2..]
+ROOT = Pathname(__FILE__).+('../..').expand_path
+BUILD_SH = Pathname(__FILE__).+('../../build.sh').expand_path
+PLATFORMS = %w{osx ios watchos tvos catalyst}
+VERBOSE = false
+
+def sh(*args)
+  puts "executing: #{args.join(' ')}" if VERBOSE
+  system(*args, VERBOSE ? {} : {:out => '/dev/null'}) || exit(1)
+end
+
+def platforms(xcode_version)
+  if xcode_version.start_with? '15'
+    %w{osx ios watchos tvos catalyst visionos}
+  else
+    %w{osx ios watchos tvos catalyst}
+  end
+end
+
+def create_xcframework(root, xcode_version, configuration, name)
+  prefix = "#{root}/#{xcode_version}"
+  output = "#{prefix}/#{configuration}/#{name}.xcframework"
+  files = Dir.glob "#{prefix}/#{configuration}/*/#{name}.xcframework/*/#{name}.framework"
+
+  # We only ship a single Realm.xcframework built with the latest non-beta version of Xcode.
+  # Until Xcode 15 leaves beta, that means we need to stick a visionos slice
+  # built with Xcode 15 into an otherwise Xcode 14 xcframework.
+  if name == 'Realm' and xcode_version.start_with? '14' and XCODE_VERSIONS.include? '15.0'
+    files += Dir.glob "#{root}/15.0/#{configuration}/visionos/#{name}.xcframework/*/#{name}.framework"
+  end
+
+  sh 'xcodebuild', '-create-xcframework', '-allow-internal-distribution',
+     '-output', output, *files.flat_map {|f| ['-framework', f]}
+end
+
+def zip(name, *files)
+  path = (DESTINATION + name).to_path
+  FileUtils.rm_f path
+  sh 'zip', '--symlinks', '-r', path, *files
+end
+
+puts "Packaging version #{VERSION} for Xcode versions #{XCODE_VERSIONS.join(', ')}"
+FileUtils.mkdir_p DESTINATION
+
+Dir.mktmpdir do |tmp|
+  # The default temp directory is in /var, which is a symlink to /private/var
+  # xcodebuild's relative path resolution breaks due to this and we need to
+  # give it the fully resolved path
+  tmp = File.realpath tmp
+
+  for version in XCODE_VERSIONS
+    puts "Extracting source binaries for Xcode #{version}"
+    FileUtils.mkdir_p "#{tmp}/#{version}"
+    Dir.chdir("#{tmp}/#{version}") do
+      for platform in platforms(version)
+        sh 'unzip', "#{ROOT}/realm-#{platform}-#{version}.zip"
+      end
+    end
+  end
+
+  for version in XCODE_VERSIONS
+    puts "Creating Swift XCFrameworks for Xcode #{version}"
+    create_xcframework tmp, version, 'Release', 'RealmSwift'
+  end
+
+  puts 'Creating Obj-C XCFrameworks'
+  xcode_14_version = XCODE_VERSIONS.filter {|v| v.start_with? '14'}.last
+  create_xcframework tmp, xcode_14_version, 'Release', 'Realm'
+  create_xcframework tmp, xcode_14_version, 'Static', 'Realm'
+
+  puts 'Creating release package'
+  package_dir = "#{tmp}/realm-swift-#{VERSION}"
+  FileUtils.mkdir_p package_dir
+  sh 'cp', "#{ROOT}/LICENSE", package_dir
+  sh 'unzip', "#{ROOT}/realm-examples.zip", '-d', package_dir
+  for lang in %w(objc swift)
+    File.write "#{package_dir}/#{lang}-docs.webloc", %Q{
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+          <key>URL</key>
+          <string>https://www.mongodb.com/docs/realm-sdks/${lang}/${version}</string>
+      </dict>
+      </plist>
+    }
+  end
+  sh 'cp', '-Rca', "#{tmp}/#{xcode_14_version}/Release/Realm.xcframework", "#{package_dir}"
+  FileUtils.mkdir_p "#{package_dir}/static"
+  sh 'cp', '-Rca', "#{tmp}/#{xcode_14_version}/Static/Realm.xcframework", "#{package_dir}/static"
+  for version in XCODE_VERSIONS
+    FileUtils.mkdir_p "#{package_dir}/#{version}"
+    sh 'cp', '-Rca', "#{tmp}/#{version}/Release/RealmSwift.xcframework", "#{package_dir}/#{version}"
+  end
+
+  Dir.chdir(tmp) do
+    zip "realm-swift-#{VERSION}.zip", "realm-swift-#{VERSION}"
+  end
+
+  puts 'Creating SPM release zips'
+  zip 'Realm.spm.zip', "#{tmp}/#{xcode_14_version}/Release/Realm.xcframework"
+  for version in XCODE_VERSIONS
+    Dir.chdir "#{tmp}/#{version}/Release" do
+      zip "RealmSwift@#{version}.spm.zip", 'RealmSwift.xcframework'
+    end
+  end
+
+  puts 'Creating Carthage release zip'
+  Dir.mktmpdir do |tmp2|
+    Dir.chdir(tmp2) do
+      sh 'cp', '-Rca', "#{tmp}/#{xcode_14_version}/Release/Realm.xcframework", tmp2
+      sh 'cp', '-Rca', "#{tmp}/#{xcode_14_version}/Release/RealmSwift.xcframework", tmp2
+      zip 'Carthage.xcframework.zip', 'Realm.xcframework', 'RealmSwift.xcframework'
+    end
+  end
+end
+

--- a/scripts/github_release.rb
+++ b/scripts/github_release.rb
@@ -39,12 +39,12 @@ Dir.mktmpdir do |tmp|
            "realm-swift-#{VERSION}/*/RealmSwift.xcframework/*",
            "realm-swift-#{VERSION}/Realm.xcframework/*"
     Dir.chdir "realm-swift-#{VERSION}" do
-      zip 'Realm.xcframework.zip', 'Realm.xcframework'
+      zip 'Realm.spm.zip', 'Realm.xcframework'
       Dir.glob '*/RealmSwift.xcframework' do |name|
         version = Pathname(name).parent
         puts "Creating SPM package for #{version}"
         Dir.chdir version do
-          zip "RealmSwift@#{version}.xcframework.zip", 'RealmSwift.xcframework'
+          zip "RealmSwift@#{version}.spm.zip", 'RealmSwift.xcframework'
         end
       end
 

--- a/scripts/github_release.rb
+++ b/scripts/github_release.rb
@@ -1,60 +1,17 @@
 #!/usr/bin/env ruby
 
-require 'fileutils'
 require 'octokit'
-require 'pathname'
-require 'tmpdir'
 
-raise 'usage: github_release.rb version xcode_version' unless ARGV.length == 2
+raise 'usage: github_release.rb version' unless ARGV.length == 1
 
 VERSION = ARGV[0]
-XCODE_VERSION = ARGV[1]
 ACCESS_TOKEN = ENV['GITHUB_ACCESS_TOKEN']
 raise 'GITHUB_ACCESS_TOKEN must be set to create GitHub releases' unless ACCESS_TOKEN
 
 BUILD_SH = Pathname(__FILE__).+('../../build.sh').expand_path
 RELEASE = "v#{VERSION}"
 
-BUILD = BUILD_SH.parent + 'build'
-SWIFT_ZIP = BUILD + "realm-swift-#{VERSION}.zip"
-
 REPOSITORY = 'realm/realm-swift'
-
-$uploads = [SWIFT_ZIP]
-
-def sh(*args)
-  system(*args, :out=>"/dev/null") || exit(1)
-end
-
-def zip(name, *files)
-  path = (BUILD + name).to_path
-  FileUtils.rm_f path
-  sh 'zip', '--symlinks', '-r', path, *files
-  $uploads.append Pathname(path)
-end
-
-Dir.mktmpdir do |tmp|
-  Dir.chdir(tmp) do
-    sh 'unzip', SWIFT_ZIP.to_path,
-           "realm-swift-#{VERSION}/*/RealmSwift.xcframework/*",
-           "realm-swift-#{VERSION}/Realm.xcframework/*"
-    Dir.chdir "realm-swift-#{VERSION}" do
-      zip 'Realm.spm.zip', 'Realm.xcframework'
-      Dir.glob '*/RealmSwift.xcframework' do |name|
-        version = Pathname(name).parent
-        puts "Creating SPM package for #{version}"
-        Dir.chdir version do
-          zip "RealmSwift@#{version}.spm.zip", 'RealmSwift.xcframework'
-        end
-      end
-
-      puts "Creating Carthage package for #{XCODE_VERSION}"
-      FileUtils.mv "#{XCODE_VERSION}/RealmSwift.xcframework",
-                   'RealmSwift.xcframework'
-      zip 'Carthage.xcframework.zip', 'Realm.xcframework', 'RealmSwift.xcframework'
-    end
-  end
-end
 
 def release_notes(version)
   changelog = BUILD_SH.parent.+('CHANGELOG.md').readlines
@@ -81,7 +38,7 @@ prerelease = (VERSION =~ /alpha|beta|rc|preview/) ? true : false
 response = github.create_release(REPOSITORY, RELEASE, name: RELEASE, body: RELEASE_NOTES, prerelease: prerelease)
 release_url = response[:url]
 
-$uploads.each do |upload|
-  puts "Uploading #{upload.basename} to GitHub"
-  github.upload_asset(release_url, upload.to_path, content_type: 'application/zip')
+Dir.glob '*.zip' do |upload|
+  puts "Uploading #{upload} to GitHub"
+  github.upload_asset(release_url, upload, content_type: 'application/zip')
 end


### PR DESCRIPTION
Carthage downloads a semi-random zip with xcframework in the name, so the SPM binaries need to not have that in the name.

The app store rejects things built with beta SDKs, so the obj-c framework needs to be built with Xcode 14 and only use Xcode 15 for the visionOS slices. I found this really obnoxious to write in shell, so I ported it to ruby, and pulled all the packaging logic from github_release.rb over to that so that it's testable without publishing releases.

Fixes #8326. Fixes #8339.