### PR TITLE
Update deprecated method usage in encryption example

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,11 @@ Data can be encrypted in-flight and at-rest, keeping even the most sensitive dat
 ```swift
 // Generate a random encryption key
 var key = Data(count: 64)
-_ = key.withUnsafeMutableBytes { bytes in
-    SecRandomCopyBytes(kSecRandomDefault, 64, bytes)
+_ = key.withUnsafeMutableBytes { (pointer: UnsafeMutableRawBufferPointer) in
+    guard let baseAddress = pointer.baseAddress else {
+        fatalError("Failed to obtain base address")
+    }
+    SecRandomCopyBytes(kSecRandomDefault, 64, baseAddress)
 }
 
 // Add the encryption key to the config and open the realm


### PR DESCRIPTION
Hello, this is just a small PR for update README example code.

### Goals
Update the code example in the documentation to replace the [deprecated `withUnsafeMutableBytes` method ](https://developer.apple.com/documentation/foundation/data/1779823-withunsafemutablebytes)with a more modern and safe approach.

### Expected results
The documentation should now include an example that does not use any deprecated methods, ensuring it remains current and free of warnings.

### Actual results
The documentation previously included an example that used the deprecated `withUnsafeMutableBytes` method, which could lead to warnings or potential issues in future Swift versions.

### Steps to reproduce
1. Open the Realm Swift documentation.
2. Locate the example code that generates a random encryption key.
3. Observe the use of the deprecated `withUnsafeMutableBytes` method.

### Code sample that highlights the issue
```swift
// Generate a random encryption key
var key = Data(count: 64)
_ = key.withUnsafeMutableBytes { bytes in
    SecRandomCopyBytes(kSecRandomDefault, 64, bytes)
}

// Add the encryption key to the config and open the realm
let config = Realm.Configuration(encryptionKey: key)
let realm = try Realm(configuration: config)

// Use the Realm as normal
let dogs = realm.objects(Dog.self).filter("name contains 'Fido'")
