### PR TITLE
Fix documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Interested in getting started for free with [a template application](https://git
 
 ## Documentation
 
-The documentation can be found at [mongodb.com/docs/atlas/device-sdks/sdk/swift/](https://www.mongodb.com/docs/atlas/device-sdks/sdk/swift//).
+The documentation can be found at [mongodb.com/docs/atlas/device-sdks/sdk/swift/](https://www.mongodb.com/docs/atlas/device-sdks/sdk/swift/).
 The API reference is located at [mongodb.com/docs/realm-sdks/swift/latest/](https://www.mongodb.com/docs/realm-sdks/swift/latest/)
 
 ## Getting Help


### PR DESCRIPTION
Before, clicking on the link redirected to a 404 page, but now it correctly navigates to the documentation.