### PR TITLE
Added missing doc comment characters

### DIFF
--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -34,7 +34,7 @@ public typealias AsyncTransactionId = RLMAsyncTransactionId
  the code which uses the Realm within an `autoreleasepool {}` and ensure you have no other strong
  references to it.
 
- - warning Non-frozen `RLMRealm` instances are thread-confined and cannot be
+ - warning: Non-frozen `RLMRealm` instances are thread-confined and cannot be
  shared across threads or dispatch queues. Trying to do so will cause an
  exception to be thrown. You must obtain an instance of `RLMRealm` on each
  thread or queue you want to interact with the Realm on. Realms can be confined
@@ -482,7 +482,7 @@ public typealias AsyncTransactionId = RLMAsyncTransactionId
      This becomes `true` following a call to `beginAsyncWrite`, `commitAsyncWrite`,
      or `writeAsync`, and remains so until all scheduled async write work has completed.
 
-     @warning If this is `true`, closing or invalidating the Realm will block until scheduled work has completed.
+     - warning: If this is `true`, closing or invalidating the Realm will block until scheduled work has completed.
      */
     public var isPerformingAsynchronousWriteOperations: Bool {
         return rlmRealm.isPerformingAsynchronousWriteOperations

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -287,7 +287,7 @@ public protocol RealmCollection: RealmCollectionBase, Equatable where Iterator =
     /**
      Returns an array containing the objects in the collection at the indexes specified by a given index set.
 
-     - warning Throws if an index supplied in the IndexSet is out of bounds.
+     - warning: Throws if an index supplied in the IndexSet is out of bounds.
 
      - parameter indexes: The indexes in the collection to select objects from.
      */


### PR DESCRIPTION
The documentation comments are missing the ":" character is missing, so it's not highlighted correctly.

Hopefully this will be fixed at some point.