### PR TITLE
Allow opening synced realm in-memory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ x.y.z Release notes (yyyy-MM-dd)
 * The `baseURL` field of `AppConfiguration` can now be updated, rather than the
   value being persisted between runs of the application in the metadata
   storage. ([Core #7201](https://github.com/realm/realm-core/issues/7201))
+* Allow in-memory synced Realms. This will allow setting and in-memory identifier on
+  flexible sync realms, this will not create a .realm file or its associated auxiliary 
+  files for the synced realm and instead stores objects in memory while the realm is 
+  open and discards them immediately when all instances are closed.
 
 ### Fixed
 * `@Persisted`'s Encodable implementation did not allow the encoder to
@@ -9393,7 +9397,7 @@ Prebuilt frameworks are now built with Xcode 7.1.
   the properties in a `RLMObject` subclass.
 * Fix crash on IN query with several thousand items.
 * Fix crash when querying indexed `NSString` properties.
-* Fixed an issue which prevented in-memory Realms from being used accross multiple threads.
+* Fixed an issue which prevented in-memory Realms from being used across multiple threads.
 * Preserve the sort order when querying a sorted `RLMResults`.
 * Fixed an issue with migrations where if a Realm file is deleted after a Realm is initialized,
   the newly created Realm can be initialized with an incorrect schema version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,8 @@ x.y.z Release notes (yyyy-MM-dd)
 * The `baseURL` field of `AppConfiguration` can now be updated, rather than the
   value being persisted between runs of the application in the metadata
   storage. ([Core #7201](https://github.com/realm/realm-core/issues/7201))
-* Allow in-memory synced Realms. This will allow setting and in-memory identifier on
-  flexible sync realms, this will not create a .realm file or its associated auxiliary 
-  files for the synced realm and instead stores objects in memory while the realm is 
-  open and discards them immediately when all instances are closed.
+* Allow in-memory synced Realms. This will allow setting an in-memory identifier on
+  a flexible sync realm.
 
 ### Fixed
 * `@Persisted`'s Encodable implementation did not allow the encoder to

--- a/Realm/ObjectServerTests/AsyncSyncTests.swift
+++ b/Realm/ObjectServerTests/AsyncSyncTests.swift
@@ -515,6 +515,52 @@ class AsyncFlexibleSyncTests: SwiftSyncTestCase {
     }
 
     @MainActor
+    func testFlexibleSyncInitInMemory() async throws {
+        try await populateSwiftPerson(5)
+
+        let user = try await createUser()
+        try await Task {
+            var config = user.flexibleSyncConfiguration(initialSubscriptions: { subs in
+                subs.append(QuerySubscription<SwiftPerson> {
+                    $0.age > 0 && $0.firstName == "\(#function)"
+                })
+            })
+            config.objectTypes = [SwiftPerson.self]
+            config.inMemoryIdentifier = "identifier"
+            let inMemoryRealm = try await Realm(configuration: config, downloadBeforeOpen: .always)
+            XCTAssertEqual(inMemoryRealm.objects(SwiftPerson.self).count, 5)
+            try! inMemoryRealm.write {
+                let person = SwiftPerson(firstName: "\(#function)",
+                                         lastName: "lastname_10",
+                                         age: 10)
+                inMemoryRealm.add(person)
+            }
+            XCTAssertEqual(inMemoryRealm.objects(SwiftPerson.self).count, 6)
+            try await inMemoryRealm.syncSession?.wait(for: .upload)
+        }.value
+
+        var config = user.flexibleSyncConfiguration(initialSubscriptions: { subs in
+            subs.append(QuerySubscription<SwiftPerson> {
+                $0.age > 5 && $0.firstName == "\(#function)"
+            })
+        })
+        config.objectTypes = [SwiftPerson.self]
+        config.inMemoryIdentifier = "identifier"
+        let inMemoryRealm = try await Realm(configuration: config, downloadBeforeOpen: .always)
+        XCTAssertEqual(inMemoryRealm.objects(SwiftPerson.self).count, 1)
+
+        var config2 = user.flexibleSyncConfiguration(initialSubscriptions: { subs in
+            subs.append(QuerySubscription<SwiftPerson> {
+                $0.age > 0 && $0.firstName == "\(#function)"
+            })
+        })
+        config2.objectTypes = [SwiftPerson.self]
+        config2.inMemoryIdentifier = "identifier2"
+        let inMemoryRealm2 = try await Realm(configuration: config2, downloadBeforeOpen: .always)
+        XCTAssertEqual(inMemoryRealm2.objects(SwiftPerson.self).count, 6)
+    }
+
+    @MainActor
     func testStates() async throws {
         let realm = try await openRealm()
         let subscriptions = realm.subscriptions

--- a/Realm/ObjectServerTests/AsyncSyncTests.swift
+++ b/Realm/ObjectServerTests/AsyncSyncTests.swift
@@ -522,7 +522,7 @@ class AsyncFlexibleSyncTests: SwiftSyncTestCase {
         try await Task {
             var config = user.flexibleSyncConfiguration(initialSubscriptions: { subs in
                 subs.append(QuerySubscription<SwiftPerson> {
-                    $0.age > 0 && $0.firstName == "\(#function)"
+                    $0.age > 0 && $0.firstName == self.name
                 })
             })
             config.objectTypes = [SwiftPerson.self]
@@ -530,7 +530,7 @@ class AsyncFlexibleSyncTests: SwiftSyncTestCase {
             let inMemoryRealm = try await Realm(configuration: config, downloadBeforeOpen: .always)
             XCTAssertEqual(inMemoryRealm.objects(SwiftPerson.self).count, 5)
             try! inMemoryRealm.write {
-                let person = SwiftPerson(firstName: "\(#function)",
+                let person = SwiftPerson(firstName: self.name,
                                          lastName: "lastname_10",
                                          age: 10)
                 inMemoryRealm.add(person)
@@ -541,7 +541,7 @@ class AsyncFlexibleSyncTests: SwiftSyncTestCase {
 
         var config = user.flexibleSyncConfiguration(initialSubscriptions: { subs in
             subs.append(QuerySubscription<SwiftPerson> {
-                $0.age > 5 && $0.firstName == "\(#function)"
+                $0.age > 5 && $0.firstName == self.name
             })
         })
         config.objectTypes = [SwiftPerson.self]
@@ -551,7 +551,7 @@ class AsyncFlexibleSyncTests: SwiftSyncTestCase {
 
         var config2 = user.flexibleSyncConfiguration(initialSubscriptions: { subs in
             subs.append(QuerySubscription<SwiftPerson> {
-                $0.age > 0 && $0.firstName == "\(#function)"
+                $0.age > 0 && $0.firstName == self.name
             })
         })
         config2.objectTypes = [SwiftPerson.self]

--- a/Realm/RLMRealmConfiguration.h
+++ b/Realm/RLMRealmConfiguration.h
@@ -75,7 +75,7 @@ typedef void(^RLMFlexibleSyncInitialSubscriptionsBlock)(RLMSyncSubscriptionSet *
 
 #pragma mark - Properties
 
-/// The local URL of the Realm file. Mutually exclusive with `inMemoryIdentifier`,
+/// The local URL of the Realm file. Mutually exclusive with `inMemoryIdentifier`;
 /// setting one of the two properties will automatically nil out the other.
 @property (nonatomic, copy, nullable) NSURL *fileURL;
 

--- a/Realm/RLMRealmConfiguration.h
+++ b/Realm/RLMRealmConfiguration.h
@@ -75,13 +75,13 @@ typedef void(^RLMFlexibleSyncInitialSubscriptionsBlock)(RLMSyncSubscriptionSet *
 
 #pragma mark - Properties
 
-/// The local URL of the Realm file. Mutually exclusive with `inMemoryIdentifier`;
+/// The local URL of the Realm file. Mutually exclusive with `inMemoryIdentifier`,
 /// setting one of the two properties will automatically nil out the other.
 @property (nonatomic, copy, nullable) NSURL *fileURL;
 
 /// A string used to identify a particular in-memory Realm. Mutually exclusive with `fileURL`,
-/// `seedFilePath`and `syncConfiguration`;
-/// setting any one of the three properties will automatically nil out the other two.
+/// `seedFilePath`.
+/// setting an in-memory identifier will automatically nil out the other two.
 @property (nonatomic, copy, nullable) NSString *inMemoryIdentifier;
 
 /// A 64-byte key to use to encrypt the data, or `nil` if encryption is not enabled.

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -174,7 +174,6 @@ NSString *RLMRealmPathForFile(NSString *fileName) {
     if (inMemoryIdentifier.length == 0) {
         @throw RLMException(@"In-memory identifier must not be empty");
     }
-    _config.sync_config = nullptr;
     _seedFilePath = nil;
 
     RLMNSStringToStdString(_config.path, [NSTemporaryDirectory() stringByAppendingPathComponent:inMemoryIdentifier]);
@@ -367,7 +366,6 @@ static bool isSync(realm::Realm::Config const& config) {
     }
 
     NSAssert(user.identifier, @"Cannot call this method on a user that doesn't have an identifier.");
-    _config.in_memory = false;
     _config.sync_config = std::make_shared<realm::SyncConfig>(syncConfiguration.rawConfiguration);
     _config.path = syncConfiguration.path;
 

--- a/RealmSwift/RealmConfiguration.swift
+++ b/RealmSwift/RealmConfiguration.swift
@@ -51,8 +51,9 @@ extension Realm {
         /**
          Creates a `Configuration` which can be used to create new `Realm` instances.
 
-         - note: The `fileURL`, `inMemoryIdentifier`, and `syncConfiguration` parameters are mutually exclusive. Only
+         - note: The `fileURL`, `inMemoryIdentifier`, parameters are mutually exclusive. Only
                  set one of them, or none if you wish to use the default file URL.
+                 Synced Realms will set a unique file path unless is an in-memory realm.
 
          - parameter fileURL:            The local URL to the Realm file.
          - parameter inMemoryIdentifier: A string used to identify a particular in-memory Realm.
@@ -106,15 +107,13 @@ extension Realm {
         // MARK: Configuration Properties
 
         /**
-         A configuration value used to configure a Realm for synchronization with Atlas App Services. Mutually
-         exclusive with `inMemoryIdentifier`.
+         A configuration value used to configure a Realm for synchronization with Atlas App Services.
          */
         public var syncConfiguration: SyncConfiguration? {
             get {
                 return _syncConfiguration
             }
             set {
-                _inMemoryIdentifier = nil
                 _syncConfiguration = newValue
             }
         }
@@ -128,15 +127,13 @@ extension Realm {
             }
         }
 
-        /// A string used to identify a particular in-memory Realm. Mutually exclusive with `fileURL` and
-        /// `syncConfiguration`.
+        /// A string used to identify a particular in-memory Realm. Mutually exclusive with `fileURL`.
         public var inMemoryIdentifier: String? {
             get {
                 return _inMemoryIdentifier
             }
             set {
                 fileURL = nil
-                _syncConfiguration = nil
                 _inMemoryIdentifier = newValue
             }
         }

--- a/RealmSwift/RealmConfiguration.swift
+++ b/RealmSwift/RealmConfiguration.swift
@@ -51,7 +51,7 @@ extension Realm {
         /**
          Creates a `Configuration` which can be used to create new `Realm` instances.
 
-         - note: The `fileURL`, `inMemoryIdentifier`, parameters are mutually exclusive. Only
+         - note: The `fileURL`, and `inMemoryIdentifier`, parameters are mutually exclusive. Only
                  set one of them, or none if you wish to use the default file URL.
                  Synced Realms will set a unique file path unless is an in-memory realm.
 


### PR DESCRIPTION
This will allow setting and in-memory identifier on flexible sync realms, this will not create a .realm file or its associated auxiliary files for the synced realm and instead stores objects in memory while the realm is open and discards them immediately when all instances are closed.