### PR TITLE
RCOCOA-2394 RCOCOA-2396 RCOCOA-2397 Build in Swift 6 language mode when supported

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -16,13 +16,8 @@ jobs:
       core-version: ${{ steps.get-core-version.outputs.version }}
     strategy:
       matrix:
-        target: [macosx, iphoneos, iphonesimulator, appletvos, appletvsimulator, watchos, watchsimulator, maccatalyst]
-        xcode: ["15.1"]
-        include:
-          - target: xros
-            xcode: "15.2.0"
-          - target: xrsimulator
-            xcode: "15.2.0"
+        target: [macosx, iphoneos, iphonesimulator, appletvos, appletvsimulator, watchos, watchsimulator, maccatalyst, xros, xrsimulator]
+        xcode: ["15.3"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -6,7 +6,7 @@ on:
       - "master"
       - "release/**"
 env:
-  XCODE_VERSION: "['15.1', '15.2', '15.3', '15.4']"
+  XCODE_VERSION: "['15.3', '15.4', '16_beta_6', '16.1_beta']"
   PLATFORM: "['ios', 'osx', 'watchos', 'tvos', 'catalyst', 'visionos']"
   DOC_VERSION: '15.4'
   RELEASE_VERSION: '15.4'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,8 +1,8 @@
 name: Publish release
 on: workflow_dispatch
 env:
-  XCODE_VERSION: "['15.1', '15.2', '15.3', '15.4']"
-  TEST_XCODE_VERSION: '15.3'
+  XCODE_VERSION: "['15.3', '15.4', '16_beta_6', '16.1_beta']"
+  TEST_XCODE_VERSION: '15.4'
 jobs:
   prepare:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,34 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
+
+The minimum supported version of Xcode is now 15.3.
+
 ### Enhancements
-* None.
+* Build in Swift 6 language mode when using Xcode 16. Libraries build in Swift
+  6 mode can be consumed by apps built in Swift 5 mode, so this should not have
+  any immediate effects beyond eliminating some warnings and ensuring that all
+  Realm APIs can be used in Swift 6 mode. Some notes about using Realm Swift in
+  Swift 6:
+  - `try await Realm(actor: actor)` has been replaced with `try await
+  Realm.open()` to work around isolated parameters not being implemented for
+  initializers (https://github.com/swiftlang/swift/issues/71174). The actor is
+  now automatically inferred and should not be manually passed in.
+  - `@ThreadSafe` is not usable as a property wrapper on local variables and
+  function arguments in Swift 6 mode. Sendability checking for property
+  wrappers never got implemented due to them being quietly deprecated in favor
+  of macros. It can still be used as a property wrapper for class properties
+  and as a manual wrapper locally, but note that it does not combine well with
+  actor-isolated Realms.
+  - In Swift 6 mode a few mongo client functions have changed from returning
+  `[AnyHashable: Any]` to `Document`. These should have been `Document` all
+  along, and the old return type no longer compiles due to not being Sendable.
+* Some SwiftUI components are now explicitly marked as `@MainActor`. These
+  types were implicitly `@MainActor` in Swift 5, but became nonisolated when
+  using Xcode 16 in Swift 5 mode due to the removal of implicit isolation when
+  using property wrappers on member variables. This resulted in some new
+  sendability warnings in Xcode 16 (or errors in Swift 6 mode).
+* Add Xcode 16 and 16.1 binaries to the release packages (currently built with
+  beta 6 and beta 1 respectively).
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-swift/issues/????), since v?.?.?)
@@ -14,7 +41,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * APIs are backwards compatible with all previous releases in the 10.x.y series.
 * Carthage release for Swift is built with Xcode 15.4.0.
 * CocoaPods: 1.10 or later.
-* Xcode: 15.1.0-16 beta 5.
+* Xcode: 15.3.0-16.1 beta.
 
 ### Internal
 * Upgraded realm-core from ? to ?

--- a/Configuration/Base.xcconfig
+++ b/Configuration/Base.xcconfig
@@ -76,6 +76,9 @@ APPLICATION_EXTENSION_API_ONLY = YES;
 REALM_MACH_O_TYPE = mh_dylib;
 SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator watchos watchsimulator appletvos appletvsimulator xros xrsimulator;
 SUPPORTS_MACCATALYST = YES;
-SWIFT_VERSION = 5.7;
 TARGETED_DEVICE_FAMILY = 1,2,3,4,6,7;
+
+SWIFT_VERSION_1500 = 5.7;
+SWIFT_VERSION_1600 = 5.7;
+SWIFT_VERSION = $(SWIFT_VERSION_$(XCODE_VERSION_MAJOR));
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,16 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.10
 
 import PackageDescription
 import Foundation
 
 let coreVersion = Version("14.12.1")
 let cocoaVersion = Version("10.53.1")
+
+#if compiler(>=6)
+let swiftVersion = [SwiftVersion.version("6")]
+#else
+let swiftVersion = [SwiftVersion.v5]
+#endif
 
 let cxxSettings: [CXXSetting] = [
     .headerSearchPath("."),
@@ -392,5 +398,6 @@ let package = Package(
             ]
         )
     ],
+    swiftLanguageVersions: swiftVersion,
     cxxLanguageStandard: .cxx20
 )

--- a/Realm/ObjectServerTests/ClientResetTests.swift
+++ b/Realm/ObjectServerTests/ClientResetTests.swift
@@ -44,6 +44,7 @@ func waitForEditRecoveryMode(flexibleSync: Bool = false, appId: String, disable:
 
 @available(macOS 13, *)
 class ClientResetTests: SwiftSyncTestCase {
+    @MainActor
     func prepareClientReset(app: App? = nil) throws -> User {
         let app = app ?? self.app
         let config = try configuration(app: app)
@@ -68,6 +69,7 @@ class ClientResetTests: SwiftSyncTestCase {
         return user
     }
 
+    @MainActor
     func expectSyncError(_ fn: () -> Void) -> SyncError? {
         let error = Locked(SyncError?.none)
         let ex = expectation(description: "Waiting for error handler to be called...")
@@ -183,6 +185,7 @@ class ClientResetTests: SwiftSyncTestCase {
 
 @available(macOS 13, *)
 class PBSClientResetTests: ClientResetTests {
+    @MainActor
     func testClientResetManual() throws {
         let user = try prepareClientReset()
         try autoreleasepool {
@@ -206,6 +209,7 @@ class PBSClientResetTests: ClientResetTests {
         try verifyClientResetDiscardedLocalChanges(user)
     }
 
+    @MainActor
     func testClientResetManualWithEnumCallback() throws {
         let user = try prepareClientReset()
         try autoreleasepool {
@@ -232,6 +236,7 @@ class PBSClientResetTests: ClientResetTests {
         try verifyClientResetDiscardedLocalChanges(user)
     }
 
+    @MainActor
     func testClientResetManualManagerFallback() throws {
         let user = try prepareClientReset()
 
@@ -259,6 +264,7 @@ class PBSClientResetTests: ClientResetTests {
 
     // If the syncManager.ErrorHandler and manual enum callback
     // are both set, use the enum callback.
+    @MainActor
     func testClientResetManualEnumCallbackNotManager() throws {
         let user = try prepareClientReset()
 
@@ -294,6 +300,7 @@ class PBSClientResetTests: ClientResetTests {
         try verifyClientResetDiscardedLocalChanges(user)
     }
 
+    @MainActor
     func testClientResetManualWithoutLiveRealmInstance() throws {
         let user = try prepareClientReset()
 
@@ -316,6 +323,7 @@ class PBSClientResetTests: ClientResetTests {
         resetSyncManager()
     }
 
+    @MainActor
     @available(*, deprecated) // .discardLocal
     func testClientResetDiscardLocal() throws {
         let user = try prepareClientReset()
@@ -347,6 +355,7 @@ class PBSClientResetTests: ClientResetTests {
         }
     }
 
+    @MainActor
     func testClientResetDiscardUnsyncedChanges() throws {
         let user = try prepareClientReset()
 
@@ -375,6 +384,7 @@ class PBSClientResetTests: ClientResetTests {
         }
     }
 
+    @MainActor
     @available(*, deprecated) // .discardLocal
     func testClientResetDiscardLocalAsyncOpen() throws {
         let user = try prepareClientReset()
@@ -393,6 +403,7 @@ class PBSClientResetTests: ClientResetTests {
         waitForExpectations(timeout: 15.0)
     }
 
+    @MainActor
     func testClientResetRecover() throws {
         let user = try prepareClientReset()
 
@@ -419,6 +430,7 @@ class PBSClientResetTests: ClientResetTests {
         }
     }
 
+    @MainActor
     func testClientResetRecoverAsyncOpen() throws {
         let user = try prepareClientReset()
 
@@ -445,6 +457,7 @@ class PBSClientResetTests: ClientResetTests {
         }
     }
 
+    @MainActor
     func testClientResetRecoverWithSchemaChanges() throws {
         let user = try prepareClientReset()
 
@@ -484,6 +497,7 @@ class PBSClientResetTests: ClientResetTests {
         }
     }
 
+    @MainActor
     func testClientResetRecoverOrDiscardLocalFailedRecovery() throws {
         let appId = try RealmServer.shared.createApp(types: [SwiftPerson.self])
         // Disable recovery mode on the server.
@@ -526,11 +540,13 @@ class FLXClientResetTests: ClientResetTests {
     }
 
     override func configuration(user: User) -> Realm.Configuration {
-        user.flexibleSyncConfiguration { subscriptions in
-            subscriptions.append(QuerySubscription<SwiftPerson> { $0.lastName == self.name })
+        let name = self.name
+        return user.flexibleSyncConfiguration { subscriptions in
+            subscriptions.append(QuerySubscription<SwiftPerson> { $0.lastName == name })
         }
     }
 
+    @MainActor
     @available(*, deprecated) // .discardLocal
     func testFlexibleSyncDiscardLocalClientReset() throws {
         let user = try prepareClientReset()
@@ -560,6 +576,7 @@ class FLXClientResetTests: ClientResetTests {
         }
     }
 
+    @MainActor
     func testFlexibleSyncDiscardUnsyncedChangesClientReset() throws {
         let user = try prepareClientReset()
 
@@ -588,6 +605,7 @@ class FLXClientResetTests: ClientResetTests {
         }
     }
 
+    @MainActor
     func testFlexibleSyncClientResetRecover() throws {
         let user = try prepareClientReset()
 
@@ -619,6 +637,7 @@ class FLXClientResetTests: ClientResetTests {
         }
     }
 
+    @MainActor
     func testFlexibleSyncClientResetRecoverOrDiscardLocalFailedRecovery() throws {
         let appId = try RealmServer.shared.createApp(fields: ["lastName"], types: [SwiftPerson.self])
         try waitForEditRecoveryMode(flexibleSync: true, appId: appId, disable: true)
@@ -654,6 +673,7 @@ class FLXClientResetTests: ClientResetTests {
         }
     }
 
+    @MainActor
     func testFlexibleClientResetManual() throws {
         let user = try prepareClientReset()
         try autoreleasepool {
@@ -676,8 +696,9 @@ class FLXClientResetTests: ClientResetTests {
             }
         }
 
+        let name = self.name
         var config = user.flexibleSyncConfiguration { subscriptions in
-            subscriptions.append(QuerySubscription<SwiftPerson> { $0.lastName == self.name })
+            subscriptions.append(QuerySubscription<SwiftPerson> { $0.lastName == name })
         }
         config.objectTypes = [SwiftPerson.self]
 

--- a/Realm/ObjectServerTests/SwiftAsymmetricSyncServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftAsymmetricSyncServerTests.swift
@@ -135,7 +135,7 @@ class SwiftAsymmetricSyncTests: SwiftSyncTestCase {
         return super.defaultTestSuite
     }
 
-    static let objectTypes = [
+    nonisolated static let objectTypes = [
         HugeObjectAsymmetric.self,
         SwiftCustomColumnAsymmetricObject.self,
         SwiftObjectAsymmetric.self,
@@ -153,6 +153,7 @@ class SwiftAsymmetricSyncTests: SwiftSyncTestCase {
         user.flexibleSyncConfiguration()
     }
 
+    @MainActor
     func testAsymmetricObjectSchema() throws {
         let realm = try openRealm()
         XCTAssertTrue(realm.schema.objectSchema[0].isAsymmetric)

--- a/Realm/ObjectServerTests/SwiftCollectionSyncTests.swift
+++ b/Realm/ObjectServerTests/SwiftCollectionSyncTests.swift
@@ -30,24 +30,11 @@ import RealmTestSupport
 class CollectionSyncTestCase: SwiftSyncTestCase {
     var readRealm: Realm!
 
-    override func setUp() {
-        super.setUp()
-        // This autoreleasepool is needed to ensure that the Realms are closed
-        // immediately in tearDown() rather than escaping to an outer pool.
-        autoreleasepool {
-            readRealm = try! openRealm()
-        }
-    }
-
-    override func tearDown() {
-        readRealm = nil
-        super.tearDown()
-    }
-
     override var objectTypes: [ObjectBase.Type] {
         [SwiftCollectionSyncObject.self, SwiftPerson.self]
     }
 
+    @MainActor
     func write(_ fn: (Realm) -> Void) throws {
         try super.write(fn)
         waitForDownloads(for: readRealm)
@@ -61,8 +48,13 @@ class CollectionSyncTestCase: SwiftSyncTestCase {
         }
     }
 
+    @MainActor
     private func roundTrip<T>(keyPath: KeyPath<SwiftCollectionSyncObject, List<T>>,
                               values: [T], partitionValue: String = #function) throws {
+        autoreleasepool {
+            readRealm = try! openRealm()
+        }
+
         checkCount(expected: 0, readRealm, SwiftCollectionSyncObject.self)
 
         // Create the object
@@ -108,8 +100,11 @@ class CollectionSyncTestCase: SwiftSyncTestCase {
         try write { realm in
             realm.deleteAll()
         }
+
+        readRealm = nil
     }
 
+    @MainActor
     func testLists() throws {
         try roundTrip(keyPath: \.intList, values: [1, 2, 3])
         try roundTrip(keyPath: \.boolList, values: [true, false, false])
@@ -137,9 +132,13 @@ class CollectionSyncTestCase: SwiftSyncTestCase {
     private typealias MutableSetKeyPath<T: RealmCollectionValue> = KeyPath<SwiftCollectionSyncObject, MutableSet<T>>
     private typealias MutableSetKeyValues<T: RealmCollectionValue> = (keyPath: MutableSetKeyPath<T>, values: [T])
 
+    @MainActor
     private func roundTrip<T>(set: MutableSetKeyValues<T>,
                               otherSet: MutableSetKeyValues<T>,
                               partitionValue: String = #function) throws {
+        autoreleasepool {
+            readRealm = try! openRealm()
+        }
         checkCount(expected: 0, readRealm, SwiftCollectionSyncObject.self)
 
         // Create the object
@@ -196,8 +195,10 @@ class CollectionSyncTestCase: SwiftSyncTestCase {
         try write { realm in
             realm.deleteAll()
         }
+        readRealm = nil
     }
 
+    @MainActor
     func testSets() throws {
         try roundTrip(set: (\.intSet, [1, 2, 3]), otherSet: (\.otherIntSet, [3, 4, 5]))
         try roundTrip(set: (\.stringSet, ["Who", "What", "When"]),
@@ -248,8 +249,13 @@ class CollectionSyncTestCase: SwiftSyncTestCase {
 
     private typealias MapKeyPath<T: RealmCollectionValue> = KeyPath<SwiftCollectionSyncObject, Map<String, T>>
 
+    @MainActor
     private func roundTrip<T>(keyPath: MapKeyPath<T>, values: [T],
                               partitionValue: String = #function) throws {
+        autoreleasepool {
+            readRealm = try! openRealm()
+        }
+
         checkCount(expected: 0, readRealm, SwiftCollectionSyncObject.self)
 
         // Create the object
@@ -296,8 +302,10 @@ class CollectionSyncTestCase: SwiftSyncTestCase {
         try write { realm in
             realm.deleteAll()
         }
+        readRealm = nil
     }
 
+    @MainActor
     func testMaps() throws {
         try roundTrip(keyPath: \.intMap, values: [1, 2, 3, 4, 5])
         try roundTrip(keyPath: \.stringMap, values: ["Who", "What", "When", "Strings", "Collide"])

--- a/Realm/ObjectServerTests/SwiftFlexibleSyncServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftFlexibleSyncServerTests.swift
@@ -43,6 +43,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         try createFlexibleSyncApp()
     }
 
+    @MainActor
     func testCreateFlexibleSyncApp() throws {
         let appId = try RealmServer.shared.createApp(fields: ["age"], types: [SwiftPerson.self])
         let flexibleApp = app(id: appId)
@@ -62,18 +63,21 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         assertThrows(realm.subscriptions)
     }
 
+    @MainActor
     func testFlexibleSyncPath() throws {
         let config = try configuration()
         let user = config.syncConfiguration!.user
         XCTAssertTrue(config.fileURL!.path.hasSuffix("mongodb-realm/\(appId)/\(user.id)/flx_sync_default.realm"))
     }
 
+    @MainActor
     func testGetSubscriptions() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
         XCTAssertEqual(subscriptions.count, 0)
     }
 
+    @MainActor
     func testWriteEmptyBlock() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -82,6 +86,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 0)
     }
 
+    @MainActor
     func testAddOneSubscriptionWithoutName() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -94,6 +99,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 1)
     }
 
+    @MainActor
     func testAddOneSubscriptionWithName() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -106,6 +112,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 1)
     }
 
+    @MainActor
     func testAddSubscriptionsInDifferentBlocks() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -123,6 +130,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 2)
     }
 
+    @MainActor
     func testAddSeveralSubscriptionsWithoutName() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -142,6 +150,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 3)
     }
 
+    @MainActor
     func testAddSeveralSubscriptionsWithName() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -160,6 +169,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 3)
     }
 
+    @MainActor
     func testAddMixedSubscriptions() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -178,6 +188,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 3)
     }
 
+    @MainActor
     func testAddDuplicateSubscriptions() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -193,6 +204,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 1)
     }
 
+    @MainActor
     func testAddDuplicateSubscriptionWithDifferentName() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -209,6 +221,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     }
 
     // FIXME: Using `assertThrows` within a Server test will crash on tear down
+    @MainActor
     func skip_testSameNamedSubscriptionThrows() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -224,6 +237,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     }
 
     // FIXME: Using `assertThrows` within a Server test will crash on tear down
+    @MainActor
     func skip_testAddSubscriptionOutsideWriteThrows() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -232,6 +246,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         }))
     }
 
+    @MainActor
     func testFindSubscriptionByName() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -255,6 +270,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(foundSubscription2!.name, "person_age_20")
     }
 
+    @MainActor
     func testFindSubscriptionByQuery() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -281,6 +297,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(foundSubscription2!.name, "object_int_more_than_zero")
     }
 
+    @MainActor
     func testRemoveSubscriptionByName() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -304,6 +321,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 2)
     }
 
+    @MainActor
     func testRemoveSubscriptionByQuery() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -338,6 +356,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 1)
     }
 
+    @MainActor
     func testRemoveSubscription() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -370,6 +389,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 0)
     }
 
