### PR TITLE
Expose SyncSession.reconnect()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Expose `SyncSession.reconnect()`, which requests an immediate reconnection if
+  the session is currently disconnected rather than waiting for the normal
+  reconnect delay.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)

--- a/Realm/RLMSyncSession.h
+++ b/Realm/RLMSyncSession.h
@@ -161,6 +161,23 @@ RLM_SWIFT_SENDABLE RLM_FINAL // is internally thread-safe
 - (void)resume;
 
 /**
+ Request an immediate reconnection to the server if the session is disconnected.
+
+ Realm automatically reconnects after disconnects with an exponential backoff,
+ which is reset when the reachability handler reports a network status change.
+ In some scenarios an application may wish to skip the reconnect delay, such as
+ when an application receives the DidBecomeActive notification, which can be
+ done by calling this method. Calling this method is never required.
+
+ This method is asynchronous and merely skips the current reconnect delay, so
+ the connection state will still normally be disconnected immediately after
+ calling it.
+
+ Has no effect if the session is currently connected.
+ */
+- (void)reconnect;
+
+/**
  Register a progress notification block.
 
  Multiple blocks can be registered with the same session at once. Each block

--- a/Realm/RLMSyncSession.mm
+++ b/Realm/RLMSyncSession.mm
@@ -174,6 +174,12 @@ static RLMSyncConnectionState convertConnectionState(SyncSession::ConnectionStat
     }
 }
 
+- (void)reconnect {
+    if (auto session = _session.lock()) {
+        session->handle_reconnect();
+    }
+}
+
 static util::UniqueFunction<void(Status)> wrapCompletion(dispatch_queue_t queue,
                                                          void (^callback)(NSError *)) {
     queue = queue ?: dispatch_get_main_queue();


### PR DESCRIPTION
I don't really see any way to usefully test this with our current testing capabilities, but it's also a completely trivial wrapper around core functionality which is tested there.