### PR TITLE
Fix UIDevice support enabled for WatchOS 26 on Xcode 26

### DIFF
--- a/Realm/RLMApp.mm
+++ b/Realm/RLMApp.mm
@@ -21,7 +21,9 @@
 #import <sys/utsname.h>
 #if __has_include(<UIKit/UIDevice.h>)
 #import <UIKit/UIDevice.h>
+#ifndef TARGET_OS_WATCH
 #define REALM_UIDEVICE_AVAILABLE
+#endif
 #endif
 
 #import "RLMAnalytics.hpp"


### PR DESCRIPTION
When building a WatchOS target with Xcode 26, the build fails due to a missing UIDevice call on the Watch SDK. 

It appears that in the initial WatchOS 26 betas that the check for `<UIKit/UIDevice.h>` in `RLMApp.mm` now passes for Watch targets when it shouldn't. 

This change adds a separate check for `TARGET_OS_WATCH` not being defined before defining the `REALM_UIDEVICE_AVAILABLE` flag.