### PR TITLE
Don't export c++ symbols when installing via CocoaPods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
 * Add a privacy manifest to both frameworks.
+* Internal C++ symbols are no longer exported from Realm.framework when
+  installing via CocoaPods, which reduces the size of the binary by ~5%,
+  improves app startup time a little, and eliminates some warnings when linking
+  the framework. This was already the case when using Carthage or a prebuilt
+  framework ([PR #8464](https://github.com/realm/realm-swift/pull/8464)).
 
 ### Fixed
 * `@Persisted`'s Encodable implementation did not allow the encoder to

--- a/Realm.podspec
+++ b/Realm.podspec
@@ -144,9 +144,9 @@ Pod::Spec.new do |s|
                                 'REALM_LD_CLASSIC_1400' => '',
                                 'REALM_LD_CLASSIC_1500' => '-Wl,-ld_classic',
                                 'REALM_LD_CLASSIC' => '$(REALM_LD_CLASSIC_$(XCODE_VERSION_MAJOR))',
-                                'OTHER_LDFLAGS' => '$(REALM_LD_CLASSIC)',
+                                'OTHER_LDFLAGS' => '$(REALM_LD_CLASSIC) "-Wl,-unexported_symbols_list,${PODS_ROOT}/Realm/Configuration/Realm/PrivateSymbols.txt"',
                               }
-  s.preserve_paths          = %w(include scripts)
+  s.preserve_paths          = %w(include scripts Configuration/Realm/PrivateSymbols.txt)
   s.resource_bundles        = {'realm_objc_privacy' => ['Realm/PrivacyInfo.xcprivacy']}
 
   s.ios.deployment_target   = '11.0'


### PR DESCRIPTION
This brings the CocoaPods build in alignment with the prebuilt framework.