### PR TITLE
Delete CocoaSyncUserContext

### DIFF
--- a/Realm/RLMSyncManager.mm
+++ b/Realm/RLMSyncManager.mm
@@ -113,7 +113,6 @@ std::shared_ptr<realm::util::Logger> RLMWrapLogFunction(RLMSyncLogFunction fn) {
 
 - (instancetype)initWithSyncManager:(std::shared_ptr<realm::SyncManager>)syncManager {
     if (self = [super init]) {
-        [RLMUser _setUpBindingContextFactory];
         _syncManager = syncManager;
         return self;
     }

--- a/Realm/RLMSyncUtil.mm
+++ b/Realm/RLMSyncUtil.mm
@@ -47,8 +47,3 @@ SyncSessionStopPolicy translateStopPolicy(RLMSyncStopPolicy stopPolicy) {
 RLMSyncStopPolicy translateStopPolicy(SyncSessionStopPolicy stopPolicy) {
     return static_cast<RLMSyncStopPolicy>(stopPolicy);
 }
-
-CocoaSyncUserContext& context_for(const std::shared_ptr<realm::SyncUser>& user)
-{
-    return *std::static_pointer_cast<CocoaSyncUserContext>(user->binding_context());
-}

--- a/Realm/RLMSyncUtil_Private.hpp
+++ b/Realm/RLMSyncUtil_Private.hpp
@@ -20,15 +20,9 @@
 
 #import <realm/object-store/sync/sync_manager.hpp>
 
-class CocoaSyncUserContext;
-
 realm::SyncSessionStopPolicy translateStopPolicy(RLMSyncStopPolicy stopPolicy);
 RLMSyncStopPolicy translateStopPolicy(realm::SyncSessionStopPolicy stop_policy);
 
 typedef NS_ENUM(NSUInteger, RLMClientResetMode);
 RLMClientResetMode translateClientResetMode(realm::ClientResyncMode mode);
 realm::ClientResyncMode translateClientResetMode(RLMClientResetMode mode);
-
-#pragma mark - Get user context
-
-CocoaSyncUserContext& context_for(const std::shared_ptr<realm::SyncUser>& user);

--- a/Realm/RLMUser.mm
+++ b/Realm/RLMUser.mm
@@ -378,12 +378,6 @@ using namespace realm;
 
 #pragma mark - Private API
 
-+ (void)_setUpBindingContextFactory {
-    SyncUser::set_binding_context_factory([] {
-        return std::make_shared<CocoaSyncUserContext>();
-    });
-}
-
 - (NSString *)refreshToken {
     if (!_user || _user->refresh_token().empty()) {
         return nil;

--- a/Realm/RLMUser_Private.hpp
+++ b/Realm/RLMUser_Private.hpp
@@ -23,31 +23,15 @@
 #import <realm/object-store/sync/sync_user.hpp>
 #import <realm/sync/config.hpp>
 
-@class RLMSyncConfiguration, RLMSyncSessionRefreshHandle, RLMApp;
+@class RLMSyncConfiguration, RLMApp;
 
 RLM_HEADER_AUDIT_BEGIN(nullability, sendability)
-
-class CocoaSyncUserContext : public realm::SyncUserContext {
-public:
-
-private:
-    /**
-     A map of paths to 'refresh handles'.
-
-     A refresh handle is an object that encapsulates the concept of periodically
-     refreshing the Realm's access token before it expires. Tokens are indexed by their
-     paths (e.g. `/~/path/to/realm`).
-     */
-    std::unordered_map<std::string, RLMSyncSessionRefreshHandle *> m_refresh_handles;
-    std::mutex m_mutex;
-};
 
 @interface RLMUser ()
 - (instancetype)initWithUser:(std::shared_ptr<realm::SyncUser>)user app:(RLMApp *)app;
 - (std::string)pathForPartitionValue:(std::string const&)partitionValue;
 - (std::string)pathForFlexibleSync;
 - (std::shared_ptr<realm::SyncUser>)_syncUser;
-+ (void)_setUpBindingContextFactory;
 @property (weak, readonly) RLMApp *app;
 
 @end


### PR DESCRIPTION
This was used to implement access token refreshes in obj-c, but hasn't actually done anything since 2016 and has somehow slipped through until now.