### PR TITLE
RCOCOA-1883: Add "Sync is not enabled for this App" as a catchable error in error handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* Added support for filtering logs by category. Users wil have more fine grained control over 
-  the log level for each category as well.
+* Added support for setting the log level for a category in `Logger`. User will have more fine grained control over 
+  the log level for each category.
   ```swift
   Logger.setLogLevel(.info, category: Category.Storage.transactions)
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ x.y.z Release notes (yyyy-MM-dd)
   binaries so Xcode can validate it was signed by the same developer on every new version. 
   ([Apple](https://developer.apple.com/support/third-party-SDK-requirements/)).
 * Throw any sync errors tagged with warning action from the server via the sync error handler. 
+* Report sync warnings from the server such as sync being disabled server-side to the sync error handler.
   ([#8020](https://github.com/realm/realm-swift/issues/8020)).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,14 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* Added support for setting the log level for a category in `Logger`. User will have more fine grained control over 
-  the log level for each category.
+* Added support for filtering logs by category. Users wil have more fine grained control over 
+  the log level for each category as well.
   ```swift
   Logger.setLogLevel(.info, category: Category.Storage.transactions)
   ```
 * Code sign our published xcframeworks. By Apple's requirements, we should sign our release
   binaries so Xcode can validate it was signed by the same developer on every new version. 
   ([Apple](https://developer.apple.com/support/third-party-SDK-requirements/)).
-* Throw any sync errors tagged with warning action from the server via the sync error handler. 
 * Report sync warnings from the server such as sync being disabled server-side to the sync error handler.
   ([#8020](https://github.com/realm/realm-swift/issues/8020)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ x.y.z Release notes (yyyy-MM-dd)
 * Code sign our published xcframeworks. By Apple's requirements, we should sign our release
   binaries so Xcode can validate it was signed by the same developer on every new version. 
   ([Apple](https://developer.apple.com/support/third-party-SDK-requirements/)).
+* Throw any sync errors tagged with warning action from the server via the sync error handler. 
+  ([#8020](https://github.com/realm/realm-swift/issues/8020)).
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)

--- a/Realm/ObjectServerTests/RealmServer.swift
+++ b/Realm/ObjectServerTests/RealmServer.swift
@@ -469,6 +469,7 @@ class Admin {
 public enum SyncMode {
     case pbs(String) // partition based
     case flx([String]) // flexible sync
+    case notSync
 }
 
 // MARK: RealmServer
@@ -815,6 +816,10 @@ public class RealmServer: NSObject {
             }
         }
 
+        if case .notSync = syncMode {
+            return clientAppId
+        }
+
         app.secrets.post(on: group, [
             "name": "BackingDB_uri",
             "value": "mongodb://localhost:26000"
@@ -927,6 +932,8 @@ public class RealmServer: NSObject {
                     "delete": true
                 ]]
             ]).get()
+        default:
+            fatalError()
         }
         _ = try app.services[serviceId].config.patch(serviceConfig).get()
 
@@ -1009,6 +1016,10 @@ public class RealmServer: NSObject {
 
     @objc public func createApp(partitionKeyType: String = "string", types: [ObjectBase.Type], persistent: Bool = false) throws -> AppId {
         return try createApp(syncMode: .pbs(partitionKeyType), types: types, persistent: persistent)
+    }
+
+    @objc public func createNotSyncApp() throws -> AppId {
+        return try createApp(syncMode: .notSync, types: [], persistent: false)
     }
 
     /// Delete all Apps created without `persistent: true`

--- a/Realm/ObjectServerTests/RealmServer.swift
+++ b/Realm/ObjectServerTests/RealmServer.swift
@@ -1028,10 +1028,7 @@ public class RealmServer: NSObject {
 
     // Retrieve Atlas App Services AppId with ClientAppId using the Admin API
     public func retrieveAppServerId(_ clientAppId: String) throws -> String {
-        guard let session = session else {
-            fatalError()
-        }
-
+        let session = try XCTUnwrap(session)
         let appsListInfo = try session.apps.get().get()
         guard let appsList = appsListInfo as? [[String: Any]] else {
             throw URLError(.badServerResponse)
@@ -1052,9 +1049,7 @@ public class RealmServer: NSObject {
     }
 
     public func retrieveSyncServiceId(appServerId: String) throws -> String {
-        guard let session = session else {
-            fatalError()
-        }
+        let session = try XCTUnwrap(session)
         let app = session.apps[appServerId]
         // Get all services
         guard let syncServices = try app.services.get().get() as? [[String: Any]] else {
@@ -1083,14 +1078,11 @@ public class RealmServer: NSObject {
         }
     }
 
-    public func isSyncEnabled(flexibleSync: Bool = false, appServerId: String, syncServiceId: String) throws -> Bool {
-        let configOption = flexibleSync ? "flexible_sync" : "sync"
-        guard let session = session else {
-            fatalError()
-        }
+    public func isSyncEnabled(appServerId: String, syncServiceId: String) throws -> Bool {
+        let session = try XCTUnwrap(session)
         let app = session.apps[appServerId]
         let response = try app.services[syncServiceId].config.get().get() as? [String: Any]
-        guard let syncInfo = response?[configOption] as? [String: Any] else {
+        guard let syncInfo = response?["flexible_sync"] as? [String: Any] else {
             return false
         }
         return syncInfo["state"] as? String == "enabled"
@@ -1113,28 +1105,23 @@ public class RealmServer: NSObject {
         return app.sync.config.put(["development_mode_enabled": true])
     }
 
-    public func disableSync(flexibleSync: Bool = false, appServerId: String, syncServiceId: String)
-            -> Result<Any?, Error> {
-        let configOption = flexibleSync ? "flexible_sync" : "sync"
-        guard let session = session else {
-            return .failure(URLError(.unknown))
-        }
+    public func disableSync(appServerId: String, syncServiceId: String) throws -> Any? {
+        let session = try XCTUnwrap(session)
         let app = session.apps[appServerId]
-        return app.services[syncServiceId].config.patch([configOption: ["state": ""]])
+        return app.services[syncServiceId].config.patch(["flexible_sync": ["state": ""]])
     }
 
-    public func enableSync(flexibleSync: Bool = false, appServerId: String, syncServiceId: String, syncServiceConfiguration: [String: Any]) -> Result<Any?, Error> {
-        let configOption = flexibleSync ? "flexible_sync" : "sync"
+    public func enableSync(appServerId: String, syncServiceId: String, syncServiceConfiguration: [String: Any]) -> Result<Any?, Error> {
         var syncConfig = syncServiceConfiguration
         guard let session = session else {
             return .failure(URLError(.unknown))
         }
         let app = session.apps[appServerId]
-        guard var syncInfo = syncConfig[configOption] as? [String: Any] else {
+        guard var syncInfo = syncConfig["flexible_sync"] as? [String: Any] else {
             return .failure(URLError(.unknown))
         }
         syncInfo["state"] = "enabled"
-        syncConfig[configOption] = syncInfo
+        syncConfig["flexible_sync"] = syncInfo
         return app.services[syncServiceId].config.patch(syncConfig)
     }
 

--- a/Realm/ObjectServerTests/SwiftFlexibleSyncServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftFlexibleSyncServerTests.swift
@@ -1188,27 +1188,17 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     }
 
     func testFlexibleSyncNotEnabledError() throws {
-        let appServerId = try RealmServer.shared.retrieveAppServerId(appId)
-        let syncServerId = try RealmServer.shared.retrieveSyncServiceId(appServerId: appServerId)
-        _ = try RealmServer.shared.disableSync(appServerId: appServerId, syncServiceId: syncServerId)
-        var isEnable = try RealmServer.shared.isSyncEnabled(appServerId: appServerId, syncServiceId: syncServerId)
-        XCTAssertFalse(isEnable)
-
+        let appId = try RealmServer.shared.createNotSyncApp()
+        let app = app(id: appId)
         let ex = expectation(description: "Waiting for error handler to be called...")
         ex.assertForOverFulfill = false // error handler can legally be called multiple times
         app.syncManager.errorHandler = { @Sendable (error, _) in
-            assertSyncError(error, .clientInternalError, "Sync is not enabled for this app")
+            assertSyncError(error, .serverWarning, "Sync is not enabled for this app")
             ex.fulfill()
         }
 
-        _ = try Realm(configuration: configuration()) // Sync is disabled so we cannot use async open
+        _ = try Realm(configuration: configuration(app: app)) // Sync is disabled so we cannot use async open
         wait(for: [ex], timeout: 10.0)
-
-        let configuration = try RealmServer.shared.getSyncServiceConfiguration(appServerId: appServerId, syncServiceId: syncServerId)
-        _ = try RealmServer.shared.enableSync(appServerId: appServerId, syncServiceId: syncServerId, syncServiceConfiguration: configuration!).get()
-
-        isEnable = try RealmServer.shared.isSyncEnabled(appServerId: appServerId, syncServiceId: syncServerId)
-        XCTAssertTrue(isEnable)
     }
 }
 

--- a/Realm/RLMError.h
+++ b/Realm/RLMError.h
@@ -328,6 +328,11 @@ typedef RLM_ERROR_ENUM(NSInteger, RLMSyncError, RLMSyncErrorDomain) {
      Connecting to the server failed due to a TLS issue such as an invalid certificate.
      */
     RLMSyncErrorTLSHandshakeFailed = 13,
+    /**
+     An error indicating the server send down an error with a warning action, which
+     needs to be executed by the client or the end user.
+     */
+    RLMSyncErrorServerWarning = 14,
 };
 
 #pragma mark - RLMSyncAuthError

--- a/Realm/RLMError.h
+++ b/Realm/RLMError.h
@@ -329,8 +329,11 @@ typedef RLM_ERROR_ENUM(NSInteger, RLMSyncError, RLMSyncErrorDomain) {
      */
     RLMSyncErrorTLSHandshakeFailed = 13,
     /**
-     An error indicating the server send down an error with a warning action, which
-     needs to be executed by the client or the end user.
+     The server has encountered an error that it wants the user to know about,
+     but is not necessarily fatal.
+
+     An error with this code may indicate that either sync is not enabled or it's trying to connect to
+     an edge server app.
      */
     RLMSyncErrorServerWarning = 14,
 };

--- a/Realm/RLMError.mm
+++ b/Realm/RLMError.mm
@@ -292,7 +292,9 @@ NSError *makeError(realm::SyncError&& error, const std::shared_ptr<realm::app::A
                 errorCode = RLMSyncErrorClientResetError;
             else if (isSyncError)
                 errorCode = RLMSyncErrorClientSessionError;
-            else if (!error.is_fatal && error.server_requests_action != realm::sync::ProtocolErrorInfo::Action::Warning)
+            else if (error.server_requests_action == realm::sync::ProtocolErrorInfo::Action::Warning)
+                errorCode = RLMSyncErrorServerWarning;
+            else if (!error.is_fatal)
                 return nil;
             break;
     }

--- a/Realm/RLMError.mm
+++ b/Realm/RLMError.mm
@@ -292,7 +292,7 @@ NSError *makeError(realm::SyncError&& error, const std::shared_ptr<realm::app::A
                 errorCode = RLMSyncErrorClientResetError;
             else if (isSyncError)
                 errorCode = RLMSyncErrorClientSessionError;
-            else if (!error.is_fatal)
+            else if (!error.is_fatal && error.server_requests_action != realm::sync::ProtocolErrorInfo::Action::Warning)
                 return nil;
             break;
     }


### PR DESCRIPTION
Report any sync errors tagged with warning action from the server via the sync error handler.