### PR TITLE
Redesign the Logger API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,25 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* Added support for filtering logs by category. Users wil have more fine grained control over
-  the log level for each category as well.
+* Redesign the Logger API to allow dynamically adding and removing log
+  callbacks and setting separate log levels for different categories.
+
   ```swift
-  Logger.setLogLevel(.info, category: Category.Storage.transactions)
+  // Unlike setting Logger.shared, this can be done at any time rather than
+  // having to be done before opening a Realm
+  Logger.add { level, category, message in
+    print("Realm Log - \(category.rawValue)-\(level): \(message)")
+  }
+  // Set the log level for just sync messages to warn
+  Logger.set(level: .warn, category: Category.Sync.all)
+  // Equivalent to old Logger.shared.level = .all
+  Logger.set(level: .all, category: Category.realm)
   ```
+
+  The old API remains for backwards compatibility but is deprecated. The two
+  cannot be mixed and setting `Logger.shared` will disable `Logger.add`.
 * Code sign our published xcframeworks. By Apple's requirements, we should sign our release
-  binaries so Xcode can validate it was signed by the same developer on every new version. 
+  binaries so Xcode can validate it was signed by the same developer on every new version.
   ([Apple](https://developer.apple.com/support/third-party-SDK-requirements/)).
 * Report sync warnings from the server such as sync being disabled server-side to the sync error handler.
   ([#8020](https://github.com/realm/realm-swift/issues/8020)).
@@ -18,9 +30,10 @@ x.y.z Release notes (yyyy-MM-dd)
 
 ### Deprecations
 * `RLMLogger.level`/`Logger.level` has been deprecated in favor of using
-  `RLMLogger.setLevel:forCategory:`/`Logger.setLevel(:category:)` and
-  `RLMLogger.getLevelForCategory:`/`Logger.getLevel(for:)`.
-* It is not recommended to initialize a `RLMLogger/Logger` with a level anymore.
+  `RLMLogger.setLevel:forCategory:`/`Logger.set(level:category:)` and
+  `RLMLogger.levelForCategory:`/`Logger.level(for:)`.
+* Initializing `RLMLogger`/`Logger` instances is deprecated in favor of calling
+  `+[RLMLogger addLogFunction:]`/`Logger.add()`.
 
 ### Compatibility
 * Realm Studio: 15.0.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* Added support for filtering logs by category. Users wil have more fine grained control over 
+* Added support for filtering logs by category. Users wil have more fine grained control over
   the log level for each category as well.
   ```swift
   Logger.setLogLevel(.info, category: Category.Storage.transactions)
@@ -17,7 +17,9 @@ x.y.z Release notes (yyyy-MM-dd)
 * None.
 
 ### Deprecations
-* `RLMLogger.level`/`Logger.level` has been deprecated in favor of using `RLMLogger.setLevel:forCategory:`/`Logger.setLevel(:category:)` and `RLMLogger.getLevelForCategory:`/`Logger.getLevel(for:)`.
+* `RLMLogger.level`/`Logger.level` has been deprecated in favor of using
+  `RLMLogger.setLevel:forCategory:`/`Logger.setLevel(:category:)` and
+  `RLMLogger.getLevelForCategory:`/`Logger.getLevel(for:)`.
 * It is not recommended to initialize a `RLMLogger/Logger` with a level anymore.
 
 ### Compatibility

--- a/Realm/ObjectServerTests/RLMSyncTestCase.mm
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.mm
@@ -613,7 +613,6 @@ static bool s_opensApp;
     RLMApp *app = [RLMApp appWithConfiguration:config];
     RLMSyncManager *syncManager = app.syncManager;
     syncManager.userAgent = self.name;
-    [RLMLogger setLevel:RLMLogLevelWarn forCategory:RLMLogCategorySync];
     return app;
 }
 

--- a/Realm/RLMLogger.h
+++ b/Realm/RLMLogger.h
@@ -168,15 +168,6 @@ __attribute__((deprecated("Use `initWithLogFunction:` instead.")));
 @property (class) RLMLogger *defaultLogger NS_SWIFT_NAME(shared);
 
 /**
- Log a message to the supplied level.
-
- @param logLevel The log level for the message.
- @param category The log category for the message.
- @param message The message to log.
- */
-- (void)logWithLevel:(RLMLogLevel)logLevel category:(RLMLogCategory)category message:(NSString *)message;
-
-/**
  Sets the gobal log level for a given category.
 
  @param level The log level to be set for the logger.

--- a/Realm/RLMLogger_Private.h
+++ b/Realm/RLMLogger_Private.h
@@ -40,8 +40,7 @@ FOUNDATION_EXTERN void RLMTestLog(RLMLogCategory category, RLMLogLevel level, co
 /// Logger function for operations within the SDK, to be used from obj-c code.
 void RLMLog(RLMLogLevel level, NSString *format, ...);
 
-// Helpers for the Swift Logger.log() function
+// Helper for the Swift Logger.log() function
 FOUNDATION_EXTERN void RLMLogRaw(RLMLogLevel level, NSString *message);
-FOUNDATION_EXTERN void RLMLogDeferred(RLMLogLevel level, NSString *(NS_NOESCAPE ^message)(void));
 
 RLM_HEADER_AUDIT_END(nullability)

--- a/Realm/RLMLogger_Private.h
+++ b/Realm/RLMLogger_Private.h
@@ -47,10 +47,6 @@ Gets all the categories from Core. This is to be used for testing purposes only.
  */
 + (NSArray<NSString *> *)allCategories;
 
-/**
-Returns a `RLMLogCategory` from a string.
- */
-+ (RLMLogCategory)categoryFromString:(NSString *)string;
 @end
 
 RLM_HEADER_AUDIT_END(nullability)

--- a/Realm/RLMLogger_Private.h
+++ b/Realm/RLMLogger_Private.h
@@ -23,23 +23,6 @@ RLM_HEADER_AUDIT_BEGIN(nullability)
 
 @interface RLMLogger()
 
-/**
- Log a message to the supplied level.
-
- @param logLevel The log level for the message.
- @param message The message to log.
- */
-- (void)logWithLevel:(RLMLogLevel)logLevel message:(NSString *)message, ... NS_SWIFT_UNAVAILABLE("");
-
-/**
- Log a message to the supplied level.
-
- @param logLevel The log level for the message.
- @param categoryName The log category name for the message.
- @param message The message to log.
- */
-- (void)logWithLevel:(RLMLogLevel)logLevel categoryName:(NSString *)categoryName message:(NSString *)message;
-
 #pragma mark Testing
 
 /**
@@ -47,6 +30,18 @@ Gets all the categories from Core. This is to be used for testing purposes only.
  */
 + (NSArray<NSString *> *)allCategories;
 
+/// Log a message via core's default logger for testing purposes
+FOUNDATION_EXTERN void RLMTestLog(RLMLogCategory category, RLMLogLevel level, const char *message);
+
 @end
+
+#pragma mark Internal SDK logging
+
+/// Logger function for operations within the SDK, to be used from obj-c code.
+void RLMLog(RLMLogLevel level, NSString *format, ...);
+
+// Helpers for the Swift Logger.log() function
+FOUNDATION_EXTERN void RLMLogRaw(RLMLogLevel level, NSString *message);
+FOUNDATION_EXTERN void RLMLogDeferred(RLMLogLevel level, NSString *(NS_NOESCAPE ^message)(void));
 
 RLM_HEADER_AUDIT_END(nullability)

--- a/Realm/RLMSyncManager.h
+++ b/Realm/RLMSyncManager.h
@@ -105,25 +105,25 @@ __attribute__((deprecated("This property is not used for anything")));
  The logging threshold which newly opened synced Realms will use. Defaults to
  `RLMSyncLogLevelInfo`.
 
- By default logging strings are output to Apple System Logger. Set `logger` to
+ By default logging strings are output to NSLog. Set `logger` to
  perform custom logging logic instead.
 
  @warning This property must be set before any synced Realms are opened. Setting it after
           opening any synced Realm will do nothing.
  */
 @property (atomic) RLMSyncLogLevel logLevel
-__attribute__((deprecated("Use `RLMLogger.default.level`/`Logger.shared.level` to set/get the default logger threshold level.")));
+__attribute__((deprecated("Use `Logger.set(level: level, category: Category.Sync.all)` to set the log level for sync operations.")));
 
 /**
  The function which will be invoked whenever the sync client has a log message.
 
- If nil, log strings are output to Apple System Logger instead.
+ If nil, log strings are output to RLMLogger instead.
 
  @warning This property must be set before any synced Realms are opened. Setting
           it after opening any synced Realm will do nothing.
  */
 @property (atomic, nullable) RLMSyncLogFunction logger
-__attribute__((deprecated("Use `RLMLogger.default`/`Logger.shared` to set/get the default logger.")));
+__attribute__((deprecated("Use `Logger.add(function:)` and filter messages by category.")));
 
 /**
  The name of the HTTP header to send authorization data in when making requests to Atlas App Services which has

--- a/Realm/TestUtils/RLMTestCase.m
+++ b/Realm/TestUtils/RLMTestCase.m
@@ -96,6 +96,9 @@ static BOOL encryptTests(void) {
     // resetting the simulator
     [NSFileManager.defaultManager createDirectoryAtURL:RLMDefaultRealmURL().URLByDeletingLastPathComponent
                            withIntermediateDirectories:YES attributes:nil error:nil];
+
+    [RLMLogger resetToDefault];
+    [RLMLogger setLevel:RLMLogLevelWarn forCategory:RLMLogCategorySync];
 }
 
 // This ensures the shared schema is initialized outside of of a test case,
@@ -114,6 +117,11 @@ static BOOL encryptTests(void) {
 
 @implementation RLMTestCase {
     dispatch_queue_t _bgQueue;
+}
+
+- (void)tearDown {
+    [RLMLogger resetToDefault];
+    [RLMLogger setLevel:RLMLogLevelWarn forCategory:RLMLogCategorySync];
 }
 
 - (void)deleteFiles {

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -3030,8 +3030,8 @@
     RLMLogger.defaultLogger = logger;
     [RLMLogger setLevel:RLMLogLevelDebug forCategory:category];
 
-    [logger logWithLevel:RLMLogLevelInfo message:@"%@ IMPORTANT INFO %i", @"TEST:", 0];
-    [logger logWithLevel:RLMLogLevelTrace message:@"IMPORTANT TRACE"];
+    RLMLog(RLMLogLevelInfo, @"%@ IMPORTANT INFO %i", @"TEST:", 0);
+    RLMLog(RLMLogLevelTrace, @"IMPORTANT TRACE");
     XCTAssertTrue([logs containsString:@"TEST: IMPORTANT INFO 0"]); // Detail
     XCTAssertFalse([logs containsString:@"IMPORTANT TRACE"]); // Trace
 }

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -3034,13 +3034,6 @@
     XCTAssertFalse([logs containsString:@"IMPORTANT TRACE"]); // Trace
 }
 
-// Core defines the different categories in runtime, forcing the SDK to define the categories again.
-// This test validates that we have added new defined categories to the RLMLogCategory enum.
-- (void)testAllCategoriesWatchDog {
-    for (id category in [RLMLogger allCategories]) {
-        XCTAssertNoThrow([RLMLogger categoryFromString:category]);
-    }
-}
 @end
 
 @interface RLMMetricsTests : RLMTestCase

--- a/RealmSwift/Logger.swift
+++ b/RealmSwift/Logger.swift
@@ -57,18 +57,18 @@ extension Logger {
      Log a message to the supplied level.
 
      ```swift
-     let logger = Logger(level: .info, logFunction: { level, message in
-         print("Realm Log - \(level): \(message)")
-     })
-     logger.log(level: .info, message: "Info DB: Database opened succesfully")
+     Logger.log(.info, "DB: Database opened succesfully")
      ```
 
      - parameter level: The log level for the message.
      - parameter category: The log category for the message.
      - parameter message: The message to log.
      */
-    internal func log(level: LogLevel, category: LogCategory = Category.sdk, message: String) {
-        self.log(with: level, category: ObjectiveCSupport.convert(value: category), message: message)
+    internal static func log(_ level: LogLevel, _ message: String) {
+        RLMLogRaw(level, message)
+    }
+    internal static func log(_ level: LogLevel, _ message: @autoclosure () -> DefaultStringInterpolation) {
+        RLMLogDeferred(level) { message().description }
     }
 
     /**
@@ -247,7 +247,7 @@ public enum Category: String, LogCategory {
     }
 }
 
-private extension ObjectiveCSupport {
+internal extension ObjectiveCSupport {
 
     /// Converts a Swift category `LogCategory` to an Objective-C `RLMLogCategory.
     /// - Parameter value: The `LogCategory`.


### PR DESCRIPTION
Rather than creating Logger instances but then setting the log level via static methods, skip creating Logger instances entirely and do something similar to Kotlin's API with `Logger.add(logFn)` which registers a new callback to be called. More than one callback can be registered at once, and callbacks can be dynamically registered and unregistered rather than having to set up the logger before opening the Realm. This differs from Kotlin's design in that we use a token to unregister rather than `Logger.remove()` as the latter has some potentially surprising quirks.

Logging messages from the SDK is now decoupled from RLMLogger and uses a separate `RLMLog()` function which logs directly to the registered callbacks.

`logCategoryForCategoryName()` was unnecessarily slow as it converted the category's name to a NSString, constructed a large NSDictionary, performed a single lookup in that dictionary, and then discarded it for every message logged. Although obj-c does now support creating literal NSDictionaries as compile-time constants that would make this reasonable, that requires a deployment target of iOS 14 and we currently target iOS 12. This change cuts the time spent in `do_log()` (which includes the actual logging of the strings) when running the tests with loglevel=all by about 20%.

The dictionary lookup also turns out to just not be faster than a linear scan on a const array. This may change if we add sufficiently more categories in the future.

The deprecated old version of the logger function still needs to be tested until it's removed entirely.