+    @MainActor
     func testRemoveSubscriptionsByType() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -401,6 +421,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 0)
     }
 
+    @MainActor
     func testRemoveAllSubscriptions() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -428,6 +449,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 0)
     }
 
+    @MainActor
     func testRemoveAllUnnamedSubscriptions() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -455,6 +477,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 2)
     }
 
+    @MainActor
     func testSubscriptionSetIterate() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -479,6 +502,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(count, numberOfSubs)
     }
 
+    @MainActor
     func testSubscriptionSetFirstAndLast() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -503,6 +527,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(lastSubscription!.name, "person_age_\(numberOfSubs)")
     }
 
+    @MainActor
     func testSubscriptionSetSubscript() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -527,6 +552,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(lastSubscription!.name, "person_age_\(numberOfSubs)")
     }
 
+    @MainActor
     func testUpdateQueries() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -552,6 +578,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 2)
     }
 
+    @MainActor
     func testUpdateQueriesWithoutName() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -578,6 +605,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     }
 
     // FIXME: Using `assertThrows` within a Server test will crash on tear down
+    @MainActor
     func skip_testFlexibleSyncAppUpdateQueryWithDifferentObjectTypeWillThrow() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -596,6 +624,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         }
     }
 
+    @MainActor
     func testFlexibleSyncTransactionsWithPredicateFormatAndNSPredicate() throws {
         let realm = try openRealm()
         let subscriptions = realm.subscriptions
@@ -624,6 +653,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(subscriptions.count, 2)
     }
 
