### PR TITLE
Only commit the changelog in the add empty changelog release step

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -168,13 +168,11 @@ jobs:
         GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       steps:
         - uses: actions/checkout@v4
-        - uses: ruby/setup-ruby@v1
-          with:
-            bundler-cache: true
         - name: Add template to changelog
           run: |
             sh build.sh add-empty-changelog
         - name: Auto-commit CHANGELOG.md
           uses: stefanzweifel/git-auto-commit-action@v4
           with:
+            file_pattern: 'CHANGELOG.md'
             commit_message: 'Add an empty changelog section'


### PR DESCRIPTION
[This added the entire ruby cache](https://github.com/realm/realm-swift/actions/runs/8194963991/job/22419745076) and some assorted other GHA files rather than only the updated changelog. It also doesn't need ruby.