### PR TITLE
Update PR matrix for Xcode 15.2

### DIFF
--- a/scripts/pr-ci-matrix.rb
+++ b/scripts/pr-ci-matrix.rb
@@ -61,9 +61,9 @@ Target = Struct.new(:name, :scheme, :filter, :destination) do
 
     test_destination = self.destination.test_destination
     if test_destination
-      action['actionType'] = 'TEST'
-      action['destination'] = 'ANY_MAC'
-      action['testConfiguration'] = {
+      action[:actionType] = 'TEST'
+      action[:destination] = 'ANY_MAC'
+      action[:testConfiguration] = {
         kind: 'USE_SCHEME_SETTINGS',
         testPlanName: '',
         testDestinations: [test_destination]
@@ -86,7 +86,7 @@ end
 # because they don't care about Xcode versions, while some others are latest-only
 # because they're particularly slow to run.
 module Workflows
-  XCODE_VERSIONS = %w(14.1 14.2 14.3.1 15.0.1 15.1)
+  XCODE_VERSIONS = %w(14.2 14.3.1 15.1 15.2)
 
   all = ->(v) { true }
   latest_only = ->(v) { v == XCODE_VERSIONS.last }


### PR DESCRIPTION
`action['actionType']` was adding a second actionType field rather than updating the existing one (since `'actionType'` and `:actionType` are different things), which Xcode cloud has starting rejecting.