### PR TITLE
Fix a crash that may occur when resolving a thread-safe reference

### DIFF
--- a/Realm/RLMError.h
+++ b/Realm/RLMError.h
@@ -199,6 +199,10 @@ typedef RLM_ERROR_ENUM(NSInteger, RLMError, RLMErrorDomain) {
      subscription or the server will reject the write.
      */
     RLMErrorNoSubscriptionForWrite = 22,
+     / **
+    Denotes an error that occurs when resolving thread safe reference returns a nil object.
+     */
+    RLMSyncErrorPermissionDeniedError = 23
 };
 
 #pragma mark - RLMSyncError

--- a/Realm/RLMError.h
+++ b/Realm/RLMError.h
@@ -202,7 +202,7 @@ typedef RLM_ERROR_ENUM(NSInteger, RLMError, RLMErrorDomain) {
      / **
     Denotes an error that occurs when resolving thread safe reference returns a nil object.
      */
-    RLMSyncErrorPermissionDeniedError = 23
+    RLMErrorObjectNotFound = 23
 };
 
 #pragma mark - RLMSyncError

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -723,6 +723,13 @@ RLM_DIRECT_MEMBERS
         return;
     }
     RLMObjectBase *obj = [_realm resolveThreadSafeReference:tsr];
+    if (!obj) {
+        error = [NSError errorWithDomain:RLMAppErrorDomain
+                                    code:RLMErrorObjectNotFound
+                                userInfo:nil];
+        block(nil, nil, nil, nil, error);
+        return;
+    }
 
     _object = realm::Object(_realm->_realm, *obj->_info->objectSchema, obj->_row);
     _token = _object.add_notification_callback(ObjectChangeCallbackWrapper{block, obj},


### PR DESCRIPTION
In some cases, as per documentation, resolveThreadSafeReference can return nil. It usually happens in highly-concurrent contexts. Checking for nil fixes this crash