### PR TITLE
RCOCOA-2310: Fix a crash when receiving 401/403 when opening a watch stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ x.y.z Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
-* Fixed a crash that would occur when an http error 401 or 403 is returned upon opening a watch stream for a MongoDB collection. ([#8519](https://github.com/realm/realm-swift/issues/8519))
+* Fixed a crash that would occur when an http error 401 or 403 is returned upon
+  opening a watch stream for a MongoDB collection. ([#8519](https://github.com/realm/realm-swift/issues/8519))
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ x.y.z Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
-* None.
+* Fixed a crash that would occur when an http error 401 or 403 is returned upon opening a watch stream for a MongoDB collection. ([#8519](https://github.com/realm/realm-swift/issues/8519))
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/ObjectServerTests/RealmServer.swift
+++ b/Realm/ObjectServerTests/RealmServer.swift
@@ -1187,6 +1187,14 @@ public class RealmServer: NSObject {
         return session.apps[appServerId].users[userId].delete()
     }
 
+    public func revokeUserSessions(_ appId: String, userId: String) -> Result<Any?, Error> {
+        guard let appServerId = try? RealmServer.shared.retrieveAppServerId(appId),
+              let session = session else {
+            return .failure(URLError(.unknown))
+        }
+        return session.apps[appServerId].users[userId].logout.put([:]);
+    }
+
     public func retrieveSchemaProperties(_ appId: String, className: String, _ completion: @escaping (Result<[String], Error>) -> Void) {
         guard let appServerId = try? RealmServer.shared.retrieveAppServerId(appId),
               let session = session else {

--- a/Realm/ObjectServerTests/RealmServer.swift
+++ b/Realm/ObjectServerTests/RealmServer.swift
@@ -1192,7 +1192,7 @@ public class RealmServer: NSObject {
               let session = session else {
             return .failure(URLError(.unknown))
         }
-        return session.apps[appServerId].users[userId].logout.put([:]);
+        return session.apps[appServerId].users[userId].logout.put([:])
     }
 
     public func retrieveSchemaProperties(_ appId: String, className: String, _ completion: @escaping (Result<[String], Error>) -> Void) {

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -1322,6 +1322,32 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         let objectCol = (obj!.anyCol.dynamicObject?.objectCol as? Object)
         XCTAssertEqual((objectCol?["firstName"] as? String), "Morty")
     }
+
+    func testRevokeUserSessions() {
+        let email = "realm_tests_do_autoverify\(randomString(7))@\(randomString(7)).com"
+        let password = randomString(10)
+
+        app.emailPasswordAuth.registerUser(email: email, password: password).await(self)
+
+        let syncUser = app.login(credentials: Credentials.emailPassword(email: email, password: password)).await(self)
+        
+        // Should succeed refreshing custom data
+        syncUser.refreshCustomData().await(self)
+
+        _ = try? RealmServer.shared.revokeUserSessions(appId, userId: syncUser.id).get()
+
+        // Should fail refreshing custom data. This verifies we're correctly handling the error in RLMSessionDelegate
+        syncUser.refreshCustomData().awaitFailure(self)
+
+        // This verifies that we don't crash in RLMEventSessionDelegate when creating a watch stream
+        // with a revoked user. See https://github.com/realm/realm-swift/issues/8519
+        let watchTestUtility = WatchTestUtility(testCase: self, expectError: true)
+        _ = syncUser.collection(for: Dog.self, app: app).watch(delegate: watchTestUtility)
+        watchTestUtility.waitForOpen()
+        watchTestUtility.waitForClose()
+
+        XCTAssertEqual(watchTestUtility.closeError?.localizedDescription, "URLSession HTTP error code: 403")
+    }
 }
 
 #endif // os(macOS)

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -1330,7 +1330,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         app.emailPasswordAuth.registerUser(email: email, password: password).await(self)
 
         let syncUser = app.login(credentials: Credentials.emailPassword(email: email, password: password)).await(self)
-        
+
         // Should succeed refreshing custom data
         syncUser.refreshCustomData().await(self)
 

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -1346,7 +1346,10 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         watchTestUtility.waitForOpen()
         watchTestUtility.waitForClose()
 
-        XCTAssertEqual(watchTestUtility.closeError?.localizedDescription, "URLSession HTTP error code: 403")
+        let didCloseError = watchTestUtility.didCloseError! as NSError
+        XCTAssertNotNil(didCloseError)
+        XCTAssertEqual(didCloseError.localizedDescription, "URLSession HTTP error code: 403")
+        XCTAssertNil(didCloseError.userInfo[NSUnderlyingErrorKey])
     }
 }
 

--- a/Realm/ObjectServerTests/WatchTestUtility.swift
+++ b/Realm/ObjectServerTests/WatchTestUtility.swift
@@ -23,13 +23,16 @@ import XCTest
 final public class WatchTestUtility: ChangeEventDelegate {
     private let testCase: XCTestCase
     private let matchingObjectId: ObjectId?
-    private let openExpectation: XCTestExpectation
+    private var openExpectation: XCTestExpectation
     private let closeExpectation: XCTestExpectation
     private var changeExpectation: XCTestExpectation?
+    private let expectError: Bool
+    public var closeError: Error?
 
-    public init(testCase: XCTestCase, matchingObjectId: ObjectId? = nil) {
+    public init(testCase: XCTestCase, matchingObjectId: ObjectId? = nil, expectError: Bool = false) {
         self.testCase = testCase
         self.matchingObjectId = matchingObjectId
+        self.expectError = expectError
         openExpectation = testCase.expectation(description: "Open watch stream")
         closeExpectation = testCase.expectation(description: "Close watch stream")
     }
@@ -57,7 +60,13 @@ final public class WatchTestUtility: ChangeEventDelegate {
     }
 
     public func changeStreamDidClose(with error: Error?) {
-        XCTAssertNil(error)
+        if (expectError) {
+            XCTAssertNotNil(error)
+        } else {
+            XCTAssertNil(error)
+        }
+
+        closeError = error
         closeExpectation.fulfill()
     }
 

--- a/Realm/ObjectServerTests/WatchTestUtility.swift
+++ b/Realm/ObjectServerTests/WatchTestUtility.swift
@@ -23,7 +23,7 @@ import XCTest
 final public class WatchTestUtility: ChangeEventDelegate {
     private let testCase: XCTestCase
     private let matchingObjectId: ObjectId?
-    private var openExpectation: XCTestExpectation
+    private let openExpectation: XCTestExpectation
     private let closeExpectation: XCTestExpectation
     private var changeExpectation: XCTestExpectation?
     private let expectError: Bool

--- a/Realm/ObjectServerTests/WatchTestUtility.swift
+++ b/Realm/ObjectServerTests/WatchTestUtility.swift
@@ -60,7 +60,7 @@ final public class WatchTestUtility: ChangeEventDelegate {
     }
 
     public func changeStreamDidClose(with error: Error?) {
-        if (expectError) {
+        if expectError {
             XCTAssertNotNil(error)
         } else {
             XCTAssertNil(error)

--- a/Realm/ObjectServerTests/WatchTestUtility.swift
+++ b/Realm/ObjectServerTests/WatchTestUtility.swift
@@ -27,7 +27,7 @@ final public class WatchTestUtility: ChangeEventDelegate {
     private let closeExpectation: XCTestExpectation
     private var changeExpectation: XCTestExpectation?
     private let expectError: Bool
-    public var closeError: Error?
+    public var didCloseError: Error?
 
     public init(testCase: XCTestCase, matchingObjectId: ObjectId? = nil, expectError: Bool = false) {
         self.testCase = testCase
@@ -66,7 +66,7 @@ final public class WatchTestUtility: ChangeEventDelegate {
             XCTAssertNil(error)
         }
 
-        closeError = error
+        didCloseError = error
         closeExpectation.fulfill()
     }
 

--- a/Realm/RLMNetworkTransport.mm
+++ b/Realm/RLMNetworkTransport.mm
@@ -226,12 +226,14 @@ didCompleteWithError:(NSError *)error
 
     NSString *errorStatus = [NSString stringWithFormat:@"URLSession HTTP error code: %ld",
                              (long)httpResponse.statusCode];
+
+    // error may be nil when the http status code is 401/403 - replace it with [NSNull null] in that case
     NSError *wrappedError = [NSError errorWithDomain:RLMAppErrorDomain
                                                 code:RLMAppErrorHttpRequestFailed
                                             userInfo:@{NSLocalizedDescriptionKey: errorStatus,
-                                                RLMHTTPStatusCodeKey: @(httpResponse.statusCode),
+                                                       RLMHTTPStatusCodeKey: @(httpResponse.statusCode),
                                                        NSURLErrorFailingURLErrorKey: task.currentRequest.URL,
-                                                       NSUnderlyingErrorKey: error}];
+                                                       NSUnderlyingErrorKey: error?: [NSNull null]}];
     return [_subscriber didCloseWithError:wrappedError];
 }
 


### PR DESCRIPTION
It looks like we can end up in a situation where `URLSession:didCompleteWithError` is invoked with `nil` error, which results in a crash if we try to insert it as a value for `NSError.userInfo` dictionary. With this change we insert `[NSNull null]` for `NSUnderlyingErrorKey` instead.

I've added a test that uses the watch functionality as that appears to be the only thing that exercises the `RLMEventSessionDelegate` codepaths. It's not the cleanest test, but I couldn't come up with anything better that reproduces the crash.

Fixes https://github.com/realm/realm-swift/issues/8519