### PR TITLE
Resolve Build Warnings With Xcode26

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.homepage                = "https://realm.io"
   s.source                  = { :git => 'https://github.com/realm/realm-swift.git', :tag => "v#{s.version}" }
   s.author                  = { 'Realm' => 'realm-help@mongodb.com' }
-  s.library                 = 'c++', 'z', 'compression'
+  s.library                 = 'z', 'compression'
   s.requires_arc            = true
   s.license                 = { :type => 'Apache 2.0', :file => 'LICENSE' }
 

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -92,7 +92,7 @@ void RLMVerifyHasPrimaryKey(Class cls) {
 
 using realm::CreatePolicy;
 static CreatePolicy updatePolicyToCreatePolicy(RLMUpdatePolicy policy) {
-    CreatePolicy createPolicy = {.create = true, .copy = false, .diff = false, .update = false};
+    CreatePolicy createPolicy = {.create = true, .copy = false, .update = false, .diff = false};
     switch (policy) {
         case RLMUpdatePolicyError:
             break;
@@ -140,7 +140,7 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
 void RLMCreateAsymmetricObjectInRealm(RLMRealm *realm, NSString *className, id value) {
     RLMVerifyInWriteTransaction(realm);
 
-    CreatePolicy createPolicy = {.create = true, .copy = true, .diff = false, .update = false};
+    CreatePolicy createPolicy = {.create = true, .copy = true, .update = false, .diff = false};
 
     auto& info = realm->_info[className];
     RLMAccessorContext c{info};

--- a/RealmSwift/ThreadSafeReference.swift
+++ b/RealmSwift/ThreadSafeReference.swift
@@ -218,7 +218,5 @@ extension Realm {
 
 extension ThreadSafeReference: Sendable {
 }
-extension RLMThreadSafeReference: @unchecked Sendable {
-}
 extension ThreadSafe: @unchecked Sendable {
 }


### PR DESCRIPTION
Issue #8817

* Specify CreatePolicy field designators in proper order
* Remove double declaration of RLMThreadSafeReference unchecked conformance to Sendable
* Remove unnecessary 'c++' library specification from podspec