### PR TITLE
Add NSPrivacyAccessedAPICategoryDiskSpace to the privacy manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+x.y.z Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
+* The Realm.framework privacy manifest was missing
+  NSPrivacyAccessedAPICategoryDiskSpace, but we check free disk space before
+  attempting to automatically back up Realm files (since 10.46.0).
+
+<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
+
+### Compatibility
+* Realm Studio: 14.0.1 or later.
+* APIs are backwards compatible with all previous releases in the 10.x.y series.
+* Carthage release for Swift is built with Xcode 15.3.0.
+* CocoaPods: 1.10 or later.
+* Xcode: 14.2-15.3.0.
+
+### Internal
+* Upgraded realm-core from ? to ?
+
 10.48.0 Release notes (2024-03-07)
 =============================================================
 

--- a/Realm/PrivacyInfo.xcprivacy
+++ b/Realm/PrivacyInfo.xcprivacy
@@ -16,6 +16,14 @@
 			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
 		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>E174.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+		</dict>
 	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>


### PR DESCRIPTION
I thought this was only called in tests, but it turns out to also be used in the backup code.