### PR TITLE
- Fix `Datetime` rounding in `RLMConvertBsonToRLMBSON`

### DIFF
--- a/Realm/RLMBSON.mm
+++ b/Realm/RLMBSON.mm
@@ -386,7 +386,7 @@ id<RLMBSON> RLMConvertBsonToRLMBSON(const Bson& b) {
         case realm::bson::Bson::Type::Timestamp:
             return [[NSDate alloc] initWithTimeIntervalSince1970:static_cast<MongoTimestamp>(b).seconds];
         case realm::bson::Bson::Type::Datetime:
-            return [[NSDate alloc] initWithTimeIntervalSince1970:static_cast<Timestamp>(b).get_seconds()];
+            return [[NSDate alloc] initWithTimeIntervalSince1970:double(static_cast<Timestamp>(b).get_seconds()) + double(static_cast<Timestamp>(b).get_nanoseconds()) / Timestamp::nanoseconds_per_second];
         case realm::bson::Bson::Type::ObjectId:
             return [[RLMObjectId alloc] initWithValue:static_cast<ObjectId>(b)];
         case realm::bson::Bson::Type::Decimal128:


### PR DESCRIPTION
I noticed that the `Date` types returned from Sync Functions calls are rounded to seconds. This PR fixes the issue. Please note that I am not a C++ programmer so this probably could be done in a better way. I will gladly accept any fix requests with hints.