### PR TITLE
fix issue: #8427 copy seedFilePath

### DIFF
--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -132,6 +132,7 @@ NSString *RLMRealmPathForFile(NSString *fileName) {
     configuration->_migrationObjectClass = _migrationObjectClass;
     configuration->_initialSubscriptions = _initialSubscriptions;
     configuration->_rerunOnOpen = _rerunOnOpen;
+    configuration->_seedFilePath = _seedFilePath;
     return configuration;
 }
 

--- a/Realm/Tests/RealmConfigurationTests.mm
+++ b/Realm/Tests/RealmConfigurationTests.mm
@@ -231,4 +231,14 @@
     XCTAssertTrue(migrationCalled);
 }
 
+-(void)testCopyConfiguration {
+    RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
+    configuration.fileURL = [NSURL fileURLWithPath:@"/dev/null"];
+    configuration.seedFilePath = [NSURL fileURLWithPath:@"/dev/null/seed"];
+    
+    RLMRealmConfiguration *copy = [configuration copy];
+    XCTAssertEqualObjects(copy.fileURL, [NSURL fileURLWithPath:@"/dev/null"]);
+    XCTAssertEqualObjects(copy.seedFilePath, [NSURL fileURLWithPath:@"/dev/null/seed"]);
+}
+
 @end

--- a/RealmSwift/RealmConfiguration.swift
+++ b/RealmSwift/RealmConfiguration.swift
@@ -342,6 +342,7 @@ extension Realm {
 
             configuration.initialSubscriptions = rlmConfiguration.initialSubscriptions.map(ObjectiveCSupport.convert(block:))
             configuration.rerunOnOpen = rlmConfiguration.rerunOnOpen
+            configuration.seedFilePath = rlmConfiguration.seedFilePath
 
             return configuration
         }

--- a/RealmSwift/Tests/RealmConfigurationTests.swift
+++ b/RealmSwift/Tests/RealmConfigurationTests.swift
@@ -34,10 +34,13 @@ class RealmConfigurationTests: TestCase {
 
     func testSetDefaultConfiguration() {
         let fileURL = Realm.Configuration.defaultConfiguration.fileURL
-        let configuration = Realm.Configuration(fileURL: URL(fileURLWithPath: "/dev/null"))
+        let seedFileURL = URL(fileURLWithPath: "/dev/null/seed")
+        let configuration = Realm.Configuration(fileURL: URL(fileURLWithPath: "/dev/null"), seedFilePath: seedFileURL)
         Realm.Configuration.defaultConfiguration = configuration
         XCTAssertEqual(Realm.Configuration.defaultConfiguration.fileURL, URL(fileURLWithPath: "/dev/null"))
+        XCTAssertEqual(Realm.Configuration.defaultConfiguration.seedFilePath, seedFileURL)
         Realm.Configuration.defaultConfiguration.fileURL = fileURL
+        Realm.Configuration.defaultConfiguration.seedFilePath = nil
     }
 
     func testCannotSetMutuallyExclusiveProperties() {


### PR DESCRIPTION
fixes bug when using `seedFilePath` and then eg. opening realm async