+    @MainActor
     func populateSwiftPerson(count: Int = 10) throws {
         try write { realm in
             for i in 1...count {
@@ -632,6 +662,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         }
     }
 
+    @MainActor
     func populateSwiftTypesObject(count: Int = 1) throws {
         try write { realm in
             for _ in 1...count {
@@ -642,6 +673,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         }
     }
 
+    @MainActor
     func testFlexibleSyncAppWithoutQuery() throws {
         try populateSwiftPerson()
 
@@ -655,6 +687,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         checkCount(expected: 0, realm, SwiftPerson.self)
     }
 
+    @MainActor
     func testFlexibleSyncAppAddQuery() throws {
         try populateSwiftPerson(count: 25)
 
@@ -680,6 +713,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         checkCount(expected: 10, realm, SwiftPerson.self)
     }
 
+    @MainActor
     func testFlexibleSyncAppMultipleQuery() throws {
         try populateSwiftPerson(count: 20)
         try populateSwiftTypesObject()
@@ -709,6 +743,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         checkCount(expected: 1, realm, SwiftTypesSyncObject.self)
     }
 
+    @MainActor
     func testFlexibleSyncAppRemoveQuery() throws {
         try populateSwiftPerson(count: 30)
         try populateSwiftTypesObject()
@@ -751,6 +786,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         checkCount(expected: 1, realm, SwiftTypesSyncObject.self)
     }
 
+    @MainActor
     func testFlexibleSyncAppRemoveAllQueries() throws {
         try populateSwiftPerson(count: 25)
         try populateSwiftTypesObject()
@@ -797,6 +833,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         checkCount(expected: 0, realm, SwiftTypesSyncObject.self)
     }
 
+    @MainActor
     func testFlexibleSyncAppRemoveQueriesByType() throws {
         try populateSwiftPerson(count: 21)
         try populateSwiftTypesObject()
@@ -843,6 +880,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         checkCount(expected: 1, realm, SwiftTypesSyncObject.self)
     }
 
+    @MainActor
     func testFlexibleSyncAppUpdateQuery() throws {
         try populateSwiftPerson(count: 25)
 
@@ -884,13 +922,15 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         checkCount(expected: 20, realm, SwiftPerson.self)
     }
 
+    @MainActor
     func testFlexibleSyncInitialSubscriptions() throws {
         try populateSwiftPerson(count: 20)
 
+        let name = self.name
         let user = createUser()
         var config = user.flexibleSyncConfiguration(initialSubscriptions: { subscriptions in
             subscriptions.append(QuerySubscription<SwiftPerson>(name: "person_age_10") {
-                $0.age > 10 && $0.firstName == self.name
+                $0.age > 10 && $0.firstName == name
             })
         })
         config.objectTypes = [SwiftPerson.self, SwiftTypesSyncObject.self]
@@ -910,6 +950,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         checkCount(expected: 10, realm, SwiftPerson.self)
     }
 
+    @MainActor
     func testFlexibleSyncCancelOnNonFatalError() throws {
         let proxy = TimeoutProxyServer(port: 5678, targetPort: 9090)
         try proxy.start()
@@ -943,15 +984,17 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
     }
 
     // MARK: - Progress notifiers
+    @MainActor
     func testAsyncOpenProgress() throws {
         try populateRealm()
 
         let asyncOpenEx = expectation(description: "async open")
 
         let user = createUser()
+        let name = self.name
         var config = user.flexibleSyncConfiguration(initialSubscriptions: { subscriptions in
             subscriptions.append(QuerySubscription<SwiftHugeSyncObject> {
-                $0.partition == self.name
+                $0.partition == name
             })
         })
         config.objectTypes = objectTypes
@@ -984,6 +1027,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertTrue(p1.isTransferComplete)
     }
 
+    @MainActor
     func testNonStreamingDownloadNotifier() async throws {
         try populateRealm()
 
@@ -1036,6 +1080,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         token!.invalidate()
     }
 
+    @MainActor
     func testStreamingDownloadNotifier() throws {
         try populateRealm()
 
@@ -1093,6 +1138,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         token!.invalidate()
     }
 
+    @MainActor
     func testStreamingUploadNotifier() throws {
         let realm = try openRealm(wait: false)
         let subscriptions = realm.subscriptions
@@ -1136,6 +1182,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertTrue(p.isTransferComplete)
     }
 
+    @MainActor
     func testStreamingNotifierInvalidate() throws {
         let realm = try openRealm()
         RLMRealmSubscribeToAll(ObjectiveCSupport.convert(object: realm))
@@ -1187,6 +1234,7 @@ class SwiftFlexibleSyncTests: SwiftSyncTestCase {
         XCTAssertEqual(uploadCount.value, 0)
     }
 
+    @MainActor
     func testFlexibleSyncNotEnabledError() throws {
         let appId = try RealmServer.shared.createNonSyncApp()
         let app = app(id: appId)

--- a/Realm/ObjectServerTests/SwiftMongoClientTests.swift
+++ b/Realm/ObjectServerTests/SwiftMongoClientTests.swift
@@ -41,6 +41,7 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
         super.tearDown()
     }
 
+    @MainActor
     func testMongoClient() {
         let user = try! logInUser(for: .anonymous)
         let mongoClient = user.mongoClient("mongodb1")
@@ -639,15 +640,18 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
         watchTestUtility.waitForClose()
     }
 
+    @MainActor
     func testWatchWithMatchFilter() throws {
         try performWatchWithMatchFilterTest(.main)
     }
 
+    @MainActor
     func testWatchWithMatchFilterQueue() throws {
         let queue = DispatchQueue(label: "io.realm.watchQueue", attributes: .concurrent)
         try performWatchWithMatchFilterTest(queue)
     }
 
+    @MainActor
     func insertDocuments(_ collection: MongoCollection) -> [ObjectId] {
         let document: Document = ["name": "fido", "breed": "cane corso"]
         let document2: Document = ["name": "rex", "breed": "cane corso"]
@@ -661,6 +665,7 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
         return objectIds
     }
 
+    @MainActor
     func performWatchWithMatchFilterTest(_ queue: DispatchQueue?) throws {
         let collection = setupMongoCollection()
         let objectIds = insertDocuments(collection)
@@ -696,15 +701,18 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
         watchTestUtility.waitForClose()
     }
 
+    @MainActor
     func testWatchWithFilterIds() throws {
         try performWatchWithFilterIdsTest(nil)
     }
 
+    @MainActor
     func testWatchWithFilterIdsQueue() throws {
         let queue = DispatchQueue(label: "io.realm.watchQueue", attributes: .concurrent)
         try performWatchWithFilterIdsTest(queue)
     }
 
+    @MainActor
     func performWatchWithFilterIdsTest(_ queue: DispatchQueue?) throws {
         let collection = setupMongoCollection()
         let objectIds = insertDocuments(collection)
@@ -739,6 +747,7 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
     }
 
     @available(macOS 13, *)
+    @MainActor
     func performAsyncWatchTest(filterIds: Bool = false, matchFilter: Bool = false) async throws {
         let collection = setupMongoCollection()
         let objectIds = insertDocuments(collection)
@@ -798,15 +807,18 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
         try await performAsyncWatchTest(filterIds: true)
     }
 
+    @MainActor
     func testWatchMultipleFilterStreams() throws {
         try performMultipleWatchStreamsTest(nil)
     }
 
+    @MainActor
     func testWatchMultipleFilterStreamsAsync() throws {
         let queue = DispatchQueue(label: "io.realm.watchQueue", attributes: .concurrent)
         try performMultipleWatchStreamsTest(queue)
     }
 
+    @MainActor
     func performMultipleWatchStreamsTest(_ queue: DispatchQueue?) throws {
         let collection = setupMongoCollection()
         let objectIds = insertDocuments(collection)
@@ -850,6 +862,7 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
         watchTestUtility2.waitForClose()
     }
 
+    @MainActor
     func testShouldNotDeleteOnMigrationWithSync() throws {
         var configuration = try configuration()
         assertThrows(configuration.deleteRealmIfMigrationNeeded = true,

--- a/Realm/ObjectServerTests/TimeoutProxyServer.swift
+++ b/Realm/ObjectServerTests/TimeoutProxyServer.swift
@@ -64,7 +64,7 @@ public class TimeoutProxyServer: NSObject, @unchecked Sendable {
 
     @objc public func start() throws {
         listener = try NWListener(using: NWParameters.tcp, on: port)
-        listener.newConnectionHandler = { [weak self] incomingConnection in
+        listener.newConnectionHandler = { @Sendable [weak self] incomingConnection in
             guard let self = self else { return }
             self.connections.append(incomingConnection)
             incomingConnection.start(queue: self.queue)

--- a/Realm/RLMUser.h
+++ b/Realm/RLMUser.h
@@ -309,7 +309,7 @@ RLM_SWIFT_SENDABLE // internally thread-safe
 /**
  Refresh a user's custom data. This will, in effect, refresh the user's auth session.
  */
-- (void)refreshCustomDataWithCompletion:(RLMUserCustomDataBlock)completion;
+- (void)refreshCustomDataWithCompletion:(RLMUserCustomDataBlock)completion NS_REFINED_FOR_SWIFT;
 
 /**
  Links the currently authenticated user with a new identity, where the identity is defined by the credential

--- a/Realm/Tests/Swift/SwiftRealmTests.swift
+++ b/Realm/Tests/Swift/SwiftRealmTests.swift
@@ -24,8 +24,7 @@ import RealmTestSupport
 #endif
 
 @available(iOS 13.0, *) // For @MainActor
-@MainActor
-class SwiftRLMRealmTests: RLMTestCase {
+class SwiftRLMRealmTests: RLMTestCase, @unchecked Sendable {
 
     // No models
 
@@ -68,6 +67,7 @@ class SwiftRLMRealmTests: RLMTestCase {
         XCTAssertEqual((objects[0] as! SwiftRLMStringObject).stringCol, "b", "Expecting column to be 'b'")
     }
 
+    @MainActor
     func testRealmIsUpdatedAfterBackgroundUpdate() {
         let realm = realmWithTestPath()
 
@@ -116,6 +116,7 @@ class SwiftRLMRealmTests: RLMTestCase {
         XCTAssertEqual(retrievedObject.objectSchema.properties.count, 2, "Only 'name' and 'age' properties should be detected by Realm")
     }
 
+    @MainActor
     func testUpdatingSortedArrayAfterBackgroundUpdate() {
         let realm = realmWithTestPath()
         let objs = SwiftRLMIntObject.allObjects(in: realm)
@@ -146,6 +147,7 @@ class SwiftRLMRealmTests: RLMTestCase {
         token.invalidate()
     }
 
+    @MainActor
     func testRealmIsUpdatedImmediatelyAfterBackgroundUpdate() {
         let realm = realmWithTestPath()
 
@@ -203,6 +205,7 @@ class SwiftRLMRealmTests: RLMTestCase {
         XCTAssertEqual((objects[0] as! StringObject).stringCol!, "b", "Expecting column to be 'b'")
     }
 
+    @MainActor
     func testRealmIsUpdatedAfterBackgroundUpdate_objc() {
         let realm = realmWithTestPath()
 
@@ -230,6 +233,7 @@ class SwiftRLMRealmTests: RLMTestCase {
         XCTAssertEqual((objects[0] as! StringObject).stringCol!, "string", "Value of first column should be 'string'")
     }
 
+    @MainActor
     func testRealmIsUpdatedImmediatelyAfterBackgroundUpdate_objc() {
         let realm = realmWithTestPath()
 

--- a/Realm/Tests/Swift/SwiftSchemaTests.swift
+++ b/Realm/Tests/Swift/SwiftSchemaTests.swift
@@ -150,10 +150,12 @@ class OnlyComputedNoBacklinksProps: FakeObject {
     }
 }
 
-@MainActor
 class RequiresObjcName: RLMObject {
+#if compiler(>=5.10)
+    nonisolated(unsafe) static var enable = false
+#else
     static var enable = false
-    @MainActor
+#endif
     override class func _realmIgnoreClass() -> Bool {
         return !enable
     }

--- a/RealmSwift/Map.swift
+++ b/RealmSwift/Map.swift
@@ -520,6 +520,7 @@ public final class Map<Key: _MapKey, Value: RealmCollectionValue>: RLMSwiftColle
         return rlmDictionary.addNotificationBlock(wrapped, keyPaths: keyPaths, queue: queue)
     }
 
+#if compiler(<6)
     /**
     Registers a block to be called each time the map changes.
 
@@ -609,7 +610,7 @@ public final class Map<Key: _MapKey, Value: RealmCollectionValue>: RLMSwiftColle
             collection.observe(keyPaths: keyPaths, on: nil) { change in
                 actor.invokeIsolated(block, change)
             }
-        } ?? NotificationToken()
+        }
     }
 
     /**
@@ -696,6 +697,185 @@ public final class Map<Key: _MapKey, Value: RealmCollectionValue>: RLMSwiftColle
     ) async -> NotificationToken where Value: OptionalProtocol, Value.Wrapped: ObjectBase {
         await observe(keyPaths: keyPaths.map(_name(for:)), on: actor, block)
     }
+#else
+    /**
+    Registers a block to be called each time the map changes.
+
+    The block will be asynchronously called on the actor with the initial map, and
+    then called again after each write transaction which changes either which keys
+    are present in the map or the values of any of the objects.
+
+    The `change` parameter that is passed to the block reports, in the form of keys
+    within the map, which of the key-value pairs were added, removed, or modified
+    during each write transaction.
+
+    Notifications are delivered to a function isolated to the given actor, on that
+    actors executor. If the actor is performing blocking work, multiple
+    notifications may be coalesced into a single notification. This can include the
+    notification with the initial collection, and changes are only reported for
+    writes which occur after the initial notification is delivered.
+
+    If no key paths are given, the block will be executed on any insertion,
+    modification, or deletion for all object properties and the properties of any
+    nested, linked objects. If a key path or key paths are provided, then the block
+    will be called for changes which occur only on the provided key paths. For
+    example, if:
+    ```swift
+    class Dog: Object {
+        @Persisted var name: String
+        @Persisted var age: Int
+        @Persisted var toys: List<Toy>
+    }
+    // ...
+    let dogs = myObject.mapOfDogs
+    let token = dogs.observe(keyPaths: ["name"], on: actor) { actor, changes in
+        switch changes {
+        case .initial(let dogs):
+            // ...
+        case .update:
+            // This case is hit:
+            // - after the token is initialized
+            // - when the name property of an object in the collection is modified
+            // - when an element is inserted or removed from the collection.
+            // This block is not triggered:
+            // - when a value other than name is modified on one of the elements.
+        case .error:
+            // No longer possible and left for backwards compatibility
+        }
+    }
+    ```
+    - If the observed key path were `["toys.brand"]`, then any insertion or
+      deletion to the `toys` list on any of the collection's elements would trigger
+      the block. Changes to the `brand` value on any `Toy` that is linked to a `Dog`
+      in this collection will trigger the block. Changes to a value other than
+      `brand` on any `Toy` that is linked to a `Dog` in this collection would not
+      trigger the block. Any insertion or removal to the `Dog` type collection being
+      observed would also trigger a notification.
+    - If the above example observed the `["toys"]` key path, then any insertion,
+      deletion, or modification to the `toys` list for any element in the collection
+      would trigger the block. Changes to any value on any `Toy` that is linked to a
+      `Dog` in this collection would *not* trigger the block. Any insertion or
+      removal to the `Dog` type collection being observed would still trigger a
+      notification.
+
+    You must retain the returned token for as long as you want updates to be sent
+    to the block. To stop receiving updates, call `invalidate()` on the token.
+
+    - warning: This method cannot be called during a write transaction, or when
+      the containing Realm is read-only.
+
+    - parameter keyPaths: Only properties contained in the key paths array will
+      trigger the block when they are modified. If `nil`, notifications will be
+      delivered for any property change on the object. String key paths which do not
+      correspond to a valid a property will throw an exception. See description above
+      for more detail on linked properties.
+    - note: The keyPaths parameter refers to object properties of the collection
+      type and *does not* refer to particular key/value pairs within the Map.
+    - parameter actor: The actor which notifications should be delivered on. The
+      block is passed this actor as an isolated parameter, allowing you to access the
+      actor synchronously from within the callback.
+    - parameter block: The block to be called whenever a change occurs.
+    - returns: A token which must be held for as long as you want updates to be delivered.
+     */
+    @available(macOS 10.15, tvOS 13.0, iOS 13.0, watchOS 6.0, *)
+    public func observe<A: Actor>(
+        keyPaths: [String]? = nil, on actor: A,
+        _isolation: isolated (any Actor)? = #isolation,
+        _ block: @Sendable @escaping (isolated A, RealmMapChange<Map>) -> Void
+    ) async -> NotificationToken {
+        nonisolated(unsafe) let collection = self
+        return await with(collection, on: actor) { actor, collection in
+            collection.observe(keyPaths: keyPaths, on: nil) { change in
+                actor.invokeIsolated(block, change)
+            }
+        }
+    }
+
+    /**
+    Registers a block to be called each time the map changes.
+
+    The block will be asynchronously called on the actor with the initial map, and
+    then called again after each write transaction which changes either which keys
+    are present in the map or the values of any of the objects.
+
+    The `change` parameter that is passed to the block reports, in the form of keys
+    within the map, which of the key-value pairs were added, removed, or modified
+    during each write transaction.
+
+    Notifications are delivered to a function isolated to the given actor, on that
+    actors executor. If the actor is performing blocking work, multiple
+    notifications may be coalesced into a single notification. This can include the
+    notification with the initial collection, and changes are only reported for
+    writes which occur after the initial notification is delivered.
+
+    The block will be called for changes which occur only on the provided key
+    paths. For example, if:
+    ```swift
+    class Dog: Object {
+        @Persisted var name: String
+        @Persisted var age: Int
+        @Persisted var toys: List<Toy>
+    }
+    // ...
+    let dogs = myObject.mapOfDogs
+    let token = dogs.observe(keyPaths: [\.name], on: actor) { actor, changes in
+        switch changes {
+        case .initial(let dogs):
+            // ...
+        case .update:
+            // This case is hit:
+            // - after the token is initialized
+            // - when the name property of an object in the collection is modified
+            // - when an element is inserted or removed from the collection.
+            // This block is not triggered:
+            // - when a value other than name is modified on one of the elements.
+        case .error:
+            // No longer possible and left for backwards compatibility
+        }
+    }
+    ```
+    - If the observed key path were `[\.toys.brand]`, then any insertion or
+      deletion to the `toys` list on any of the collection's elements would trigger
+      the block. Changes to the `brand` value on any `Toy` that is linked to a `Dog`
+      in this collection will trigger the block. Changes to a value other than
+      `brand` on any `Toy` that is linked to a `Dog` in this collection would not
+      trigger the block. Any insertion or removal to the `Dog` type collection being
+      observed would also trigger a notification.
+    - If the above example observed the `[\.toys]` key path, then any insertion,
+      deletion, or modification to the `toys` list for any element in the collection
+      would trigger the block. Changes to any value on any `Toy` that is linked to a
+      `Dog` in this collection would *not* trigger the block. Any insertion or
+      removal to the `Dog` type collection being observed would still trigger a
+      notification.
+
+    You must retain the returned token for as long as you want updates to be sent
+    to the block. To stop receiving updates, call `invalidate()` on the token.
+
+    - warning: This method cannot be called during a write transaction, or when
+      the containing Realm is read-only.
+
+    - parameter keyPaths: Only properties contained in the key paths array will
+      trigger the block when they are modified. If `nil`, notifications will be
+      delivered for any property change on the object. String key paths which do not
+      correspond to a valid a property will throw an exception. See description above
+      for more detail on linked properties.
+    - note: The keyPaths parameter refers to object properties of the collection
+      type and *does not* refer to particular key/value pairs within the Map.
+    - parameter actor: The actor which notifications should be delivered on. The
+      block is passed this actor as an isolated parameter, allowing you to access the
+      actor synchronously from within the callback.
+    - parameter block: The block to be called whenever a change occurs.
+    - returns: A token which must be held for as long as you want updates to be delivered.
+     */
+    @available(macOS 10.15, tvOS 13.0, iOS 13.0, watchOS 6.0, *)
+    public func observe<A: Actor>(
+        keyPaths: [PartialKeyPath<Value.Wrapped>], on actor: A,
+        _isolation: isolated (any Actor)? = #isolation,
+        _ block: @Sendable @escaping (isolated A, RealmMapChange<Map>) -> Void
+    ) async -> NotificationToken where Value: OptionalProtocol, Value.Wrapped: ObjectBase {
+        await observe(keyPaths: keyPaths.map(_name(for:)), on: actor, block)
+    }
+#endif
 
     // MARK: Frozen Objects
 

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -406,6 +406,7 @@ extension Object: _RealmCollectionValueInsideOptional {
         _observe(keyPaths: keyPaths.map(_name(for:)), on: queue, block)
     }
 
+#if compiler(<6)
     /**
     Registers a block to be called each time the object changes.
 
@@ -447,7 +448,7 @@ extension Object: _RealmCollectionValueInsideOptional {
     ) async -> NotificationToken {
         await with(self, on: actor) { actor, obj in
             await obj._observe(keyPaths: keyPaths, on: actor, block)
-        } ?? NotificationToken()
+        }
     }
 
     /**
@@ -491,6 +492,93 @@ extension Object: _RealmCollectionValueInsideOptional {
     ) async -> NotificationToken {
         await observe(keyPaths: keyPaths.map(_name(for:)), on: actor, block)
     }
+#else
+    /**
+    Registers a block to be called each time the object changes.
+
+    The block will be asynchronously called on the given actor's executor after
+    each write transaction which deletes the object or modifies any of the managed
+    properties of the object, including self-assignments that set a property to its
+    existing value. The block is passed a copy of the object isolated to the
+    requested actor which can be safely used on that actor along with information
+    about what changed.
+
+    For write transactions performed on different threads or in different
+    processes, the block will be called when the managing Realm is
+    (auto)refreshed to a version including the changes, while for local write
+    transactions it will be called at some point in the future after the write
+    transaction is committed.
+
+    Only objects which are managed by a Realm can be observed in this way. You
+    must retain the returned token for as long as you want updates to be sent
+    to the block. To stop receiving updates, call `invalidate()` on the token.
+
+    By default, only direct changes to the object's properties will produce
+    notifications, and not changes to linked objects. Note that this is different
+    from collection change notifications. If a non-nil, non-empty keypath array is
+    passed in, only changes to the properties identified by those keypaths will
+    produce change notifications. The keypaths may traverse link properties to
+    receive information about changes to linked objects.
+
+    - warning: This method cannot be called during a write transaction, or when
+    the containing Realm is read-only.
+    - parameter actor: The actor to isolate notifications to.
+    - parameter block: The block to call with information about changes to the object.
+    - returns: A token which must be held for as long as you want updates to be delivered.
+     */
+    @available(macOS 10.15, tvOS 13.0, iOS 13.0, watchOS 6.0, *)
+    public func observe<A: Actor, T: Object>(
+        keyPaths: [String]? = nil, on actor: A,
+        _isolation: isolated (any Actor)? = #isolation,
+        _ block: @Sendable @escaping (isolated A, ObjectChange<T>) -> Void
+    ) async -> NotificationToken {
+        await with(self, on: actor) { actor, obj in
+            await obj._observe(keyPaths: keyPaths, on: actor, block)
+        }
+    }
+
+    /**
+    Registers a block to be called each time the object changes.
+
+    The block will be asynchronously called on the given actor's executor after
+    each write transaction which deletes the object or modifies any of the managed
+    properties of the object, including self-assignments that set a property to its
+    existing value. The block is passed a copy of the object isolated to the
+    requested actor which can be safely used on that actor along with information
+    about what changed.
+
+    For write transactions performed on different threads or in different
+    processes, the block will be called when the managing Realm is
+    (auto)refreshed to a version including the changes, while for local write
+    transactions it will be called at some point in the future after the write
+    transaction is committed.
+
+    Only objects which are managed by a Realm can be observed in this way. You
+    must retain the returned token for as long as you want updates to be sent
+    to the block. To stop receiving updates, call `invalidate()` on the token.
+
+    By default, only direct changes to the object's properties will produce
+    notifications, and not changes to linked objects. Note that this is different
+    from collection change notifications. If a non-nil, non-empty keypath array is
+    passed in, only changes to the properties identified by those keypaths will
+    produce change notifications. The keypaths may traverse link properties to
+    receive information about changes to linked objects.
+
+    - warning: This method cannot be called during a write transaction, or when
+    the containing Realm is read-only.
+    - parameter actor: The actor to isolate notifications to.
+    - parameter block: The block to call with information about changes to the object.
+    - returns: A token which must be held for as long as you want updates to be delivered.
+     */
+    @available(macOS 10.15, tvOS 13.0, iOS 13.0, watchOS 6.0, *)
+    public func observe<A: Actor, T: Object>(
+        keyPaths: [PartialKeyPath<T>], on actor: A,
+        _isolation: isolated (any Actor)? = #isolation,
+        _ block: @Sendable @escaping (isolated A, ObjectChange<T>) -> Void
+    ) async -> NotificationToken {
+        await observe(keyPaths: keyPaths.map(_name(for:)), on: actor, block)
+    }
+#endif
 
     // MARK: Dynamic list
 

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -584,7 +584,13 @@ public typealias InitialSubscriptionsConfiguration = RLMInitialSubscriptionsConf
         config.initialSubscriptions
     }
 
-    @Unchecked internal var config: RLMSyncConfiguration
+    // Although RLMSyncConfiguration objects are mutable, we don't expose a way
+    // to mutate the one wrapped by this struct, which makes this safe
+    #if compiler(<6)
+    internal let config: RLMSyncConfiguration
+    #else
+    nonisolated(unsafe) internal let config: RLMSyncConfiguration
+    #endif
     internal init(config: RLMSyncConfiguration) {
         self.config = config
     }
@@ -1131,19 +1137,33 @@ extension User: ObservableObject {}
 #endif
 
 public extension User {
-    // NEXT-MAJOR: This function returns the incorrect type. It should be Document
-    // rather than `[AnyHashable: Any]`
     /// Refresh a user's custom data. This will, in effect, refresh the user's auth session.
     /// @completion A completion that eventually return `Result.success(Dictionary)` with user's data or `Result.failure(Error)`.
     @preconcurrency
     func refreshCustomData(_ completion: @escaping @Sendable (Result<[AnyHashable: Any], Error>) -> Void) {
-        self.refreshCustomData { customData, error in
+        self.__refreshCustomData { customData, error in
             if let customData = customData {
                 completion(.success(customData))
             } else {
                 completion(.failure(error ?? Realm.Error.callFailed))
             }
         }
+    }
+
+    /// Refresh a user's custom data. This will, in effect, refresh the user's auth session.
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    @discardableResult
+    func refreshCustomData() async throws -> Document {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            self.__refreshCustomData { _, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+        return customData
     }
 }
 

--- a/RealmSwift/SyncSubscription.swift
+++ b/RealmSwift/SyncSubscription.swift
@@ -170,6 +170,7 @@ import Realm.Private
     /// :nodoc:
     public typealias QueryFunction = (Query<T>) -> Query<Bool>
 
+#if compiler(<6)
     /**
      Creates a `QuerySubscription` for the given type.
 
@@ -181,6 +182,18 @@ import Realm.Private
         self.className = "\(T.self)"
         self.predicate = query?(Query()).predicate ?? NSPredicate(format: "TRUEPREDICATE")
     }
+#else
+    /**
+     Creates a `QuerySubscription` which subscribes to all documents of the given type.
+
+     - parameter name: Name of the subscription.
+     */
+    public init(name: String? = nil) {
+        self.name = name
+        self.className = "\(T.self)"
+        self.predicate = NSPredicate(format: "TRUEPREDICATE")
+    }
+#endif
 
     /**
      Creates a `QuerySubscription` for the given type.
@@ -188,7 +201,7 @@ import Realm.Private
      - parameter name: Name of the subscription.
      - parameter query: The query for the subscription.
      */
-    public init(name: String? = nil, query: QueryFunction) {
+    public init(name: String? = nil, query: borrowing QueryFunction) {
         // This overload is required to make `query` non-escaping, as optional
         // function parameters always are.
         self.name = name

--- a/RealmSwift/Tests/CombineTests.swift
+++ b/RealmSwift/Tests/CombineTests.swift
@@ -293,7 +293,7 @@ class CombineObjectPublisherTests: CombinePublisherTestCase, @unchecked Sendable
             }
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 XCTAssertEqual(arr.count, 10)
                 sema.signal()
             }
@@ -560,7 +560,7 @@ class CombineObjectPublisherTests: CombinePublisherTestCase, @unchecked Sendable
             .freeze()
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 var prev: SwiftIntObject?
                 for change in arr {
                     guard case .change(let obj, let properties) = change else {
@@ -595,7 +595,7 @@ class CombineObjectPublisherTests: CombinePublisherTestCase, @unchecked Sendable
             .receive(on: receiveOnQueue)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 for change in arr {
                     guard case .change(let obj, let properties) = change else {
                         XCTFail("Expected .change but got \(change)")
@@ -629,7 +629,7 @@ class CombineObjectPublisherTests: CombinePublisherTestCase, @unchecked Sendable
             .receive(on: receiveOnQueue)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 var prev: SwiftIntObject?
                 for change in arr {
                     guard case .change(let obj, let properties) = change else {
@@ -962,44 +962,44 @@ private class CombineCollectionPublisherTests<Collection: RealmCollection>: Comb
             sema.wait()
         }
     }
+
     func testSubscribeOnKeyPath() {
         var ex = expectation(description: "initial notification")
 
         cancellable = collection.collectionPublisher(keyPaths: collection.includedKeyPath)
             .subscribe(on: subscribeOnQueue)
             .assertNoFailure()
-            .sink { _ in
-                ex.fulfill()
+            .sink { _ in ex.fulfill()
         }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "change notification")
         try! realm.write { collection.appendObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "change notification")
         try! realm.write { collection.modifyObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
     }
+
     func testSubscribeOnKeyPathNoChange() {
         var ex = expectation(description: "initial notification")
 
         cancellable = collection.collectionPublisher(keyPaths: collection.excludedKeyPath)
             .subscribe(on: subscribeOnQueue)
             .assertNoFailure()
-            .sink { _ in
-                ex.fulfill()
+            .sink { _ in ex.fulfill()
         }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "change notification")
         try! realm.write { collection.appendObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "no change notification")
         ex.isInverted = true
         try! realm.write { collection.modifyObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
     }
 
     func testSubscribeOnWithToken() {
@@ -1090,18 +1090,16 @@ private class CombineCollectionPublisherTests<Collection: RealmCollection>: Comb
 
         cancellable = collection.changesetPublisher(keyPaths: collection.includedKeyPath)
             .subscribe(on: subscribeOnQueue)
-            .sink { _ in
-                ex.fulfill()
-        }
-        waitForExpectations(timeout: 1.0, handler: nil)
+            .sink { _ in ex.fulfill() }
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "change notification")
         try! realm.write { collection.appendObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "change notification")
         try! realm.write { collection.modifyObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
     }
 
     func testChangeSetSubscribeOnKeyPathNoChange() {
@@ -1109,19 +1107,17 @@ private class CombineCollectionPublisherTests<Collection: RealmCollection>: Comb
 
         cancellable = collection.changesetPublisher(keyPaths: collection.excludedKeyPath)
             .subscribe(on: subscribeOnQueue)
-            .sink { _ in
-                ex.fulfill()
-        }
-        waitForExpectations(timeout: 1.0, handler: nil)
+            .sink { _ in ex.fulfill() }
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "change notification")
         try! realm.write { collection.appendObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "no change notification")
         ex.isInverted = true
         try! realm.write { collection.modifyObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
     }
 
     func testChangeSetSubscribeOnWithToken() {
@@ -1284,7 +1280,7 @@ private class CombineCollectionPublisherTests<Collection: RealmCollection>: Comb
             .signal(sema)
             .prefix(10)
             .collect()
-            .sink { arr in
+            .sink { @Sendable arr in
                 XCTAssertEqual(arr.count, 10)
                 for (i, change) in arr.enumerated() {
                     self.checkChangeset(change, calls: i, frozen: true)
@@ -1307,7 +1303,7 @@ private class CombineCollectionPublisherTests<Collection: RealmCollection>: Comb
             .prefix(10)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 XCTAssertEqual(arr.count, 10)
                 for (i, change) in arr.enumerated() {
                     self.checkChangeset(change, calls: i, frozen: true)
@@ -1331,7 +1327,7 @@ private class CombineCollectionPublisherTests<Collection: RealmCollection>: Comb
             .prefix(10)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 for (i, change) in arr.enumerated() {
                     self.checkChangeset(change, calls: i, frozen: true)
                 }
@@ -1354,7 +1350,7 @@ private class CombineCollectionPublisherTests<Collection: RealmCollection>: Comb
             .prefix(10)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 for (i, collection) in arr.enumerated() {
                     XCTAssertTrue(collection.isFrozen)
                     XCTAssertEqual(collection.count, i)
@@ -1377,7 +1373,7 @@ private class CombineCollectionPublisherTests<Collection: RealmCollection>: Comb
             .prefix(10)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 for (i, change) in arr.enumerated() {
                     self.checkChangeset(change, calls: i, frozen: true)
                 }
@@ -1726,18 +1722,17 @@ private class CombineMapPublisherTests<Collection: RealmKeyedCollection>: Combin
         cancellable = collection.collectionPublisher(keyPaths: collection.includedKeyPath)
             .subscribe(on: subscribeOnQueue)
             .assertNoFailure()
-            .sink { _ in
-                ex.fulfill()
+            .sink { _ in ex.fulfill()
         }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "change notification")
         try! realm.write { collection.appendObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "change notification")
         try! realm.write { collection.modifyObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
     }
 
     func testSubscribeOnKeyPathNoChange() {
@@ -1746,19 +1741,18 @@ private class CombineMapPublisherTests<Collection: RealmKeyedCollection>: Combin
         cancellable = collection.collectionPublisher(keyPaths: collection.excludedKeyPath)
             .subscribe(on: subscribeOnQueue)
             .assertNoFailure()
-            .sink { _ in
-                ex.fulfill()
+            .sink { _ in ex.fulfill()
         }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "change notification")
         try! realm.write { collection.appendObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "no change notification")
         ex.isInverted = true
         try! realm.write { collection.modifyObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
     }
 
     func testSubscribeOnWithToken() {
@@ -1849,18 +1843,17 @@ private class CombineMapPublisherTests<Collection: RealmKeyedCollection>: Combin
 
         cancellable = collection.changesetPublisher(keyPaths: collection.includedKeyPath)
             .subscribe(on: subscribeOnQueue)
-            .sink { _ in
-                ex.fulfill()
+            .sink { _ in ex.fulfill()
         }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "change notification")
         try! realm.write { collection.appendObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "change notification")
         try! realm.write { collection.modifyObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
     }
 
     func testChangeSetSubscribeOnKeyPathNoChange() {
@@ -1868,19 +1861,18 @@ private class CombineMapPublisherTests<Collection: RealmKeyedCollection>: Combin
 
         cancellable = collection.changesetPublisher(keyPaths: collection.excludedKeyPath)
             .subscribe(on: subscribeOnQueue)
-            .sink { _ in
-                ex.fulfill()
+            .sink { _ in ex.fulfill()
         }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "change notification")
         try! realm.write { collection.appendObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "no change notification")
         ex.isInverted = true
         try! realm.write { collection.modifyObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
     }
 
     func testChangeSetSubscribeOnWithToken() {
@@ -2042,7 +2034,7 @@ private class CombineMapPublisherTests<Collection: RealmKeyedCollection>: Combin
             .signal(sema)
             .prefix(10)
             .collect()
-            .sink { arr in
+            .sink { @Sendable arr in
                 for (i, change) in arr.enumerated() {
                     self.checkChangeset(change, calls: i, frozen: true)
                 }
@@ -2064,7 +2056,7 @@ private class CombineMapPublisherTests<Collection: RealmKeyedCollection>: Combin
             .prefix(10)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 for (i, change) in arr.enumerated() {
                     self.checkChangeset(change, calls: i, frozen: true)
                 }
@@ -2087,7 +2079,7 @@ private class CombineMapPublisherTests<Collection: RealmKeyedCollection>: Combin
             .prefix(10)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 for (i, change) in arr.enumerated() {
                     self.checkChangeset(change, calls: i, frozen: true)
                 }
@@ -2110,7 +2102,7 @@ private class CombineMapPublisherTests<Collection: RealmKeyedCollection>: Combin
             .prefix(10)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 for (i, collection) in arr.enumerated() {
                     XCTAssertTrue(collection.isFrozen)
                     XCTAssertEqual(collection.count, i)
@@ -2133,7 +2125,7 @@ private class CombineMapPublisherTests<Collection: RealmKeyedCollection>: Combin
             .prefix(10)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 for (i, change) in arr.enumerated() {
                     self.checkChangeset(change, calls: i, frozen: true)
                 }
@@ -2505,18 +2497,17 @@ private class CombineSectionedResultsPublisherTests<Collection: RealmCollection>
         cancellable = sectionedResults.collectionPublisher(keyPaths: collection.includedKeyPath)
             .subscribe(on: subscribeOnQueue)
             .assertNoFailure()
-            .sink { _ in
-                ex.fulfill()
+            .sink { _ in ex.fulfill()
         }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "change notification")
         try! realm.write { collection.appendObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "change notification")
         try! realm.write { collection.modifyObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         cancellable?.cancel()
         var sectionEx = expectation(description: "initial notification")
@@ -2527,15 +2518,15 @@ private class CombineSectionedResultsPublisherTests<Collection: RealmCollection>
             .sink { _ in
                 sectionEx.fulfill()
         }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [sectionEx], timeout: 1.0)
 
         sectionEx = expectation(description: "change notification")
         try! realm.write { collection.appendObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [sectionEx], timeout: 1.0)
 
         sectionEx = expectation(description: "change notification")
         try! realm.write { collection.modifyObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [sectionEx], timeout: 1.0)
     }
 
     func testSubscribeOnKeyPathNoChange() {
@@ -2545,19 +2536,18 @@ private class CombineSectionedResultsPublisherTests<Collection: RealmCollection>
         cancellable = sectionedResults.collectionPublisher(keyPaths: collection.excludedKeyPath)
             .subscribe(on: subscribeOnQueue)
             .assertNoFailure()
-            .sink { _ in
-                ex.fulfill()
+            .sink { _ in ex.fulfill()
         }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "change notification")
         try! realm.write { collection.appendObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "no change notification")
         ex.isInverted = true
         try! realm.write { collection.modifyObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         var sectionEx = expectation(description: "initial notification")
         cancellable?.cancel()
@@ -2567,16 +2557,16 @@ private class CombineSectionedResultsPublisherTests<Collection: RealmCollection>
             .sink { _ in
                 sectionEx.fulfill()
         }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [sectionEx], timeout: 1.0)
 
         sectionEx = expectation(description: "change notification")
         try! realm.write { collection.appendObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [sectionEx], timeout: 1.0)
 
         sectionEx = expectation(description: "no change notification")
         sectionEx.isInverted = true
         try! realm.write { collection.modifyObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [sectionEx], timeout: 1.0)
     }
 
     func testSubscribeOnWithToken() {
@@ -2755,46 +2745,44 @@ private class CombineSectionedResultsPublisherTests<Collection: RealmCollection>
         cancellable = collection.sectioned(by: \.key)
             .changesetPublisher(keyPaths: collection.includedKeyPath)
             .subscribe(on: subscribeOnQueue)
-            .sink { _ in
-                ex.fulfill()
+            .sink { _ in ex.fulfill()
         }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "change notification")
         try! realm.write {
             collection.appendObject()
 
         }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "change notification")
         try! realm.write {
             collection.modifyObject()
 
         }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         var sectionEx = expectation(description: "initial notification")
 
         cancellable = collection.sectioned(by: \.key)[0]
             .changesetPublisher(keyPaths: collection.includedKeyPath)
             .subscribe(on: subscribeOnQueue)
-            .sink { _ in
-                sectionEx.fulfill()
+            .sink { _ in sectionEx.fulfill()
         }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [sectionEx], timeout: 1.0)
 
         sectionEx = expectation(description: "change notification")
         try! realm.write {
             collection.appendObject()
         }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [sectionEx], timeout: 1.0)
 
         sectionEx = expectation(description: "change notification")
         try! realm.write {
             collection.modifyObject()
         }
-        waitForExpectations(timeout: 10.0, handler: nil)
+        wait(for: [sectionEx], timeout: 1.0)
     }
 
     func testChangeSetSubscribeOnKeyPathNoChange() {
@@ -2803,38 +2791,36 @@ private class CombineSectionedResultsPublisherTests<Collection: RealmCollection>
         cancellable = collection.sectioned(by: \.key)
             .changesetPublisher(keyPaths: collection.excludedKeyPath)
             .subscribe(on: subscribeOnQueue)
-            .sink { _ in
-                ex.fulfill()
+            .sink { _ in ex.fulfill()
         }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "change notification")
         try! realm.write { collection.appendObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         ex = expectation(description: "no change notification")
         ex.isInverted = true
         try! realm.write { collection.modifyObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [ex], timeout: 1.0)
 
         var sectionEx = expectation(description: "initial notification")
 
         cancellable = collection.sectioned(by: \.key)[0]
             .changesetPublisher(keyPaths: collection.excludedKeyPath)
             .subscribe(on: subscribeOnQueue)
-            .sink { _ in
-                sectionEx.fulfill()
+            .sink { _ in sectionEx.fulfill()
         }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [sectionEx], timeout: 1.0)
 
         sectionEx = expectation(description: "change notification")
         try! realm.write { collection.appendObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [sectionEx], timeout: 1.0)
 
         sectionEx = expectation(description: "no change notification")
         sectionEx.isInverted = true
         try! realm.write { collection.modifyObject() }
-        waitForExpectations(timeout: 1.0, handler: nil)
+        wait(for: [sectionEx], timeout: 1.0)
 
     }
 
@@ -3132,7 +3118,7 @@ private class CombineSectionedResultsPublisherTests<Collection: RealmCollection>
             .prefix(10)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 XCTAssertEqual(arr.count, 10)
                 for (i, collection) in arr.enumerated() {
                     XCTAssertTrue(collection.isFrozen)
@@ -3159,7 +3145,7 @@ private class CombineSectionedResultsPublisherTests<Collection: RealmCollection>
             .signal(sema)
             .prefix(10)
             .collect()
-            .sink { arr in
+            .sink { @Sendable arr in
                 XCTAssertEqual(arr.count, 10)
                 for (i, change) in arr.enumerated() {
                     self.checkChangeset(change, insertions: [IndexPath(item: i - 1, section: 0)], frozen: true)
@@ -3181,7 +3167,7 @@ private class CombineSectionedResultsPublisherTests<Collection: RealmCollection>
             .signal(sema)
             .prefix(10)
             .collect()
-            .sink { arr in
+            .sink { @Sendable arr in
                 XCTAssertEqual(arr.count, objectsCount)
                 for (i, change) in arr.enumerated() {
                     self.checkChangeset(change, insertions: [IndexPath(item: (i + objectsCount) - 1, section: 0)], frozen: true)
@@ -3207,7 +3193,7 @@ private class CombineSectionedResultsPublisherTests<Collection: RealmCollection>
             .prefix(10)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 XCTAssertEqual(arr.count, 10)
                 for (i, change) in arr.enumerated() {
                     self.checkChangeset(change, insertions: [IndexPath(item: i - 1, section: 0)], frozen: true)
@@ -3228,7 +3214,7 @@ private class CombineSectionedResultsPublisherTests<Collection: RealmCollection>
             .prefix(10)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 XCTAssertEqual(arr.count, objectsCount)
                 for (i, change) in arr.enumerated() {
                     self.checkChangeset(change, insertions: [IndexPath(item: (i + objectsCount) - 1, section: 0)], frozen: true)
@@ -3255,7 +3241,7 @@ private class CombineSectionedResultsPublisherTests<Collection: RealmCollection>
             .prefix(10)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 for (i, change) in arr.enumerated() {
                     self.checkChangeset(change, insertions: [IndexPath(item: i - 1, section: 0)], frozen: true)
                 }
@@ -3277,7 +3263,7 @@ private class CombineSectionedResultsPublisherTests<Collection: RealmCollection>
             .prefix(10)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 for (i, change) in arr.enumerated() {
                     self.checkChangeset(change, insertions: [IndexPath(item: (i + objectsCount) - 1, section: 0)], frozen: true)
                 }
@@ -3303,7 +3289,7 @@ private class CombineSectionedResultsPublisherTests<Collection: RealmCollection>
             .prefix(10)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 for (i, collection) in arr.enumerated() {
                     XCTAssertTrue(collection.isFrozen)
                     if collection.count != 0 {
@@ -3327,7 +3313,7 @@ private class CombineSectionedResultsPublisherTests<Collection: RealmCollection>
             .prefix(10)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 for (i, collection) in arr.enumerated() {
                     XCTAssertTrue(collection.isFrozen)
                     if collection.count != 0 {
@@ -3355,7 +3341,7 @@ private class CombineSectionedResultsPublisherTests<Collection: RealmCollection>
             .prefix(10)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 for (i, change) in arr.enumerated() {
                     self.checkChangeset(change, insertions: [IndexPath(item: i - 1, section: 0)], frozen: true)
                 }
@@ -3376,7 +3362,7 @@ private class CombineSectionedResultsPublisherTests<Collection: RealmCollection>
             .prefix(10)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 for (i, change) in arr.enumerated() {
                     self.checkChangeset(change, insertions: [IndexPath(item: (i + objectsCount) - 1, section: 0)], frozen: true)
                 }
@@ -3536,7 +3522,7 @@ class CombineProjectionPublisherTests: CombinePublisherTestCase, @unchecked Send
             }
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 XCTAssertEqual(arr.count, 10)
                 sema.signal()
             }
@@ -3779,7 +3765,7 @@ class CombineProjectionPublisherTests: CombinePublisherTestCase, @unchecked Send
             .freeze()
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 XCTAssertEqual(arr.count, 10)
                 for i in 0..<10 {
                     XCTAssertEqual(arr[i].int, i + 1)
@@ -3807,7 +3793,7 @@ class CombineProjectionPublisherTests: CombinePublisherTestCase, @unchecked Send
             }
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 XCTAssertEqual(arr.count, 10)
                 for i in 0..<10 {
                     XCTAssertEqual(arr[i].int, i + 1)
@@ -3832,7 +3818,7 @@ class CombineProjectionPublisherTests: CombinePublisherTestCase, @unchecked Send
             .freeze()
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 var prev: SimpleProjection?
                 for change in arr {
                     guard case .change(let p, let properties) = change else {
@@ -3867,7 +3853,7 @@ class CombineProjectionPublisherTests: CombinePublisherTestCase, @unchecked Send
             .receive(on: receiveOnQueue)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 for change in arr {
                     guard case .change(let p, let properties) = change else {
                         XCTFail("Expected .change but got \(change)")
@@ -3901,7 +3887,7 @@ class CombineProjectionPublisherTests: CombinePublisherTestCase, @unchecked Send
             .receive(on: receiveOnQueue)
             .collect()
             .assertNoFailure()
-            .sink { arr in
+            .sink { @Sendable arr in
                 var prev: SimpleProjection?
                 for change in arr {
                     guard case .change(let p, let properties) = change else {
@@ -4081,6 +4067,7 @@ class CombineProjectionPublisherTests: CombinePublisherTestCase, @unchecked Send
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 class CombineAsyncRealmTests: CombinePublisherTestCase, @unchecked Sendable {
+    @MainActor
     func testWillChangeLocalWrite() {
         let asyncWriteExpectation = expectation(description: "Should complete async write")
         cancellable = realm.objectWillChange.sink {

--- a/RealmSwift/Tests/CompactionTests.swift
+++ b/RealmSwift/Tests/CompactionTests.swift
@@ -19,24 +19,16 @@
 import XCTest
 import RealmSwift
 
-// MARK: Expected Sizes
-
-private var expectedTotalBytesBefore = 0
-private let expectedUsedBytesBeforeMin = 50000
-private var count = 1000
-
-// MARK: Helpers
-
 private func fileSize(path: String) -> Int {
     let attributes = try! FileManager.default.attributesOfItem(atPath: path)
     return attributes[.size] as! Int
 }
 
-// MARK: Tests
-
 class CompactionTests: TestCase, @unchecked Sendable {
-    override func setUp() {
-        super.setUp()
+    func testSuccessfulCompactOnLaunch() {
+        let expectedUsedBytesBeforeMin = 50000
+        let count = 1000
+
         autoreleasepool {
             // Make compactable Realm
             let realm = realmWithTestPath()
@@ -49,10 +41,8 @@ class CompactionTests: TestCase, @unchecked Sendable {
                 realm.create(SwiftStringObject.self, value: ["B"])
             }
         }
-        expectedTotalBytesBefore = fileSize(path: testRealmURL().path)
-    }
+        let expectedTotalBytesBefore = fileSize(path: testRealmURL().path)
 
-    func testSuccessfulCompactOnLaunch() {
         // Configure the Realm to compact on launch
         let config = Realm.Configuration(fileURL: testRealmURL(),
                                          shouldCompactOnLaunch: { totalBytes, usedBytes in

--- a/RealmSwift/Tests/MapTests.swift
+++ b/RealmSwift/Tests/MapTests.swift
@@ -709,19 +709,17 @@ class MapTests: TestCase, @unchecked Sendable {
         let mapObj = createMap()
         try! mapObj.realm!.commitWrite()
 
-        let exp = expectation(description: "does receive notification")
+        let ex = expectation(description: "does receive notification")
         let token = mapObj.observe(on: queue) { change in
             switch change {
             case .initial(let map):
                 XCTAssertNotNil(map)
-                exp.fulfill()
-            case .update:
-                XCTFail("should not get here for this test")
-            case .error:
+                ex.fulfill()
+            default:
                 XCTFail("should not get here for this test")
             }
         }
-        waitForExpectations(timeout: 2.0, handler: nil)
+        wait(for: [ex], timeout: 2.0)
         token.invalidate()
         queue.sync { }
     }
@@ -756,27 +754,27 @@ class MapTests: TestCase, @unchecked Sendable {
                 XCTFail("should not get here for this test")
             }
         }
-        waitForExpectations(timeout: 2.0, handler: nil)
+        wait(for: [exp], timeout: 2.0)
         exp = expectation(description: "does receive notification")
         try! realm.write {
             mapObj["myNewKey"] = SwiftStringObject(value: ["one"])
             mapObj["anotherNewKey"] = SwiftStringObject(value: ["two"])
         }
-        waitForExpectations(timeout: 2.0, handler: nil)
+        wait(for: [exp], timeout: 2.0)
         XCTAssertTrue(didInsert)
 
         exp = expectation(description: "does receive notification")
         try! realm.write {
             mapObj["myNewKey"] = SwiftStringObject(value: ["three"])
         }
-        waitForExpectations(timeout: 2.0, handler: nil)
+        wait(for: [exp], timeout: 2.0)
 
         exp = expectation(description: "does receive notification")
         XCTAssertTrue(didModify)
         try! realm.write {
             mapObj["myNewKey"] = nil
         }
-        waitForExpectations(timeout: 2.0, handler: nil)
+        wait(for: [exp], timeout: 2.0)
         XCTAssertTrue(didDelete)
 
         token.invalidate()
@@ -804,7 +802,7 @@ class MapTests: TestCase, @unchecked Sendable {
             }
             ex.fulfill()
         }
-        waitForExpectations(timeout: 0.1, handler: nil)
+        wait(for: [ex], timeout: 2.0)
 
         /* Expect notification on "intCol" key path when intCol is changed */
         ex = expectation(description: "change notification")
@@ -816,7 +814,7 @@ class MapTests: TestCase, @unchecked Sendable {
             value.intCol = 8
             try! realm.commitWrite()
         }
-        waitForExpectations(timeout: 0.1, handler: nil)
+        wait(for: [ex], timeout: 2.0)
         token.invalidate()
     }
 
@@ -839,7 +837,7 @@ class MapTests: TestCase, @unchecked Sendable {
             }
             ex.fulfill()
         }
-        waitForExpectations(timeout: 0.1, handler: nil)
+        wait(for: [ex], timeout: 0.1)
 
         /* Expect no notification on "intCol" key path when stringCol is changed */
         ex = expectation(description: "NO change notification")
@@ -852,7 +850,7 @@ class MapTests: TestCase, @unchecked Sendable {
             value.stringCol = "new string"
             try! realm.commitWrite()
         }
-        waitForExpectations(timeout: 0.1, handler: nil)
+        wait(for: [ex], timeout: 0.1)
         token.invalidate()
     }
 
@@ -878,7 +876,7 @@ class MapTests: TestCase, @unchecked Sendable {
             }
             ex.fulfill()
         }
-        waitForExpectations(timeout: 0.1, handler: nil)
+        wait(for: [ex], timeout: 0.1)
 
         /* Expect notification on "intCol" key path when intCol is changed */
         ex = expectation(description: "change notification")
@@ -889,7 +887,7 @@ class MapTests: TestCase, @unchecked Sendable {
             obj.swiftObjectMap.removeObject(for: "first")
             try! realm.commitWrite()
         }
-        waitForExpectations(timeout: 0.1, handler: nil)
+        wait(for: [ex], timeout: 0.1)
         token.invalidate()
     }
 
@@ -915,7 +913,7 @@ class MapTests: TestCase, @unchecked Sendable {
             }
             ex.fulfill()
         }
-        waitForExpectations(timeout: 0.1, handler: nil)
+        wait(for: [ex], timeout: 0.1)
 
         ex = expectation(description: "change notification")
         dispatchSyncNewThread {
@@ -926,7 +924,7 @@ class MapTests: TestCase, @unchecked Sendable {
             realm.delete(value)
             try! realm.commitWrite()
         }
-        waitForExpectations(timeout: 0.1, handler: nil)
+        wait(for: [ex], timeout: 0.1)
         token.invalidate()
     }
 
@@ -954,7 +952,7 @@ class MapTests: TestCase, @unchecked Sendable {
             }
             ex.fulfill()
         }
-        waitForExpectations(timeout: 0.1, handler: nil)
+        wait(for: [ex], timeout: 0.1)
 
         ex = expectation(description: "change notification")
         dispatchSyncNewThread {
@@ -964,7 +962,7 @@ class MapTests: TestCase, @unchecked Sendable {
             obj.name = "Curley"
             try! realm.commitWrite()
         }
-        waitForExpectations(timeout: 0.1, handler: nil)
+        wait(for: [ex], timeout: 0.1)
         token.invalidate()
     }
 

--- a/RealmSwift/Tests/MixedCollectionTest.swift
+++ b/RealmSwift/Tests/MixedCollectionTest.swift
@@ -610,6 +610,7 @@ class MixedCollectionTest: TestCase, @unchecked Sendable {
         XCTAssertNotEqual(mixedObject.anyCol.dictionaryValue?["key0"]?.dictionaryValue?["key5"]?.listValue?[0], mixedObject3.anyCol.dictionaryValue?["key0"]?.dictionaryValue?["key5"]?.listValue?[0])
     }
 
+    @MainActor
     func testMixedCollectionObjectNotifications() throws {
         let subArray3: AnyRealmValue = AnyRealmValue.fromArray([ .int(3) ])
         let subArray2: AnyRealmValue = AnyRealmValue.fromArray([ subArray3 ])
@@ -683,6 +684,7 @@ class MixedCollectionTest: TestCase, @unchecked Sendable {
         }
     }
 
+    @MainActor
     func testMixedCollectionDictionaryNotifications() throws {
         let subDict2: AnyRealmValue = AnyRealmValue.fromDictionary([ "key5": .float(43) ])
         let subDict1: AnyRealmValue = AnyRealmValue.fromDictionary([ "key1": subDict2 ])
@@ -754,6 +756,7 @@ class MixedCollectionTest: TestCase, @unchecked Sendable {
         }
     }
 
+    @MainActor
     func testMixedCollectionArrayNotifications() throws {
         let subArray2: AnyRealmValue = AnyRealmValue.fromArray([ .float(43), .string("lunch"), .double(12.34) ])
         let subArray1: AnyRealmValue = AnyRealmValue.fromArray([ subArray2, .bool(false) ])

--- a/RealmSwift/Tests/ModernObjectAccessorTests.swift
+++ b/RealmSwift/Tests/ModernObjectAccessorTests.swift
@@ -673,7 +673,7 @@ class ModernObjectAccessorTests: TestCase, @unchecked Sendable {
 
     func testThreadChecking() {
         let realm = try! Realm()
-        var obj: ModernAllTypesObject!
+        nonisolated(unsafe) var obj: ModernAllTypesObject!
         try! realm.write {
             obj = realm.create(ModernAllTypesObject.self)
             // Create the lazily-initialized List to test the cached codepath

--- a/RealmSwift/Tests/ModernObjectTests.swift
+++ b/RealmSwift/Tests/ModernObjectTests.swift
@@ -20,7 +20,7 @@ import XCTest
 import RealmSwift
 import Foundation
 
-private var dynamicDefaultSeed = 0
+private nonisolated(unsafe) var dynamicDefaultSeed = 0
 private func nextDynamicDefaultSeed() -> Int {
     dynamicDefaultSeed += 1
     return dynamicDefaultSeed

--- a/RealmSwift/Tests/ObjectCustomPropertiesTests.swift
+++ b/RealmSwift/Tests/ObjectCustomPropertiesTests.swift
@@ -71,6 +71,6 @@ private final class CustomPropertiesObject: Object {
         return injected_customRealmProperties
     }
 
-    static var injected_customRealmProperties: [RLMProperty]?
+    static nonisolated(unsafe) var injected_customRealmProperties: [RLMProperty]?
     static let preMadeRLMProperty = RLMProperty(name: "value", objectType: CustomPropertiesObject.self, valueType: String.self)
 }

--- a/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
@@ -806,7 +806,7 @@ class SwiftObjectWithNonOptionalLinkProperty: SwiftFakeObject {
     @objc dynamic var objectCol = SwiftBoolObject()
 }
 
-#if compiler(<6)
+#if compiler(<6) || SWIFT_PACKAGE
 extension Set: RealmOptionalType {
     public static func _rlmFromObjc(_ value: Any, insideOptional: Bool) -> Set<Element>? {
         fatalError()

--- a/RealmSwift/Tests/ObjectiveCSupportTests.swift
+++ b/RealmSwift/Tests/ObjectiveCSupportTests.swift
@@ -49,14 +49,14 @@ class ObjectiveCSupportTests: TestCase, @unchecked Sendable {
         set.insert(SwiftObject())
         let rlmSet = ObjectiveCSupport.convert(object: set)
         XCTAssert(rlmSet.isKind(of: RLMSet<AnyObject>.self))
-        XCTAssertEqual(unsafeBitCast(rlmSet.allObjects[0], to: SwiftObject.self).floatCol, 1.23)
+        XCTAssertEqual(unsafeDowncast(rlmSet.allObjects[0], to: SwiftObject.self).floatCol, 1.23)
         XCTAssertEqual(rlmSet.count, 1)
 
         let map = Map<String, SwiftObject?>()
         map["0"] = SwiftObject()
         let rlmDictionary = ObjectiveCSupport.convert(object: map)
         XCTAssert(rlmDictionary.isKind(of: RLMDictionary<AnyObject, AnyObject>.self))
-        XCTAssertEqual(unsafeBitCast(rlmDictionary.allValues[0], to: SwiftObject.self).floatCol, 1.23)
+        XCTAssertEqual(unsafeDowncast(rlmDictionary.allValues[0], to: SwiftObject.self).floatCol, 1.23)
         XCTAssertEqual(rlmDictionary.count, 1)
 
         let rlmRealm = ObjectiveCSupport.convert(object: realm)

--- a/RealmSwift/Tests/PerformanceTests.swift
+++ b/RealmSwift/Tests/PerformanceTests.swift
@@ -40,9 +40,9 @@ class SwiftIntProjection: Projection<SwiftIntObject> {
     @Projected(\SwiftIntObject.intCol) var intCol
 }
 
-private var smallRealm: Realm!
-private var mediumRealm: Realm!
-private var largeRealm: Realm!
+private nonisolated(unsafe) var smallRealm: Realm!
+private nonisolated(unsafe) var mediumRealm: Realm!
+private nonisolated(unsafe) var largeRealm: Realm!
 
 private let isRunningOnDevice = TARGET_IPHONE_SIMULATOR == 0
 
@@ -418,7 +418,7 @@ class SwiftPerformanceTests: TestCase, @unchecked Sendable {
     }
 
     func testRealmCreationCached() {
-        var realm: Realm!
+        nonisolated(unsafe) var realm: Realm!
         dispatchSyncNewThread {
             realm = try! Realm()
         }
@@ -453,9 +453,12 @@ class SwiftPerformanceTests: TestCase, @unchecked Sendable {
     }
 
     func testSyncRealmCreationCached() {
-        var config = ObjectiveCSupport.convert(object: RLMRealmConfiguration.fakeSync())
-        config.objectTypes = []
-        var realm: Realm!
+        let config = {
+            var config = ObjectiveCSupport.convert(object: RLMRealmConfiguration.fakeSync())
+            config.objectTypes = []
+            return config
+        }()
+        nonisolated(unsafe) var realm: Realm!
         dispatchSyncNewThread {
             realm = try! Realm(configuration: config)
         }
@@ -468,9 +471,12 @@ class SwiftPerformanceTests: TestCase, @unchecked Sendable {
     }
 
     func testSyncRealmMultithreadedCacheLookup() {
-        var config = ObjectiveCSupport.convert(object: RLMRealmConfiguration.fakeSync())
-        config.objectTypes = []
-        var realm: Realm!
+        let config = {
+            var config = ObjectiveCSupport.convert(object: RLMRealmConfiguration.fakeSync())
+            config.objectTypes = []
+            return config
+        }()
+        nonisolated(unsafe) var realm: Realm!
         dispatchSyncNewThread {
             realm = try! Realm(configuration: config)
         }
@@ -493,9 +499,12 @@ class SwiftPerformanceTests: TestCase, @unchecked Sendable {
     }
 
     func testSyncRealmMultithreadedCreationCached() {
-        var config = ObjectiveCSupport.convert(object: RLMRealmConfiguration.fakeSync())
-        config.objectTypes = []
-        var realm: Realm!
+        let config = {
+            var config = ObjectiveCSupport.convert(object: RLMRealmConfiguration.fakeSync())
+            config.objectTypes = []
+            return config
+        }()
+        nonisolated(unsafe) var realm: Realm!
         dispatchSyncNewThread {
             realm = try! Realm(configuration: config)
         }
@@ -978,7 +987,7 @@ class SwiftSyncRealmPerformanceTests: TestCase, @unchecked Sendable {
 
     func testSyncRealmCreationCached() {
         let config = self.config
-        var realm: Realm!
+        nonisolated(unsafe) var realm: Realm!
         dispatchSyncNewThread {
             // Open on a different thread so that the test hits the path where
             // the cache lookup is a miss but there's a cached Realm on a

--- a/RealmSwift/Tests/PrimitiveMapTests.swift
+++ b/RealmSwift/Tests/PrimitiveMapTests.swift
@@ -58,6 +58,7 @@ class PrimitiveMapTests<O: ObjectFactory, V: MapValueFactory>: PrimitiveMapTests
         }
     }
 
+    @MainActor
     func testEnumeration() {
         XCTAssertEqual(0, map.count)
         map.merge(values) { $1 }

--- a/RealmSwift/Tests/ProjectedCollectTests.swift
+++ b/RealmSwift/Tests/ProjectedCollectTests.swift
@@ -141,6 +141,7 @@ class ProjectedCollectionsTestsTemplate: TestCase, @unchecked Sendable {
         }
     }
 
+    @MainActor
     func testObserve() {
         let ex = expectation(description: "initial notification")
         let token = collection.observe { (changes: RealmCollectionChange) in
@@ -177,6 +178,7 @@ class ProjectedCollectionsTestsTemplate: TestCase, @unchecked Sendable {
         token2.invalidate()
     }
 
+    @MainActor
     func testObserveKeyPathNoChange() {
         let ex = expectation(description: "initial notification")
         let token0 = collection.observe(keyPaths: ["firstName"]) { (changes: RealmCollectionChange) in
@@ -191,7 +193,7 @@ class ProjectedCollectionsTestsTemplate: TestCase, @unchecked Sendable {
             ex.fulfill()
         }
 
-        dispatchSyncNewThread {
+        dispatchSyncNewThread { @Sendable in
             let realm = self.realmWithTestPath()
             realm.beginWrite()
             let obj = realm.create(CommonPerson.self)
@@ -258,7 +260,7 @@ class ProjectedCollectionsTestsTemplate: TestCase, @unchecked Sendable {
     }
 
     func testThawFromDifferentThread() {
-        let frozen = collection.freeze()
+        nonisolated(unsafe) let frozen = collection.freeze()
         XCTAssertTrue(frozen.isFrozen)
 
         dispatchSyncNewThread {
@@ -273,14 +275,14 @@ class ProjectedCollectionsTestsTemplate: TestCase, @unchecked Sendable {
     }
 
     func testFreezeFromWrongThread() {
-        let collection = realmWithTestPath().objects(PersonProjection.self).first!.firstFriendsName
+        nonisolated(unsafe) let collection = realmWithTestPath().objects(PersonProjection.self).first!.firstFriendsName
         dispatchSyncNewThread {
             self.assertThrows(collection.freeze(), reason: "Realm accessed from incorrect thread")
         }
     }
 
     func testAccessFrozenCollectionFromDifferentThread() {
-        let frozen = collection.freeze()
+        nonisolated(unsafe) let frozen = collection.freeze()
         dispatchSyncNewThread {
             XCTAssertTrue(frozen.contains(where: { $0 == "Daenerys" }))
             XCTAssertTrue(frozen.contains(where: { $0 == "Tyrion" }))

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -842,6 +842,7 @@ class RealmTests: TestCase, @unchecked Sendable {
         XCTAssertFalse(notificationCalled)
     }
 
+    @MainActor
     func testAutorefresh() {
         let realm = try! Realm()
         XCTAssertTrue(realm.autorefresh, "Autorefresh should default to true")
@@ -858,7 +859,7 @@ class RealmTests: TestCase, @unchecked Sendable {
             notificationFired.fulfill()
         }
 
-        dispatchSyncNewThread {
+        dispatchSyncNewThread { @Sendable in
             let realm = try! Realm()
             try! realm.write {
                 realm.create(SwiftStringObject.self, value: ["string"])
@@ -873,6 +874,7 @@ class RealmTests: TestCase, @unchecked Sendable {
         XCTAssertEqual(results[0].stringCol, "string", "Value of first column should be 'string'")
     }
 
+    @MainActor
     func testRefresh() {
         let realm = try! Realm()
         realm.autorefresh = false
@@ -890,7 +892,7 @@ class RealmTests: TestCase, @unchecked Sendable {
         let results = realm.objects(SwiftStringObject.self)
         XCTAssertEqual(results.count, Int(0), "There should be 1 object of type StringObject")
 
-        dispatchSyncNewThread {
+        dispatchSyncNewThread { @Sendable in
             try! Realm().write {
                 _ = try! Realm().create(SwiftStringObject.self, value: ["string"])
             }
@@ -1020,7 +1022,7 @@ class RealmTests: TestCase, @unchecked Sendable {
     }
 
     func testEquals() {
-        let realm = try! Realm()
+        nonisolated(unsafe) let realm = try! Realm()
         XCTAssertTrue(try! realm == Realm())
 
         let testRealm = realmWithTestPath()
@@ -1063,7 +1065,7 @@ class RealmTests: TestCase, @unchecked Sendable {
     func testThaw() {
         XCTAssertEqual(try! Realm().objects(SwiftBoolObject.self).count, 0)
         let realm = try! Realm()
-        let frozenRealm = realm.freeze()
+        nonisolated(unsafe) let frozenRealm = realm.freeze()
         XCTAssert(frozenRealm.isFrozen)
 
         dispatchSyncNewThread {
@@ -1080,6 +1082,7 @@ class RealmTests: TestCase, @unchecked Sendable {
 
     // MARK: - Async Transactions
 
+    @MainActor
     func testAsyncTransactionShouldWrite() {
         let realm = try! Realm()
         let asyncComplete = expectation(description: "async transaction complete")
@@ -1095,6 +1098,7 @@ class RealmTests: TestCase, @unchecked Sendable {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
+    @MainActor
     func testAsyncTransactionShouldWriteOnCommit() {
         let realm = try! Realm()
         let writeComplete = expectation(description: "async transaction complete")
@@ -1116,6 +1120,7 @@ class RealmTests: TestCase, @unchecked Sendable {
         XCTAssertEqual(realm.objects(SwiftStringObject.self).count, 1)
     }
 
+    @MainActor
     func testAsyncTransactionShouldCancel() {
         let realm = try! Realm()
         let asyncComplete = expectation(description: "async transaction complete")
@@ -1134,6 +1139,7 @@ class RealmTests: TestCase, @unchecked Sendable {
         XCTAssertNil(realm.objects(SwiftStringObject.self).first)
     }
 
+    @MainActor
     func testAsyncTransactionShouldCancelWithoutCommit() {
         let realm = try! Realm()
         let asyncComplete = expectation(description: "async transaction complete")
@@ -1149,6 +1155,7 @@ class RealmTests: TestCase, @unchecked Sendable {
         XCTAssertNil(realm.objects(SwiftStringObject.self).first)
     }
 
+    @MainActor
     func testAsyncTransactionShouldNotAutoCommitOnCanceledTransaction() {
         let realm = try! Realm()
         let waitComplete = expectation(description: "async wait complete")
@@ -1170,6 +1177,7 @@ class RealmTests: TestCase, @unchecked Sendable {
         XCTAssertNil(realm.objects(SwiftStringObject.self).first)
     }
 
+    @MainActor
     func testAsyncTransactionShouldAutorefresh() {
         let realm = try! Realm()
         realm.autorefresh = false
@@ -1201,6 +1209,7 @@ class RealmTests: TestCase, @unchecked Sendable {
         XCTAssertEqual(results[0].stringCol, "string")
     }
 
+    @MainActor
     func testAsyncTransactionSyncCommit() {
         let realm = try! Realm()
         let asyncComplete = expectation(description: "async transaction complete")
@@ -1222,6 +1231,7 @@ class RealmTests: TestCase, @unchecked Sendable {
         XCTAssertEqual(2, realm.objects(SwiftStringObject.self).count)
     }
 
+    @MainActor
     func testAsyncTransactionSyncAfterAsyncWithoutCommit() {
         let realm = try! Realm()
         XCTAssertEqual(0, realm.objects(SwiftStringObject.self).count)
@@ -1241,6 +1251,7 @@ class RealmTests: TestCase, @unchecked Sendable {
         XCTAssertEqual("string 2", realm.objects(SwiftStringObject.self).first?.stringCol)
     }
 
+    @MainActor
     func testAsyncTransactionWriteWithSync() {
         let realm = try! Realm()
         let asyncComplete = expectation(description: "async transaction complete")
@@ -1261,6 +1272,7 @@ class RealmTests: TestCase, @unchecked Sendable {
         XCTAssertEqual(2, realm.objects(SwiftStringObject.self).count)
     }
 
+    @MainActor
     func testAsyncTransactionMixedWithSync() {
         let realm = try! Realm()
         let asyncComplete = expectation(description: "async transaction complete")
@@ -1285,6 +1297,7 @@ class RealmTests: TestCase, @unchecked Sendable {
         XCTAssertEqual(3, realm.objects(SwiftStringObject.self).count)
     }
 
+    @MainActor
     func testAsyncTransactionMixedWithCancelledSync() {
         let realm = try! Realm()
         let asyncComplete = expectation(description: "async transaction complete")
@@ -1309,6 +1322,7 @@ class RealmTests: TestCase, @unchecked Sendable {
         XCTAssertEqual(2, realm.objects(SwiftStringObject.self).count)
     }
 
+    @MainActor
     func testAsyncTransactionChangeNotification() {
         let realm = try! Realm()
         let asyncWriteComplete = expectation(description: "async write complete")
@@ -1345,6 +1359,7 @@ class RealmTests: TestCase, @unchecked Sendable {
         token.invalidate()
     }
 
+    @MainActor
     func testBeginAsyncTransactionInAsyncTransaction() {
         let realm = try! Realm()
         let transaction1 = expectation(description: "async transaction 1 complete")
@@ -1369,6 +1384,7 @@ class RealmTests: TestCase, @unchecked Sendable {
         XCTAssertEqual(2, realm.objects(SwiftStringObject.self).count)
     }
 
+    @MainActor
     func testAsyncTransactionFromSyncTransaction() {
         let realm = try! Realm()
         let transaction1 = expectation(description: "async transaction 1 complete")
@@ -1425,6 +1441,7 @@ class RealmTests: TestCase, @unchecked Sendable {
         XCTAssertEqual(2, realm.objects(SwiftStringObject.self).count)
     }
 
+    @MainActor
     func testAsyncTransactionCommit() {
         let realm = try! Realm()
         let changesAddedExpectation = expectation(description: "testAsyncTransactionCommit expectation")
@@ -1450,6 +1467,7 @@ class RealmTests: TestCase, @unchecked Sendable {
         XCTAssertEqual(1, realm.objects(SwiftStringObject.self).count)
     }
 
+    @MainActor
     func testAsyncTransactionShouldWriteObjectFromOutsideOfTransaction() {
         let realm = try! Realm()
         let asyncComplete = expectation(description: "async transaction complete")
@@ -1468,6 +1486,7 @@ class RealmTests: TestCase, @unchecked Sendable {
         XCTAssertNotNil(realm.objects(SwiftStringObject.self).first { $0.stringCol == "string I" })
     }
 
+    @MainActor
     func testAsyncTransactionShouldChangeExistingObject() {
         let realm = try! Realm()
         let asyncComplete = expectation(description: "async transaction complete")
@@ -1497,7 +1516,7 @@ extension RealmTests {
         let realm = try await Realm(downloadBeforeOpen: .always)
         _ = try await Realm(downloadBeforeOpen: .always)
         _ = try await Task { @CustomGlobalActor in
-            _ = try await Realm(actor: CustomGlobalActor.shared, downloadBeforeOpen: .always)
+            _ = try await openRealm(actor: CustomGlobalActor.shared, downloadBeforeOpen: .always)
         }.value
         realm.invalidate()
     }
@@ -1513,7 +1532,7 @@ extension RealmTests {
 
     @MainActor
     func testAsyncRefresh() async throws {
-        let realm = try await Realm(actor: MainActor.shared)
+        let realm = try await openRealm(actor: MainActor.shared)
         realm.autorefresh = false
 
         let results = realm.objects(SwiftStringObject.self)
@@ -1522,7 +1541,7 @@ extension RealmTests {
         XCTAssertFalse(didRefresh)
 
         try await Task { @CustomGlobalActor in
-            let realm = try await Realm(actor: CustomGlobalActor.shared)
+            let realm = try await openRealm(actor: CustomGlobalActor.shared)
             try! realm.write {
                 _ = realm.create(SwiftStringObject.self, value: ["string"])
             }
@@ -1684,7 +1703,7 @@ extension RealmTests {
 
     @MainActor
     func testAsyncWriteBasics() async throws {
-        let realm = try await Realm(actor: MainActor.shared)
+        let realm = try await openRealm(actor: MainActor.shared)
         let obj = try await realm.asyncWrite {
             XCTAssertTrue(realm.isInWriteTransaction)
             XCTAssertTrue(realm.isPerformingAsynchronousWriteOperations)
@@ -1698,7 +1717,7 @@ extension RealmTests {
 
     @MainActor
     func testAsyncWriteCancel() async throws {
-        let realm = try await Realm(actor: MainActor.shared)
+        let realm = try await openRealm(actor: MainActor.shared)
         try await realm.asyncWrite {
             realm.create(SwiftStringObject.self, value: ["foo"])
             realm.cancelWrite()
@@ -1709,7 +1728,7 @@ extension RealmTests {
 
     @MainActor
     func testAsyncWriteBeginNewWriteAfterCancel() async throws {
-        let realm = try await Realm(actor: MainActor.shared)
+        let realm = try await openRealm(actor: MainActor.shared)
         try await realm.asyncWrite {
             realm.create(SwiftStringObject.self, value: ["foo"])
             realm.cancelWrite()
@@ -1723,7 +1742,7 @@ extension RealmTests {
 
     @MainActor
     func testAsyncWriteModifyExistingObject() async throws {
-        let realm = try await Realm(actor: MainActor.shared)
+        let realm = try await openRealm(actor: MainActor.shared)
         let obj = try await realm.asyncWrite {
             realm.create(SwiftStringObject.self, value: ["foo"])
         }
@@ -1735,7 +1754,7 @@ extension RealmTests {
 
     @MainActor
     func testAsyncWriteCancelsOnThrow() async throws {
-        let realm = try await Realm(actor: MainActor.shared)
+        let realm = try await openRealm(actor: MainActor.shared)
 
         await assertThrowsErrorAsync(try await realm.asyncWrite {
             realm.create(SwiftStringObject.self, value: ["foo"])
@@ -1753,7 +1772,7 @@ extension RealmTests {
 
     @CustomGlobalActor
     func testAsyncWriteCustomGlobalActor() async throws {
-        let realm = try await Realm(actor: CustomGlobalActor.shared)
+        let realm = try await openRealm(actor: CustomGlobalActor.shared)
         let obj = try await realm.asyncWrite {
             realm.create(SwiftStringObject.self, value: ["foo"])
         }
@@ -1770,7 +1789,7 @@ extension RealmTests {
             var realm: Realm!
             var obj: SwiftStringObject?
             init() async throws {
-                realm = try await Realm(actor: self)
+                realm = try await openRealm(actor: self)
             }
 
             var count: Int {
@@ -1819,12 +1838,12 @@ extension RealmTests {
 
     @MainActor
     func testAsyncWriteTaskCancellation() async throws {
-        let realm = try await Realm(actor: MainActor.shared)
+        let realm = try await openRealm(actor: MainActor.shared)
         realm.beginWrite()
 
         let ex = expectation(description: "Background thread ready")
         let task = Task { @CustomGlobalActor in
-            let realm = try await Realm(actor: CustomGlobalActor.shared)
+            let realm = try await openRealm(actor: CustomGlobalActor.shared)
             ex.fulfill()
             try await realm.asyncWrite {
                 XCTFail("Should not have been called")
@@ -1842,12 +1861,12 @@ extension RealmTests {
 
     @MainActor
     func testAsyncWriteTaskCancelledBeforeWriteCalled() async throws {
-        let realm = try await Realm(actor: MainActor.shared)
+        let realm = try await openRealm(actor: MainActor.shared)
         realm.beginWrite()
 
         let ex = expectation(description: "Background thread ready")
         let task = Task { @CustomGlobalActor in
-            let realm = try await Realm(actor: CustomGlobalActor.shared)
+            let realm = try await openRealm(actor: CustomGlobalActor.shared)
             ex.fulfill()
             // Block until cancelWrite() is called, ensuring that the Task is
             // cancelled before the call to asyncWrite
@@ -1867,7 +1886,7 @@ extension RealmTests {
     // FIXME: deadlocks without https://github.com/realm/realm-core/pull/6413
     @MainActor
     func skip_testAsyncWriteTaskCancellationTiming() async throws {
-        let realm = try await Realm(actor: MainActor.shared)
+        let realm = try await openRealm(actor: MainActor.shared)
         realm.beginWrite()
 
         // Try to hit the timing windows which can't be deterministically tested
@@ -1876,7 +1895,7 @@ extension RealmTests {
         for _ in 0..<1000 {
             let ex = expectation(description: "Background thread ready")
             let task = Task { @CustomGlobalActor in
-                let realm = try await Realm(actor: CustomGlobalActor.shared)
+                let realm = try await openRealm(actor: CustomGlobalActor.shared)
                 // Tearing down a Realm which is in the middle of async writes
                 // is itself async, so we need to explicitly wait for that to
                 // happen or we'll hit a data race when we try to close all
@@ -1954,7 +1973,7 @@ class LoggerTests: TestCase, @unchecked Sendable {
         Logger.shared = logger
     }
     func testSetDefaultLogLevel() throws {
-        var logs: String = ""
+        nonisolated(unsafe) var logs: String = ""
         let logger = Logger(level: .off) { level, message in
             logs += "\(Date.now) \(level.logLevel) \(message)"
         }
@@ -1971,7 +1990,7 @@ class LoggerTests: TestCase, @unchecked Sendable {
     }
 
     func testDefaultLogger() throws {
-        var logs: String = ""
+        nonisolated(unsafe) var logs: String = ""
         let logger = Logger(level: .off) { level, message in
             logs += "\(Date.now) \(level.logLevel) \(message)"
         }

--- a/RealmSwift/Tests/SectionedResultsTests.swift
+++ b/RealmSwift/Tests/SectionedResultsTests.swift
@@ -367,6 +367,7 @@ class SectionedResultsTests: SectionedResultsTestsBase {
         XCTAssertEqual(obj.stringCol, "apple")
     }
 
+    @MainActor
     func testObservation() {
         let realm = createObjects()
         let results = realm.objects(ModernAllTypesObject.self)
@@ -403,6 +404,7 @@ class SectionedResultsTests: SectionedResultsTestsBase {
         token2.invalidate()
     }
 
+    @MainActor
     func testObserveWithKeyPathFilter() {
         let realm = createObjects()
         let results = realm.objects(ModernAllTypesObject.self)
@@ -443,6 +445,7 @@ class SectionedResultsTests: SectionedResultsTestsBase {
         realmToken.invalidate()
     }
 
+    @MainActor
     func testObserveWithKeyPathFilterOnSection() {
         let realm = createObjects()
         let results = realm.objects(ModernAllTypesObject.self)
@@ -845,6 +848,7 @@ class SectionedResultsProjectionTests: SectionedResultsTestsBase {
         assert(ascending: false, sectionCount: 3, sectionKeys: ["c", "b", "a"])
     }
 
+    @MainActor
     func testObservation() {
         let realm = createObjects()
         let results = realm.objects(ModernAllTypesProjection.self)

--- a/RealmSwift/Tests/SwiftUITests.swift
+++ b/RealmSwift/Tests/SwiftUITests.swift
@@ -69,48 +69,51 @@ class SwiftUITests: TestCase, @unchecked Sendable {
 
     // MARK: - List Operations
 
-    func testManagedUnmanagedListAppendPrimitive() throws {
+    @MainActor func testManagedUnmanagedListAppendPrimitive() throws {
         let object = SwiftUIObject()
-        let state = StateRealmObject(wrappedValue: object.primitiveList)
-        XCTAssertEqual(state.wrappedValue.count, 0)
-        state.projectedValue.append(1)
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        @StateRealmObject var state = object.primitiveList
+        XCTAssertEqual(state.count, 0)
+        $state.append(1)
+        XCTAssertEqual(state.count, 1)
 
         let realm = inMemoryRealm(inMemoryIdentifier)
         try realm.write { realm.add(object) }
 
-        state.projectedValue.append(2)
-        XCTAssertEqual(state.wrappedValue.count, 2)
+        $state.append(2)
+        XCTAssertEqual(state.count, 2)
     }
-    func testManagedUnmanagedListAppendUnmanagedObject() throws {
+
+    @MainActor func testManagedUnmanagedListAppendUnmanagedObject() throws {
         let object = SwiftUIObject()
-        let state = StateRealmObject(wrappedValue: object.list)
-        XCTAssertEqual(state.wrappedValue.count, 0)
-        state.projectedValue.append(SwiftBoolObject())
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        @StateRealmObject var state = object.list
+        XCTAssertEqual(state.count, 0)
+        $state.append(SwiftBoolObject())
+        XCTAssertEqual(state.count, 1)
 
         let realm = inMemoryRealm(inMemoryIdentifier)
         try realm.write { realm.add(object) }
 
-        state.projectedValue.append(SwiftBoolObject())
-        XCTAssertEqual(state.wrappedValue.count, 2)
+        $state.append(SwiftBoolObject())
+        XCTAssertEqual(state.count, 2)
     }
-    func testManagedListAppendUnmanagedObservedObject() throws {
+
+    @MainActor func testManagedListAppendUnmanagedObservedObject() throws {
         let object = SwiftUIObject()
-        var state = StateRealmObject(wrappedValue: object.list)
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        @StateRealmObject var state = object.list
+        XCTAssertEqual(state.count, 0)
 
         let realm = inMemoryRealm(inMemoryIdentifier)
         try realm.write { realm.add(object) }
 
-        state.update()
-        state.projectedValue.append(SwiftBoolObject())
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        _state.update()
+        $state.append(SwiftBoolObject())
+        XCTAssertEqual(state.count, 1)
     }
-    func testManagedListAppendFrozenObject() throws {
+
+    @MainActor func testManagedListAppendFrozenObject() throws {
         let listObj = SwiftUIObject()
-        var state = StateRealmObject(wrappedValue: listObj.list)
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        @StateRealmObject var state = listObj.list
+        XCTAssertEqual(state.count, 0)
 
         let realm = inMemoryRealm(inMemoryIdentifier)
         let obj = SwiftBoolObject()
@@ -120,97 +123,99 @@ class SwiftUITests: TestCase, @unchecked Sendable {
         }
         let frozen = obj.freeze()
 
-        state.update()
-        state.projectedValue.append(frozen)
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        _state.update()
+        $state.append(frozen)
+        XCTAssertEqual(state.count, 1)
     }
-    func testManagedUnmanagedListRemovePrimitive() throws {
+
+    @MainActor func testManagedUnmanagedListRemovePrimitive() throws {
         let object = SwiftUIObject()
-        let state = StateRealmObject(wrappedValue: object.primitiveList)
-        XCTAssertEqual(state.wrappedValue.count, 0)
-        state.projectedValue.append(1)
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        @StateRealmObject var state = object.primitiveList
+        XCTAssertEqual(state.count, 0)
+        $state.append(1)
+        XCTAssertEqual(state.count, 1)
 
         let realm = inMemoryRealm(inMemoryIdentifier)
         try realm.write { realm.add(object) }
 
-        state.projectedValue.append(2)
-        XCTAssertEqual(state.wrappedValue.count, 2)
+        $state.append(2)
+        XCTAssertEqual(state.count, 2)
 
-        state.projectedValue.remove(at: 0)
-        XCTAssertEqual(state.wrappedValue[0], 2)
-        XCTAssertEqual(state.wrappedValue.count, 1)
-    }
-    func testManagedUnmanagedListRemoveUnmanagedObject() throws {
-        let object = SwiftUIObject()
-        let state = StateRealmObject(wrappedValue: object.list)
-        XCTAssertEqual(state.wrappedValue.count, 0)
-        state.projectedValue.append(SwiftBoolObject())
-        XCTAssertEqual(state.wrappedValue.count, 1)
-        state.projectedValue.remove(at: 0)
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        $state.remove(at: 0)
+        XCTAssertEqual(state[0], 2)
+        XCTAssertEqual(state.count, 1)
     }
 
-    func testManagedListAppendRemoveObservedObject() throws {
+    @MainActor func testManagedUnmanagedListRemoveUnmanagedObject() throws {
         let object = SwiftUIObject()
-        var state = StateRealmObject(wrappedValue: object.list)
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        @StateRealmObject var state = object.list
+        XCTAssertEqual(state.count, 0)
+        $state.append(SwiftBoolObject())
+        XCTAssertEqual(state.count, 1)
+        $state.remove(at: 0)
+        XCTAssertEqual(state.count, 0)
+    }
+
+    @MainActor func testManagedListAppendRemoveObservedObject() throws {
+        let object = SwiftUIObject()
+        @StateRealmObject var state = object.list
+        XCTAssertEqual(state.count, 0)
 
         let realm = inMemoryRealm(inMemoryIdentifier)
         try realm.write { realm.add(object) }
 
-        state.update()
-        state.projectedValue.append(SwiftBoolObject())
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        _state.update()
+        $state.append(SwiftBoolObject())
+        XCTAssertEqual(state.count, 1)
 
-        state.projectedValue.remove(at: 0)
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        $state.remove(at: 0)
+        XCTAssertEqual(state.count, 0)
     }
 
     // MARK: - MutableSet Operations
 
-    func testManagedUnmanagedMutableSetInsertPrimitive() throws {
+    @MainActor func testManagedUnmanagedMutableSetInsertPrimitive() throws {
         let object = SwiftUIObject()
-        let state = StateRealmObject(wrappedValue: object.primitiveSet)
-        XCTAssertEqual(state.wrappedValue.count, 0)
-        state.projectedValue.insert(1)
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        @StateRealmObject var state = object.primitiveSet
+        XCTAssertEqual(state.count, 0)
+        $state.insert(1)
+        XCTAssertEqual(state.count, 1)
 
         let realm = inMemoryRealm(inMemoryIdentifier)
         try realm.write { realm.add(object) }
 
-        state.projectedValue.insert(2)
-        XCTAssertEqual(state.wrappedValue.count, 2)
+        $state.insert(2)
+        XCTAssertEqual(state.count, 2)
     }
-    func testManagedUnmanagedMutableSetInsertUnmanagedObject() throws {
+    @MainActor func testManagedUnmanagedMutableSetInsertUnmanagedObject() throws {
         let object = SwiftUIObject()
-        let state = StateRealmObject(wrappedValue: object.set)
-        XCTAssertEqual(state.wrappedValue.count, 0)
-        state.projectedValue.insert(SwiftBoolObject())
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        @StateRealmObject var state = object.set
+        XCTAssertEqual(state.count, 0)
+        $state.insert(SwiftBoolObject())
+        XCTAssertEqual(state.count, 1)
 
         let realm = inMemoryRealm(inMemoryIdentifier)
         try realm.write { realm.add(object) }
 
-        state.projectedValue.insert(SwiftBoolObject())
-        XCTAssertEqual(state.wrappedValue.count, 2)
+        $state.insert(SwiftBoolObject())
+        XCTAssertEqual(state.count, 2)
     }
-    func testManagedMutableSetInsertUnmanagedObservedObject() throws {
+    @MainActor func testManagedMutableSetInsertUnmanagedObservedObject() throws {
         let object = SwiftUIObject()
-        var state = StateRealmObject(wrappedValue: object.set)
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        @StateRealmObject var state = object.set
+        XCTAssertEqual(state.count, 0)
 
         let realm = inMemoryRealm(inMemoryIdentifier)
         try realm.write { realm.add(object) }
 
-        state.update()
-        state.projectedValue.insert(SwiftBoolObject())
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        _state.update()
+        $state.insert(SwiftBoolObject())
+        XCTAssertEqual(state.count, 1)
     }
-    func testManagedMutableSetInsertFrozenObject() throws {
+    @MainActor func testManagedMutableSetInsertFrozenObject() throws {
         let object = SwiftUIObject()
-        var state = StateRealmObject(wrappedValue: object.set)
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        @StateRealmObject var state = object.set
+        XCTAssertEqual(state.count, 0)
 
         let realm = inMemoryRealm(inMemoryIdentifier)
         let obj = SwiftBoolObject()
@@ -219,59 +224,59 @@ class SwiftUITests: TestCase, @unchecked Sendable {
             realm.add(obj)
         }
         let frozen = obj.freeze()
-        state.update()
-        state.projectedValue.insert(frozen)
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        _state.update()
+        $state.insert(frozen)
+        XCTAssertEqual(state.count, 1)
     }
-    func testMutableSetRemovePrimitive() throws {
+    @MainActor func testMutableSetRemovePrimitive() throws {
         let object = SwiftUIObject()
-        let state = StateRealmObject(wrappedValue: object.primitiveSet)
-        XCTAssertEqual(state.wrappedValue.count, 0)
-        state.projectedValue.insert(1)
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        @StateRealmObject var state = object.primitiveSet
+        XCTAssertEqual(state.count, 0)
+        $state.insert(1)
+        XCTAssertEqual(state.count, 1)
 
         let realm = inMemoryRealm(inMemoryIdentifier)
         try realm.write { realm.add(object) }
 
-        state.projectedValue.insert(2)
-        XCTAssertEqual(state.wrappedValue.count, 2)
+        $state.insert(2)
+        XCTAssertEqual(state.count, 2)
 
-        state.projectedValue.remove(1)
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        $state.remove(1)
+        XCTAssertEqual(state.count, 1)
     }
-    func testUnmanagedMutableSetRemoveUnmanagedObject() throws {
+    @MainActor func testUnmanagedMutableSetRemoveUnmanagedObject() throws {
         let object = SwiftUIObject()
-        let state = StateRealmObject(wrappedValue: object.set)
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        @StateRealmObject var state = object.set
+        XCTAssertEqual(state.count, 0)
         let obj = SwiftBoolObject()
-        state.projectedValue.insert(obj)
-        XCTAssertEqual(state.wrappedValue.count, 1)
-        state.projectedValue.remove(obj)
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        $state.insert(obj)
+        XCTAssertEqual(state.count, 1)
+        $state.remove(obj)
+        XCTAssertEqual(state.count, 0)
     }
-    func testManagedMutableSetRemoveUnmanagedObject() throws {
+    @MainActor func testManagedMutableSetRemoveUnmanagedObject() throws {
         let object = SwiftUIObject()
         let realm = inMemoryRealm(inMemoryIdentifier)
         try realm.write { realm.add(object) }
-        let state = StateRealmObject(wrappedValue: object.set)
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        @StateRealmObject var state = object.set
+        XCTAssertEqual(state.count, 0)
         let obj = SwiftBoolObject()
-        state.projectedValue.insert(obj)
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        $state.insert(obj)
+        XCTAssertEqual(state.count, 1)
         XCTAssertNotNil(obj.realm)
-        state.projectedValue.remove(obj)
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        $state.remove(obj)
+        XCTAssertEqual(state.count, 0)
     }
 
-    func testManagedMutableSetRemoveObservedObject() throws {
+    @MainActor func testManagedMutableSetRemoveObservedObject() throws {
         let object = SwiftUIObject()
-        var state = StateRealmObject(wrappedValue: object.set)
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        @StateRealmObject var state = object.set
+        XCTAssertEqual(state.count, 0)
 
         let realm = inMemoryRealm(inMemoryIdentifier)
         try realm.write { realm.add(object) }
 
-        state.update()
+        _state.update()
         let obj = SwiftBoolObject()
         let objState = StateRealmObject(wrappedValue: obj)
 
@@ -284,105 +289,105 @@ class SwiftUITests: TestCase, @unchecked Sendable {
             }
         objState.wrappedValue.boolCol = true
         XCTAssertEqual(hit, 1)
-        state.projectedValue.insert(objState.wrappedValue)
-        XCTAssertEqual(state.wrappedValue.count, 1)
-        state.projectedValue.remove(objState.wrappedValue)
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        $state.insert(objState.wrappedValue)
+        XCTAssertEqual(state.count, 1)
+        $state.remove(objState.wrappedValue)
+        XCTAssertEqual(state.count, 0)
         cancellable.cancel()
     }
 
     // MARK: - Map Operations
 
-    func testManagedUnmanagedMapAppendPrimitive() throws {
+    @MainActor func testManagedUnmanagedMapAppendPrimitive() throws {
         let object = SwiftUIObject()
-        let state = StateRealmObject(wrappedValue: object.primitiveMap)
-        XCTAssertEqual(state.wrappedValue.count, 0)
-        state.projectedValue.set(object: 1, for: "one")
-        XCTAssertEqual(state.wrappedValue.count, 1)
-        XCTAssertEqual(state.projectedValue["one"], 1)
+        @StateRealmObject var state = object.primitiveMap
+        XCTAssertEqual(state.count, 0)
+        $state.set(object: 1, for: "one")
+        XCTAssertEqual(state.count, 1)
+        XCTAssertEqual($state["one"], 1)
 
         let realm = inMemoryRealm(inMemoryIdentifier)
         try realm.write { realm.add(object) }
 
-        state.projectedValue.set(object: 2, for: "two")
-        state.projectedValue.set(object: 3, for: "two")
-        XCTAssertEqual(state.wrappedValue.count, 2)
-        XCTAssertEqual(state.projectedValue["two"], 3)
+        $state.set(object: 2, for: "two")
+        $state.set(object: 3, for: "two")
+        XCTAssertEqual(state.count, 2)
+        XCTAssertEqual($state["two"], 3)
     }
 
-    func testManagedUnmanagedMapAppendUnmanagedObject() throws {
+    @MainActor func testManagedUnmanagedMapAppendUnmanagedObject() throws {
         let object = SwiftUIObject()
-        let state = StateRealmObject(wrappedValue: object.map)
-        XCTAssertEqual(state.wrappedValue.count, 0)
-        state.projectedValue.set(object: SwiftBoolObject(), for: "one")
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        @StateRealmObject var state = object.map
+        XCTAssertEqual(state.count, 0)
+        $state.set(object: SwiftBoolObject(), for: "one")
+        XCTAssertEqual(state.count, 1)
 
         let realm = inMemoryRealm(inMemoryIdentifier)
         try realm.write { realm.add(object) }
 
-        state.projectedValue.set(object: SwiftBoolObject(), for: "two")
-        XCTAssertEqual(state.wrappedValue.count, 2)
+        $state.set(object: SwiftBoolObject(), for: "two")
+        XCTAssertEqual(state.count, 2)
     }
 
-    func testManagedMapAppendUnmanagedObservedObject() throws {
+    @MainActor func testManagedMapAppendUnmanagedObservedObject() throws {
         let object = SwiftUIObject()
-        var state = StateRealmObject(wrappedValue: object.map)
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        @StateRealmObject var state = object.map
+        XCTAssertEqual(state.count, 0)
 
         let realm = inMemoryRealm(inMemoryIdentifier)
         try realm.write { realm.add(object) }
 
-        state.update()
-        state.projectedValue.set(object: SwiftBoolObject(), for: "one")
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        _state.update()
+        $state.set(object: SwiftBoolObject(), for: "one")
+        XCTAssertEqual(state.count, 1)
     }
 
-    func testManagedUnmanagedMapRemovePrimitive() throws {
+    @MainActor func testManagedUnmanagedMapRemovePrimitive() throws {
         let object = SwiftUIObject()
-        let state = StateRealmObject(wrappedValue: object.primitiveMap)
-        XCTAssertEqual(state.wrappedValue.count, 0)
-        state.projectedValue.set(object: 1, for: "one")
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        @StateRealmObject var state = object.primitiveMap
+        XCTAssertEqual(state.count, 0)
+        $state.set(object: 1, for: "one")
+        XCTAssertEqual(state.count, 1)
 
         let realm = inMemoryRealm(inMemoryIdentifier)
         try realm.write { realm.add(object) }
 
-        state.projectedValue.set(object: 2, for: "two")
-        XCTAssertEqual(state.wrappedValue.count, 2)
+        $state.set(object: 2, for: "two")
+        XCTAssertEqual(state.count, 2)
 
-        state.projectedValue.set(object: nil, for: "one")
-        XCTAssertEqual(state.wrappedValue.count, 1)
-        XCTAssertEqual(state.wrappedValue.keys, ["two"])
+        $state.set(object: nil, for: "one")
+        XCTAssertEqual(state.count, 1)
+        XCTAssertEqual(state.keys, ["two"])
     }
 
-    func testManagedUnmanagedMapRemoveUnmanagedObject() throws {
+    @MainActor func testManagedUnmanagedMapRemoveUnmanagedObject() throws {
         let object = SwiftUIObject()
-        let state = StateRealmObject(wrappedValue: object.map)
-        XCTAssertEqual(state.wrappedValue.count, 0)
-        state.projectedValue.set(object: SwiftBoolObject(), for: "one")
-        XCTAssertEqual(state.wrappedValue.count, 1)
-        state.projectedValue.set(object: nil, for: "one")
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        @StateRealmObject var state = object.map
+        XCTAssertEqual(state.count, 0)
+        $state.set(object: SwiftBoolObject(), for: "one")
+        XCTAssertEqual(state.count, 1)
+        $state.set(object: nil, for: "one")
+        XCTAssertEqual(state.count, 0)
     }
 
-    func testManagedMapAppendRemoveObservedObject() throws {
+    @MainActor func testManagedMapAppendRemoveObservedObject() throws {
         let object = SwiftUIObject()
-        var state = StateRealmObject(wrappedValue: object.map)
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        @StateRealmObject var state = object.map
+        XCTAssertEqual(state.count, 0)
 
         let realm = inMemoryRealm(inMemoryIdentifier)
         try realm.write { realm.add(object) }
 
-        state.update()
-        state.projectedValue.set(object: SwiftBoolObject(), for: "one")
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        _state.update()
+        $state.set(object: SwiftBoolObject(), for: "one")
+        XCTAssertEqual(state.count, 1)
 
-        state.projectedValue.set(object: nil, for: "one")
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        $state.set(object: nil, for: "one")
+        XCTAssertEqual(state.count, 0)
     }
 
     // MARK: - ObservedResults Operations
-    func testResultsAppendUnmanagedObject() throws {
+    @MainActor func testResultsAppendUnmanagedObject() throws {
         let object = SwiftUIObject()
         let fullResults = ObservedResults(SwiftUIObject.self,
                                           configuration: inMemoryRealm(inMemoryIdentifier).configuration)
@@ -416,38 +421,35 @@ class SwiftUITests: TestCase, @unchecked Sendable {
         XCTAssertEqual(sortedResults.wrappedValue[0].int, 1)
         XCTAssertEqual(sortedResults.wrappedValue[1].int, 0)
     }
-    func testResultsAppendManagedObject() throws {
-        let state = ObservedResults(SwiftUIObject.self, configuration: inMemoryRealm(inMemoryIdentifier).configuration)
+    @MainActor func testResultsAppendManagedObject() throws {
+        @ObservedResults(SwiftUIObject.self, configuration: inMemoryRealm(inMemoryIdentifier).configuration) var state
         let object = SwiftUIObject()
-        XCTAssertEqual(state.wrappedValue.count, 0)
-        state.projectedValue.append(object)
-        XCTAssertEqual(state.wrappedValue.count, 1)
-        state.projectedValue.append(object)
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        XCTAssertEqual(state.count, 0)
+        $state.append(object)
+        XCTAssertEqual(state.count, 1)
+        $state.append(object)
+        XCTAssertEqual(state.count, 1)
     }
-    func testResultsRemoveUnmanagedObject() throws {
-        let state = ObservedResults(SwiftUIObject.self,
-                                    configuration: inMemoryRealm(inMemoryIdentifier).configuration)
+    @MainActor func testResultsRemoveUnmanagedObject() throws {
+        @ObservedResults(SwiftUIObject.self, configuration: inMemoryRealm(inMemoryIdentifier).configuration) var state
         let object = SwiftUIObject()
-        XCTAssertEqual(state.wrappedValue.count, 0)
-        assertThrows(state.projectedValue.remove(object))
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        XCTAssertEqual(state.count, 0)
+        assertThrows($state.remove(object))
+        XCTAssertEqual(state.count, 0)
     }
-    func testResultsRemoveManagedObject() throws {
-        let state = ObservedResults(SwiftUIObject.self,
-                                    configuration: inMemoryRealm(inMemoryIdentifier).configuration)
+    @MainActor func testResultsRemoveManagedObject() throws {
+        @ObservedResults(SwiftUIObject.self, configuration: inMemoryRealm(inMemoryIdentifier).configuration) var state
         let object = SwiftUIObject()
-        XCTAssertEqual(state.wrappedValue.count, 0)
-        state.projectedValue.append(object)
-        XCTAssertEqual(state.wrappedValue.count, 1)
-        state.projectedValue.remove(object)
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        XCTAssertEqual(state.count, 0)
+        $state.append(object)
+        XCTAssertEqual(state.count, 1)
+        $state.remove(object)
+        XCTAssertEqual(state.count, 0)
     }
-    func testResultsMoveUnmanagedObject() throws {
-        let state = ObservedResults(SwiftUIObject.self,
-                                    configuration: inMemoryRealm(inMemoryIdentifier).configuration)
+    @MainActor func testResultsMoveUnmanagedObject() throws {
+        @ObservedResults(SwiftUIObject.self, configuration: inMemoryRealm(inMemoryIdentifier).configuration) var state
         let object = SwiftUIObject()
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        XCTAssertEqual(state.count, 0)
 
         object.stringList.append(SwiftStringObject(stringCol: "Tom"))
         object.stringList.append(SwiftStringObject(stringCol: "Sam"))
@@ -478,20 +480,19 @@ class SwiftUITests: TestCase, @unchecked Sendable {
         XCTAssertEqual(object.stringList[2].stringCol, "Dan")
         XCTAssertEqual(object.stringList.last!.stringCol, "Paul")
 
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        XCTAssertEqual(state.count, 0)
     }
-    func testResultsMoveManagedObject() throws {
-        let state = ObservedResults(SwiftUIObject.self,
-                                    configuration: inMemoryRealm(inMemoryIdentifier).configuration)
+    @MainActor func testResultsMoveManagedObject() throws {
+        @ObservedResults(SwiftUIObject.self, configuration: inMemoryRealm(inMemoryIdentifier).configuration) var state
         let object = SwiftUIObject()
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        XCTAssertEqual(state.count, 0)
 
         object.stringList.append(SwiftStringObject(stringCol: "Tom"))
         object.stringList.append(SwiftStringObject(stringCol: "Sam"))
         object.stringList.append(SwiftStringObject(stringCol: "Dan"))
         object.stringList.append(SwiftStringObject(stringCol: "Paul"))
 
-        state.projectedValue.append(object)
+        $state.append(object)
 
         let binding = object.bind(\.stringList)
         XCTAssertEqual(object.stringList.first!.stringCol, "Tom")
@@ -517,9 +518,9 @@ class SwiftUITests: TestCase, @unchecked Sendable {
         XCTAssertEqual(object.stringList[2].stringCol, "Dan")
         XCTAssertEqual(object.stringList.last!.stringCol, "Paul")
 
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        XCTAssertEqual(state.count, 1)
     }
-    func testSwiftQuerySyntax() throws {
+    @MainActor func testSwiftQuerySyntax() throws {
         let realm = inMemoryRealm(inMemoryIdentifier)
         try realm.write {
             realm.add(SwiftUIObject(value: ["str": "apple"]))
@@ -534,7 +535,7 @@ class SwiftUITests: TestCase, @unchecked Sendable {
         XCTAssertEqual(filteredResults.wrappedValue.count, 2)
         XCTAssertEqual(filteredResults.wrappedValue[0].str, "antenna")
     }
-    func testResultsAppendFrozenObject() throws {
+    @MainActor func testResultsAppendFrozenObject() throws {
         let state1 = ObservedResults(SwiftUIObject.self, configuration: inMemoryRealm(inMemoryIdentifier).configuration)
         let object1 = SwiftUIObject()
         XCTAssertEqual(state1.wrappedValue.count, 0)
@@ -559,34 +560,34 @@ class SwiftUITests: TestCase, @unchecked Sendable {
         XCTAssertEqual(state2.wrappedValue.count, 2)
     }
     // MARK: Object Operations
-    func testUnmanagedObjectModification() throws {
-        let state = StateRealmObject(wrappedValue: SwiftUIObject())
-        state.wrappedValue.str = "bar"
-        XCTAssertEqual(state.wrappedValue.str, "bar")
-        XCTAssertEqual(state.projectedValue.wrappedValue.str, "bar")
+    @MainActor func testUnmanagedObjectModification() throws {
+        @StateRealmObject var state = SwiftUIObject()
+        state.str = "bar"
+        XCTAssertEqual(state.str, "bar")
+        XCTAssertEqual($state.wrappedValue.str, "bar")
     }
-    func testManagedObjectModification() throws {
-        let state = StateRealmObject(wrappedValue: SwiftUIObject())
+    @MainActor func testManagedObjectModification() throws {
+        @StateRealmObject var state = SwiftUIObject()
         ObservedResults(SwiftUIObject.self,
                         configuration: inMemoryRealm(inMemoryIdentifier).configuration)
-            .projectedValue.append(state.wrappedValue)
-        assertThrows(state.wrappedValue.str = "bar")
-        state.projectedValue.str.wrappedValue = "bar"
-        XCTAssertEqual(state.projectedValue.wrappedValue.str, "bar")
+            .projectedValue.append(state)
+        assertThrows(state.str = "bar")
+        $state.str.wrappedValue = "bar"
+        XCTAssertEqual($state.wrappedValue.str, "bar")
     }
-    func testManagedObjectDelete() throws {
+    @MainActor func testManagedObjectDelete() throws {
         let results = ObservedResults(SwiftUIObject.self,
                                       configuration: inMemoryRealm(inMemoryIdentifier).configuration)
-        let state = StateRealmObject(wrappedValue: SwiftUIObject())
+        @StateRealmObject var state = SwiftUIObject()
         XCTAssertEqual(results.wrappedValue.count, 0)
-        state.projectedValue.delete()
+        $state.delete()
         XCTAssertEqual(results.wrappedValue.count, 0)
-        results.projectedValue.append(state.wrappedValue)
+        results.projectedValue.append(state)
         XCTAssertEqual(results.wrappedValue.count, 1)
-        state.projectedValue.delete()
+        $state.delete()
     }
     // MARK: Bind
-    func testUnmanagedManagedObjectBind() {
+    @MainActor func testUnmanagedManagedObjectBind() {
         let object = SwiftUIObject()
         let binding = object.bind(\.str)
         XCTAssertEqual(object.str, "foo")
@@ -605,7 +606,7 @@ class SwiftUITests: TestCase, @unchecked Sendable {
         XCTAssertEqual(binding.wrappedValue, "baz")
     }
 
-    func testStateRealmObjectKVO() throws {
+    @MainActor func testStateRealmObjectKVO() throws {
         @StateRealmObject var object = SwiftUIObject()
         var hit = 0
 
@@ -633,33 +634,31 @@ class SwiftUITests: TestCase, @unchecked Sendable {
     }
 
     // MARK: - Projection ObservedResults Operations
-    func testResultsAppendProjection() throws {
+    @MainActor func testResultsAppendProjection() throws {
         let realm = inMemoryRealm(inMemoryIdentifier)
-        let state = ObservedResults(UIElementsProjection.self,
-                                    configuration: inMemoryRealm(inMemoryIdentifier).configuration)
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        @ObservedResults(UIElementsProjection.self, configuration: inMemoryRealm(inMemoryIdentifier).configuration) var state
+        XCTAssertEqual(state.count, 0)
         try! realm.write {
             realm.create(SwiftUIObject.self)
         }
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        XCTAssertEqual(state.count, 1)
     }
 
-    func testResultsRemoveProjection() throws {
+    @MainActor func testResultsRemoveProjection() throws {
         let realm = inMemoryRealm(inMemoryIdentifier)
-        let state = ObservedResults(UIElementsProjection.self,
-                                    configuration: inMemoryRealm(inMemoryIdentifier).configuration)
+        @ObservedResults(UIElementsProjection.self, configuration: inMemoryRealm(inMemoryIdentifier).configuration) var state
         var object: SwiftUIObject!
         try! realm.write {
             object = realm.create(SwiftUIObject.self)
         }
-        XCTAssertEqual(state.wrappedValue.count, 1)
+        XCTAssertEqual(state.count, 1)
         try! realm.write {
             realm.delete(object)
         }
-        XCTAssertEqual(state.wrappedValue.count, 0)
+        XCTAssertEqual(state.count, 0)
     }
 
-    func testProjectionStateRealmObjectKVO() throws {
+    @MainActor func testProjectionStateRealmObjectKVO() throws {
         @StateRealmObject var projection = UIElementsProjection(projecting: SwiftUIObject())
         var hit = 0
 
@@ -686,22 +685,22 @@ class SwiftUITests: TestCase, @unchecked Sendable {
         XCTAssertEqual(hit, 2)
     }
 
-    func testProjectionDelete() throws {
+    @MainActor func testProjectionDelete() throws {
         let results = ObservedResults(UIElementsProjection.self,
                                       configuration: inMemoryRealm(inMemoryIdentifier).configuration)
         let projection = UIElementsProjection(projecting: SwiftUIObject())
-        let state = StateRealmObject(wrappedValue: projection)
+        @StateRealmObject var state = projection
 
         XCTAssertEqual(results.wrappedValue.count, 0)
-        state.projectedValue.delete()
+        $state.delete()
         XCTAssertEqual(results.wrappedValue.count, 0)
-        results.projectedValue.append(state.wrappedValue)
+        results.projectedValue.append(state)
         XCTAssertEqual(results.wrappedValue.count, 1)
-        state.projectedValue.delete()
+        $state.delete()
     }
 
     // MARK: - Projection Bind
-    func testProjectionBind() {
+    @MainActor func testProjectionBind() {
         let projection = UIElementsProjection(projecting: SwiftUIObject())
         let binding = projection.bind(\.label)
         XCTAssertEqual(projection.label, "foo")
@@ -722,7 +721,7 @@ class SwiftUITests: TestCase, @unchecked Sendable {
 
     // MARK: - ObservedSectionedResults
 
-    func testObservedSectionedResults() throws {
+    @MainActor func testObservedSectionedResults() throws {
         let fullResults = ObservedSectionedResults(SwiftUIObject.self,
                                                    sectionKeyPath: \.str,
                                                    configuration: inMemoryRealm(inMemoryIdentifier).configuration)
@@ -768,7 +767,7 @@ class SwiftUITests: TestCase, @unchecked Sendable {
         XCTAssertEqual(fullResults.wrappedValue[0].key, "abc")
     }
 
-    func testObservedSectionedResultsWithProjection() throws {
+    @MainActor func testObservedSectionedResultsWithProjection() throws {
         let fullResults = ObservedSectionedResults(UIElementsProjection.self,
                                                    sectionKeyPath: \.label,
                                                    configuration: inMemoryRealm(inMemoryIdentifier).configuration)
@@ -801,7 +800,7 @@ class SwiftUITests: TestCase, @unchecked Sendable {
         XCTAssertEqual(filteredResults.wrappedValue[0].key, "def")
     }
 
-    func testAllObservedSectionedResultsConstructors() throws {
+    @MainActor func testAllObservedSectionedResultsConstructors() throws {
         let realm = inMemoryRealm(inMemoryIdentifier)
         let object1 = SwiftUIObject()
         let object2 = SwiftUIObject()

--- a/RealmSwift/Util.swift
+++ b/RealmSwift/Util.swift
@@ -161,40 +161,12 @@ internal func logRuntimeIssue(_ message: StaticString) {
 }
 
 @available(macOS 10.15, tvOS 13.0, iOS 13.0, watchOS 6.0, *)
-@_unavailableFromAsync
-internal func assumeOnMainActorExecutor(_ operation: @MainActor () throws -> Void,
-                                        file: StaticString = #fileID, line: UInt = #line
-) rethrows {
-#if compiler(>=5.10)
-    // This is backdeployable in Xcode 15.3+, but not 15.1
-    try MainActor.assumeIsolated(operation)
-#else
-    if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
-        return try MainActor.assumeIsolated(operation)
-    }
-
-    precondition(Thread.isMainThread, file: file, line: line)
-    return try withoutActuallyEscaping(operation) { fn in
-        try unsafeBitCast(fn, to: (() throws -> ()).self)()
-    }
-#endif
-}
-
-@available(macOS 10.15, tvOS 13.0, iOS 13.0, watchOS 6.0, *)
 extension Actor {
     @_unavailableFromAsync
     internal func invokeIsolated<Ret, Arg>(_ operation: (isolated Self, Arg) throws -> Ret, _ arg: Arg,
                                            file: StaticString = #fileID, line: UInt = #line
     ) rethrows -> Ret {
-#if compiler(>=5.10)
-        // This is backdeployable in Xcode 15.3+, but not 15.1
         preconditionIsolated(file: file, line: line)
-#else
-        if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
-            preconditionIsolated(file: file, line: line)
-        }
-#endif
-
         return try withoutActuallyEscaping(operation) { fn in
             try unsafeBitCast(fn, to: ((Self, Arg) throws -> Ret).self)(self, arg)
         }

--- a/build.sh
+++ b/build.sh
@@ -1359,7 +1359,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * APIs are backwards compatible with all previous releases in the 10.x.y series.
 * Carthage release for Swift is built with Xcode 15.4.0.
 * CocoaPods: 1.10 or later.
-* Xcode: 15.1.0-16 beta 5.
+* Xcode: 15.3.0-16.1 beta.
 
 ### Internal
 * Upgraded realm-core from ? to ?

--- a/scripts/package_examples.rb
+++ b/scripts/package_examples.rb
@@ -44,7 +44,7 @@ base_examples = [
   "examples/tvos/swift",
 ]
 
-xcode_versions = %w(15.1 15.2 15.3 15.4)
+xcode_versions = %w(15.3 15.4 16 16.1)
 
 # Remove reference to Realm.xcodeproj from all example workspaces.
 base_examples.each do |example|

--- a/scripts/pr-ci-matrix.rb
+++ b/scripts/pr-ci-matrix.rb
@@ -86,7 +86,7 @@ end
 # because they don't care about Xcode versions, while some others are latest-only
 # because they're particularly slow to run.
 module Workflows
-  XCODE_VERSIONS = %w(15.1 15.2 15.3 15.4 16\ beta\ 5)
+  XCODE_VERSIONS = %w(15.3 15.4 16\ beta\ 6 16.1\ beta)
 
   all = ->(v) { true }
   latest_only = ->(v) { v == XCODE_VERSIONS.last }
@@ -115,9 +115,6 @@ module Workflows
     Target.new('watchos-swift', 'RealmSwift', oldest_and_latest, Destination.generic),
 
     Target.new('swiftui', 'SwiftUITests', latest_only, Destination.iOS),
-    Target.new('swiftui-sync', 'SwiftUISyncTests', latest_only, Destination.macOS),
-
-    Target.new('sync', 'Object Server Tests', oldest_and_latest, Destination.macOS),
 
     Target.new('docs', 'CI', latest_only, Destination.generic),
     Target.new('swiftlint', 'CI', latest_only, Destination.generic),


### PR DESCRIPTION
This drops support for Xcode 15.1 and 15.2 as supporting both Swift 5.9 and 6 at the same time turned out to be an utter mess.

SPM and the Xcode project build in Swift 6 mode when using Xcode 16. CocoaPods always builds in Swift 5 mode since there doesn't appear to be any functional benefit to make it conditional, and it's a bit complicated to do.

Most of the library changes are just replacing `@_unsafeInheritExecutor` with `#isolation`, which is the proper official way to achieve the same effect. Sadly it was not added until Swift 6, so a lot of `#if` is involved. Some of the mongo client functions were incorrectly returning `[AnyHashable: String]` rather than `Document`, which now doesn't compile at all so I fixed the return type in Swift 6 mode. Isolated init never got implemented, so `try await Realm(actor: actor)` has been replaced with `try await Realm.open()`, since doing the same thing in a static function does work.

Swift used to have a thing where an isolated property wrapper would make the containing type implicitly isolated. This was very confusing and weird so it got removed and the SwiftUI types now need to be explicitly marked as `@MainActor`.

The changes to tests are mostly boring mechanic changes. Making XCTest subclasses `@MainActor` didn't actually work, and instead individual test functions need to be marked with it. `setUp` *can't* be isolated, so a bunch of test init and deinit had to be adjusted to become thread-safe. `waitForExpectations()` is main actor isolated while `wait(for:)` isn't (as it doesn't have the magic global list of expectations), so a bunch of tests were switched to that. `@ThreadSafe` just plain doesn't work in swift 6 mode due to sendability checking on property wrappers never being implemented, so those tests are disabled.

For some reason the compiler is convinced that `QuerySubscription`'s callback function needs to be Sendable, so a bunch of tests had to be updated to not capture `self` in that callback.