### PR TITLE
RCOCOA-2423 Fix the type signature of async `User.functions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ x.y.z Release notes (yyyy-MM-dd)
   non-null return value despite always returning `nil` (since v10.29.0).
 * Eliminate several clang static analyzer warnings which did not report actual
   bugs.
+* The async and Future versions of `User.functions` only worked for functions
+  which took exactly one argument, which had to be an array ([#8669](https://github.com/realm/realm-swift/issues/8669), since 10.16.0).
 
 ### Compatibility
 * Realm Studio: 15.0.0 or later.

--- a/Realm/ObjectServerTests/AsyncSyncTests.swift
+++ b/Realm/ObjectServerTests/AsyncSyncTests.swift
@@ -350,7 +350,7 @@ class AsyncAwaitSyncTests: SwiftSyncTestCase {
 
     func testUserCallFunctionAsyncAwait() async throws {
         let user = try await self.app.login(credentials: basicCredentials())
-        guard case let .int32(sum) = try await user.functions.sum([1, 2, 3, 4, 5]) else {
+        guard case let .int32(sum) = try await user.functions.sum(.array([1, 2, 3, 4, 5])) else {
             return XCTFail("Should be int32")
         }
         XCTAssertEqual(sum, 15)

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -893,7 +893,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         let credentials = Credentials.emailPassword(email: email, password: password)
         let syncUser = app.login(credentials: credentials).await(self)
 
-        let bson = syncUser.functions.sum([1, 2, 3, 4, 5]).await(self)
+        let bson = syncUser.functions.sum(.array([1, 2, 3, 4, 5])).await(self)
         guard case let .int32(sum) = bson else {
             XCTFail("unexpected bson type in sum: \(bson)")
             return


### PR DESCRIPTION
The async and Future versions of this were incorrectly defined as taking exactly one argument which had to be an array of BSON values rather than any number of BSON arguments.

Fixes #8669.