### PR TITLE
Fix release workflow issues

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -93,6 +93,7 @@ jobs:
       name: Run installation test for ${{ matrix.platform }}, ${{ matrix.installation }} and ${{ matrix.linkage }}
       needs: [create-release, prepare, publish-cocoapods]
       strategy:
+        fail-fast: false
         matrix:
           platform: [ios, osx, watchos, tvos, catalyst, visionos]
           installation: [cocoapods, spm, carthage, xcframework]
@@ -135,13 +136,19 @@ jobs:
         - name: Set REALM_TEST_RELEASE
           run: echo "REALM_TEST_RELEASE=${{ needs.prepare.outputs.VERSION }}" >> $GITHUB_ENV
         - name: Run installation test
-          run: |
-            cd examples/installation
-            bundle exec ./build.rb ${{ matrix.platform }} ${{ matrix.installation }} ${{ matrix.linkage }}
+          uses: nick-fields/retry@v3
+          with:
+            command: |
+              cd examples/installation
+              bundle exec ./build.rb ${{ matrix.platform }} ${{ matrix.installation }} ${{ matrix.linkage }}
+            timeout_minutes: 30
+            max_attempts: 10
+            retry_wait_seconds: 60
+            retry_on: error
   post-slack-release:
       runs-on: macos-latest
       name: Publish to release Slack channel
-      needs: [test-installation, prepare]
+      needs: [create-release, prepare, publish-cocoapods, update-checker, publish-docs]
       env:
         WEBHOOK_URL: ${{ secrets.SLACK_RELEASES_WEBHOOK }}
       steps:
@@ -152,7 +159,7 @@ jobs:
         - name: Prepare Changelog
           run: bundle exec ./build.sh prepare-publish-changelog
         - name: 'Post to #realm-releases'
-          uses: realm/ci-actions/release-to-slack@v3
+          uses: realm/ci-actions/release-to-slack@a2191a6cbf2f5b50aa71026dd068582dbd5016cc
           with:
             changelog: ExtractedChangelog/CHANGELOG.md
             sdk: Swift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+x.y.z Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
+* None.
+
+<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
+
+### Compatibility
+* Realm Studio: 15.0.0 or later.
+* APIs are backwards compatible with all previous releases in the 10.x.y series.
+* Carthage release for Swift is built with Xcode 15.3.0.
+* CocoaPods: 1.10 or later.
+* Xcode: 15.1.0-15.3.0.
+
+### Internal
+* Upgraded realm-core from ? to ?
+
 10.50.0 Release notes (2024-05-02)
 =============================================================
 


### PR DESCRIPTION
This adds an empty changelog section as well as tweaks a few things about the release workflow
1. Disable fail-fast for the installation test job as we want to try and test all installation methods, even if some of them fail.
2. Uses https://github.com/marketplace/actions/retry-step to retry installation tests on failure. Currently set to 10 retries with 60 seconds between them. This is needed due to CocoaPods not indexing a new release quickly enough.
3. Parallelize some of the steps - i.e. the post to slack/update changelog jobs don't need to be waiting for the installation tests.
4. Bump the `release-to-slack` action to latest main. It includes a bugfix where not being able to transform markdown to slack blocks won't fail the job, but rather will post a message with a link to the release instead.